### PR TITLE
[DO NOT MERGE] Add missing `mvn -N io.takari:maven:wrapper`

### DIFF
--- a/_guides/getting-started-guide.adoc
+++ b/_guides/getting-started-guide.adoc
@@ -65,6 +65,8 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=getting-started \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello"
+
+mvn -N io.takari:maven:wrapper
 ----
 
 It generates:


### PR DESCRIPTION
This doc says "Use: ./mvnw compile quarkus:dev" but it results in the following error:

```
./mvnw
-bash: mvnw: command not found
```