### PR TITLE
Characters like p, q, j, g are cut at the bottom in code and command examples #110

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -297,6 +297,7 @@ b.conum {
   overflow-y: hidden;
   background: inherit;
   padding: 0;
+  line-height: 1.4em;
 }
 
 .hljs-built_in,


### PR DESCRIPTION
This fix tries to address the problem of the of line height in highlight boxes.