### PR TITLE
remove {project-name} template from page header

### DIFF
--- a/_guides/ap4k.adoc
+++ b/_guides/ap4k.adoc
@@ -1,4 +1,4 @@
-= {project-name} - Generating Kubernetes resources
+= Generating Kubernetes resources
 
 This guide covers generating Kubernetes resources based on sane defaults and user supplied configuration.
 


### PR DESCRIPTION
{project-name} is not being substituted by the build/publish process, so it's appearing live at https://quarkus.io/guides/ap4k

Looking at the other guides, they typically don't have {project-name} in their heading (any more) so just remove it to be consistent