### PR TITLE
Correcting distroless image location

### DIFF
--- a/_guides/README.adoc
+++ b/_guides/README.adoc
@@ -35,6 +35,7 @@ complete list of externalized variables for use is given in the following table:
 |\{quarkus-archive-url}|{quarkus-archive-url}| {project-name} URL to master source archive.
 |\{quarkus-blob-url}|{quarkus-blob-url}| {project-name} URL to master blob source tree; used for referencing source files.
 |\{quarkus-tree-url}|{quarkus-tree-url}| {project-name} URL to master source tree root; used for referencing directories.
+|\{quarkus-images-url}|{quarkus-images-url}| {project-name} URL to set of container images delivered for Quarkus.
 |\{quarkus-issues-url}|{quarkus-issues-url}| {project-name} URL to the issues page.
 
 |\{quarkus-chat-url}|{quarkus-chat-url} | URL of our chat.

--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -14,6 +14,7 @@
 :quarkus-archive-url: https://github.com/quarkusio/quarkus/archive/master.zip
 :quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/master
 :quarkus-issues-url: https://github.com/quarkusio/quarkus/issues
+:quarkus-images-url: https://github.com/quarkusio/quarkus-images/tree
 :quarkus-chat-url: https://quarkusio.zulipchat.com
 :quarkus-mailing-list-subscription-email: quarkus-dev+subscribe@googlegroups.com
 :quarkus-mailing-list-index: https://groups.google.com/d/forum/quarkus-dev

--- a/_guides/building-native-image-guide.adoc
+++ b/_guides/building-native-image-guide.adoc
@@ -220,7 +220,7 @@ And finally, run it with:
 docker run -i --rm -p 8080:8080 quarkus-quickstart/quickstart
 ----
 
-NOTE: Interested by tiny Docker images, check the {quarkus-tree-url}/docker/distroless[distroless] version.
+NOTE: Interested by tiny Docker images, check the {quarkus-images-url}/graalvm-1.0.0-rc14/distroless[distroless] version.
 
 == What's next?
 

--- a/_guides/pom.xml
+++ b/_guides/pom.xml
@@ -85,6 +85,9 @@
                         <quarkus-tree-url>${quarkus-base-url}/tree/master</quarkus-tree-url>
                         <!-- Quarkus URL to issues -->
                         <quarkus-issues-url>${quarkus-base-url}/issues</quarkus-issues-url>
+                        <!-- Quarkus URL to images -->
+                        <quarkus-images-url>${quarkus-images-url}/issues</quarkus-images-url>
+
 
                         <!-- === Quickstart settings === -->
                         <!-- Quickstart repository base URL -->


### PR DESCRIPTION
Submitting fix for Issue #144 . Added quarkus-image-url var for referencing and utilizing it along with corrected link to distroless location