### PR TITLE
Update gradle-tooling.adoc

### DIFF
--- a/_guides/gradle-tooling.adoc
+++ b/_guides/gradle-tooling.adoc
@@ -42,7 +42,7 @@ Here is a complete sample file for a simple REST project:
 ----
 plugins {
     id 'java'
-    id 'io.quarkus.' version '{quarkus-version}' <1>
+    id 'io.quarkus' version '{quarkus-version}' <1>
 }
 
 repositories {


### PR DESCRIPTION
The example had a trailing . that shouln't be there. The code works as intended after removing the dot.