### PR TITLE
Improvement of instructions to verify OpenShift deployment

### DIFF
--- a/_guides/kubernetes-guide.adoc
+++ b/_guides/kubernetes-guide.adoc
@@ -78,7 +78,7 @@ oc expose service quarkus-quickstart
 # Get the route URL
 export URL="http://$(oc get route | grep quarkus-quickstart | awk '{print $2}')"
 echo "Application URL: $URL"
-curl $URL/hello/greeting/quarkus
+curl $URL/hello/greeting/quarkus && echo
 ----
 
 Your application is accessible at the printed URL.

--- a/_guides/kubernetes-guide.adoc
+++ b/_guides/kubernetes-guide.adoc
@@ -77,7 +77,7 @@ oc expose service quarkus-quickstart
 
 # Get the route URL
 export URL="http://$(oc get route | grep quarkus-quickstart | awk '{print $2}')"
-curl $URL/hello/quarkus
+curl $URL/hello/greeting/quarkus
 ----
 
 Your application is accessible at the printed URL.

--- a/_guides/kubernetes-guide.adoc
+++ b/_guides/kubernetes-guide.adoc
@@ -77,6 +77,7 @@ oc expose service quarkus-quickstart
 
 # Get the route URL
 export URL="http://$(oc get route | grep quarkus-quickstart | awk '{print $2}')"
+echo "Application URL: $URL"
 curl $URL/hello/greeting/quarkus
 ----
 


### PR DESCRIPTION
The following command wasn't working `curl $URL/hello/quarkus` since it requires `/hello/greeting/quarkus`. I have updated that and have done two other small changes to make the output a bit more friendly