### PR TITLE
Make CDI constructor injection example compilable

### DIFF
--- a/_guides/cdi-reference.adoc
+++ b/_guides/cdi-reference.adoc
@@ -74,6 +74,7 @@ public class CounterBean {
     private final CounterService service;
 
     CounterBean() { // <1>
+        this.service = null;
     }
 
     @Inject


### PR DESCRIPTION
Set field to `null` in default constructor, while it will not compile otherwise due to the `final` keyword.