### PR TITLE
InjectionPoint.getMember() is currently supported

### DIFF
--- a/_guides/cdi-reference.adoc
+++ b/_guides/cdi-reference.adoc
@@ -95,7 +95,7 @@ public class CounterBean {
 ** Type-safe resolution 
 ** Programmatic lookup via `javax.enterprise.inject.Instance`
 ** Client proxies
-** Injection point metadata footnote:[`InjectionPoint.getMember()` is currently not supported.]
+** Injection point metadata
 * Scopes and contexts
 ** `@Dependent`, `@ApplicationScoped`, `@Singleton`, `@RequestScoped` and `@SessionScoped`
 ** Custom scopes and contexts


### PR DESCRIPTION
See `InjectionPointImpl` in `CurrentInjectionPointProvider`.

https://github.com/quarkusio/quarkus/blob/1b723f5a8942437bfa5cfa50f53e1f9a2307c3e0/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/CurrentInjectionPointProvider.java#L115-L118