### PR TITLE
fix link color in code

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -192,7 +192,6 @@ code, pre {
   padding: 0;
   a {
     text-decoration: none;
-    color: $white;
   }
 }
 


### PR DESCRIPTION
link should be displayed in the same color than other `code` text