### PR TITLE
Panache guide: specify how to run write operations

### DIFF
--- a/_guides/hibernate-orm-panache-guide.adoc
+++ b/_guides/hibernate-orm-panache-guide.adoc
@@ -133,7 +133,8 @@ This allows for proper encapsulation at runtime as all fields calls will be repl
 
 == Most useful operations
 
-Once you have written your entity, here are the most common operations you will be able to do:
+Once you have written your entity, here are the most common operations you will be able to do (run these inside a CDI method
+annotated with `@Transactional`):
 
 [source,java]
 --


### PR DESCRIPTION
With this commit, the Panache guide specifies that we should run the
`persist` operations inside a CDI method annotated with `@Transactional`