### PR TITLE
fixed typo

### DIFF
--- a/_guides/building-native-image-guide.adoc
+++ b/_guides/building-native-image-guide.adoc
@@ -148,7 +148,7 @@ public class NativeGreetingResourceIT extends GreetingResourceTest { // <2>
 The executable is retrieved using the `native.image.path` system property configured in the _Failsafe Maven Plugin_.
 <2> We extend our previous tests, but you can also implement your tests
 
-To see the `NativeGreetingResourceIT` run against the native executable, runs `./mvnw verify -Pnative`:
+To see the `NativeGreetingResourceIT` run against the native executable, use `./mvnw verify -Pnative`:
 [source,shell]
 ----
 ./mvnw verify -Pnative


### PR DESCRIPTION
Was 'runs' and shouldn't have been plural. However, 'use' makes more sense in this context.