### PR TITLE
Add the author, the date and the share links to the blog post page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,16 @@ layout: base
 <div class="post-page grid-wrapper">
   <div class="grid__item width-10-12 doc-content">
     <h1>{{ page.title }}</h1>
+    <div class="grid-wrapper">
+      <div class="grid__item width-8-12 width-12-12-m byline-wrapper">
+        {% assign author = site.data.authors[page.author] %}
+        {% if author.emailhash %}
+          <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+        {% endif %}
+        <p class="byline">By {{ author.name }} | {{ page.date | date: '%B %d, %Y' }}</p>
+      </div>
+      <div class="grid__item width-4-12 width-12-12-m">{% include share-page.html %}</div>
+    </div>
     {{ content }}
   </div>
 </div>

--- a/_sass/layouts/blog.scss
+++ b/_sass/layouts/blog.scss
@@ -24,6 +24,9 @@ body.post {
       }
     }
   }
+}
+
+.blog-page, .post-page {
   .byline-wrapper {
     display: flex;
     align-items:center;
@@ -38,6 +41,14 @@ body.post {
   }
   .share-page {
     text-align: right;
+  }
+}
+
+.post-page {
+  .byline-wrapper {
+    p {
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Before: https://quarkus.io/blog/quarkus-has-a-new-logo/ 

After:
![Screenshot from 2019-06-05 17-52-42](https://user-images.githubusercontent.com/1279749/58971059-ee1c2700-87ba-11e9-86ab-dfc983f3939e.png)
