### PR TITLE
improve Guides menu Cloud headings clarity

### DIFF
--- a/_guides/guides.md
+++ b/_guides/guides.md
@@ -39,8 +39,8 @@ permalink: /guides/
 
 ### Cloud
 
-- [Deploying Knative Application to Kubernetes or OpenShift]({{site.baseurl}}/guides/getting-started-knative-guide)
-- [Deploying Applications on Kubernetes]({{site.baseurl}}/guides/kubernetes-guide)
+- [Deploying native Applications on Kubernetes or OpenShift]({{site.baseurl}}/guides/kubernetes-guide)
+- [Deploying native Applications on Knative Kubernetes or OpenShift]({{site.baseurl}}/guides/getting-started-knative-guide)
 
 ### Observability
 

--- a/_guides/guides.md
+++ b/_guides/guides.md
@@ -39,8 +39,8 @@ permalink: /guides/
 
 ### Cloud
 
-- [Deploying native Applications on Kubernetes or OpenShift]({{site.baseurl}}/guides/kubernetes-guide)
-- [Deploying native Applications on Knative Kubernetes or OpenShift]({{site.baseurl}}/guides/getting-started-knative-guide)
+- [Deploying Native Applications on Kubernetes or OpenShift]({{site.baseurl}}/guides/kubernetes-guide)
+- [Deploying Native Applications on Knative Kubernetes or OpenShift]({{site.baseurl}}/guides/getting-started-knative-guide)
 
 ### Observability
 


### PR DESCRIPTION
because the section currently named "Deploying Applications on Kubernetes"
also covers OpenShift and is really about Quarkus native (GraalVM) support.

Also update the Knative heading by moving it to a bit later in the title
to more clearly distinguish Quarkus native from Knative.

Lastly switched the order - pushing Knative into someone's face as the first
item could be consuing to anyone who is not clear about Knative yet.
The knative chapter anyway only mentions Knative building and not Knative serve, yet.