### PR TITLE
fix: avoid private members in application beans

### DIFF
--- a/_guides/hibernate-orm-guide.adoc
+++ b/_guides/hibernate-orm-guide.adoc
@@ -61,7 +61,8 @@ You can then happily inject your `EntityManager`:
 --
 @ApplicationScoped
 public class SantaClausService {
-    @Inject private EntityManager em; <1>
+    @Inject
+    EntityManager em; <1>
 
     @Transactional <2>
     public void createGift(String giftDescription) {


### PR DESCRIPTION
This fixes the following warning during build: 
```
[INFO] [io.quarkus.arc.processor.BeanProcessor] Found unrecommended usage of private members (use package-private instead) in application beans:
        - @Inject field SantaClausService#em
```