### PR TITLE
Fix typo in user home dir syntax

### DIFF
--- a/_guides/building-native-image-guide.adoc
+++ b/_guides/building-native-image-guide.adoc
@@ -25,13 +25,13 @@ Version {graalvm-version} is required.
 
 [NOTE]
 ====
-Once you have downloaded GraalVM, expand the archive and set the `GRAALVM_HOME` variable to this location:
+Once you have downloaded GraalVM, expand the archive into your home directory and set the `GRAALVM_HOME` variable to this location:
 
-`export GRAALVM_HOME=~clement/Development/graalvm/`
+`export GRAALVM_HOME=~/Development/graalvm/`
 
 On MacOS, point the variable to the `Home` sub-directory:
 
-`export GRAALVM_HOME=~clement/Development/graalvm/Contents/Home/`
+`export GRAALVM_HOME=~/Development/graalvm/Contents/Home/`
 ====
 
 


### PR DESCRIPTION
There is only a few chances that the current person reading the guide unpack the GraalVM distribution into a home directory for a user named `clement` 😉. 

Fixed this by removing the user name in the syntax and explicitely tell the user to expand the archive into its home directory.