### PR TITLE
Create jdk-version Variable to Make it Easier to Maintain JDK Versions for Quarkus GuidsT

### DIFF
--- a/_guides/README.adoc
+++ b/_guides/README.adoc
@@ -47,4 +47,6 @@ complete list of externalized variables for use is given in the following table:
 |\{quickstarts-tree-url}|{quickstarts-tree-url}| Quickstarts URL to master source tree root; used for referencing directories.
 
 |\{graalvm-version}|{graalvm-version}| Recommended Graal VM version to use.
+
+|\{jdk-version}|{graalvm-version}| Recommended JDK version to use.
 |===

--- a/_guides/amqp-guide.adoc
+++ b/_guides/amqp-guide.adoc
@@ -14,7 +14,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * A running AMQP 1.0 broker, or Docker Compose to start a development cluster
 * GraalVM installed if you want to run in native mode.

--- a/_guides/ap4k.adoc
+++ b/_guides/ap4k.adoc
@@ -15,7 +15,7 @@ To complete this guide, you need:
 
 * roughly 10 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * access to a Kubernetes or cluster (Minikube is a viable options)
 

--- a/_guides/application-configuration-guide.adoc
+++ b/_guides/application-configuration-guide.adoc
@@ -16,7 +16,7 @@ To complete this guide, you need:
 
 * between 5 and 10 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Solution
@@ -74,7 +74,7 @@ String message;
 @ConfigProperty(name = "greeting.suffix", defaultValue="!") <2>
 String suffix;
 
-@ConfigProperty(name = "greeting.name") 
+@ConfigProperty(name = "greeting.name")
 Optional<String> name; <3>
 ----
 <1> If you do not provide a value for this property, the application startup fails with `javax.enterprise.inject.spi.DeploymentException: No config value of type [class java.lang.String] exists for: greeting.message`.
@@ -341,7 +341,7 @@ By default, if no `@Priority` can be found on a converter, it's registered with 
 and all Quarkus core converters are registered with a priority of 200, so depending on which
 converter you would like to replace, you need to set a higher value.
 
-To demonstrate the idea let us implement a custom converter which will take precedence over 
+To demonstrate the idea let us implement a custom converter which will take precedence over
 `MicroProfileCustomValueConverter` implemented in the previous example.
 
 [source,java]

--- a/_guides/application-lifecycle-events-guide.adoc
+++ b/_guides/application-lifecycle-events-guide.adoc
@@ -19,7 +19,7 @@ To complete this guide, you need:
 
 * less than 10 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 

--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -6,6 +6,7 @@
 :graalvm-version: 19.0.2
 :surefire-version: 2.22.0
 :restassured-version: 3.3.0
+:jdk-version: JDK 8 to 11
 
 :quarkus-home-url: https://quarkus.io
 :quarkus-site-getting-started: /get-started

--- a/_guides/building-native-image-guide.adoc
+++ b/_guides/building-native-image-guide.adoc
@@ -20,7 +20,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * GraalVM installed from the http://www.graalvm.org/downloads/[GraalVM web site].
 Using the community edition is enough.
 Version {graalvm-version} is required.
@@ -275,7 +275,7 @@ NOTE: Interested by tiny Docker images, check the {quarkus-images-url}/graalvm-{
 
 The previous section showed you how to build a native executable using Maven, but implicitly required that the proper GraalVM version be installed on the building machine (be it your local machine or your CI/CD infrastructure).
 
-In cases where the GraalVM requirement cannot be met, you can use Docker to perform the Maven build by using a multi-stage Docker build. A multi-stage Docker build is like two Dockerfile files combined in one, the first is used to build the artifact used by the second. 
+In cases where the GraalVM requirement cannot be met, you can use Docker to perform the Maven build by using a multi-stage Docker build. A multi-stage Docker build is like two Dockerfile files combined in one, the first is used to build the artifact used by the second.
 
 In this guide we will use the first stage to generate the native executable using Maven and the second stage to create our runtime image.
 

--- a/_guides/datasource-guide.adoc
+++ b/_guides/datasource-guide.adoc
@@ -23,7 +23,7 @@ To complete this guide, you need:
 
 * less than 10 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Creating the Maven project
@@ -295,4 +295,3 @@ You can also provide duration values starting with a number.
 In this case, if the value consists only of a number, the converter treats the value as seconds.
 Otherwise, `PT` is implicitly appended to the value to obtain a standard `java.time.Duration` format.
 ====
-

--- a/_guides/fault-tolerance-guide.adoc
+++ b/_guides/fault-tolerance-guide.adoc
@@ -20,7 +20,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == The Scenario

--- a/_guides/getting-started-guide.adoc
+++ b/_guides/getting-started-guide.adoc
@@ -33,7 +33,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Architecture
@@ -416,4 +416,3 @@ In addition, the link:tooling.html[tooling guide] document explains how to:
 * enable the _development mode_ (hot reload)
 * import the project in your favorite IDE
 * and more
-

--- a/_guides/getting-started-testing.adoc
+++ b/_guides/getting-started-testing.adoc
@@ -31,7 +31,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * The completed greeter application from the link:getting-started-guide.html[Getting Started Guide]
 
@@ -306,9 +306,9 @@ public class TestStereotypeTestCase {
 == Mock Support
 
 Quarkus supports the use of mock objects using the CDI `@Alternative` mechanism.
-To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean. 
+To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean.
 Alternatively, a convenient `io.quarkus.test.Mock` stereotype annotation could be used.
-This built-in stereotype declares `@Alternative`, `@Priority(1)` and `@Dependent`. 
+This built-in stereotype declares `@Alternative`, `@Priority(1)` and `@Dependent`.
 For example if I have the following service:
 
 [source,java]

--- a/_guides/health-guide.adoc
+++ b/_guides/health-guide.adoc
@@ -7,12 +7,12 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-This guide demonstrates how your Quarkus application can utilize the MicroProfile 
+This guide demonstrates how your Quarkus application can utilize the MicroProfile
 Health specification through the SmallRye Health extension.
 
-MicroProfile Health allows applications to provide information about their state 
-to external viewers which is typically useful in cloud environments where automated 
-processes must be able to determine whether the application should be discarded 
+MicroProfile Health allows applications to provide information about their state
+to external viewers which is typically useful in cloud environments where automated
+processes must be able to determine whether the application should be discarded
 or restarted.
 
 == Prerequisites
@@ -21,12 +21,12 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Architecture
 
-In this guide, we build a simple REST application that exposes MicroProfile Health functionalities at 
+In this guide, we build a simple REST application that exposes MicroProfile Health functionalities at
 the `/health` endpoint according to the specification. It will also provide several other REST
 endpoints to allow us to dynamically change the healthness of our Quarkus application.
 
@@ -51,16 +51,16 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="health"
 ----
 
-This command generates a Maven project, importing the `smallrye-health` extension 
+This command generates a Maven project, importing the `smallrye-health` extension
 which is an implementation of the MicroProfile Health specification used in Quarkus.
 
 == Running the health check
 
-Importing the `smallrye-health` extension directly exposes a single REST endpoint at 
+Importing the `smallrye-health` extension directly exposes a single REST endpoint at
 the `/health` endpoint that can be used to run the health check procedures:
 
 * start your Quarkus application with `mvn compile quarkus:dev`
-* access the `http://localhost:8080/health` endpoint using your browser or 
+* access the `http://localhost:8080/health` endpoint using your browser or
 `curl http://localhost:8080/health`
 
 The health REST enpoint returns a simple JSON object with two fields:
@@ -68,8 +68,8 @@ The health REST enpoint returns a simple JSON object with two fields:
 * `outcome` -- the overall result of all the health check procedures
 * `checks` -- an array of individual checks
 
-The general `outcome` of the health check is computed as a logical AND of all the declared 
-health check procedures. The `checks` array is empty as we have not specified any health 
+The general `outcome` of the health check is computed as a logical AND of all the declared
+health check procedures. The `checks` array is empty as we have not specified any health
 check procedure yet so let's define some.
 
 == Creating your first health check
@@ -91,7 +91,7 @@ import javax.enterprise.context.ApplicationScoped;
 @Health
 @ApplicationScoped
 public class SimpleHealthCheck implements HealthCheck {
-    
+
     @Override
     public HealthCheckResponse call() {
         return HealthCheckResponse.named("Simple health check").up().build();
@@ -99,24 +99,24 @@ public class SimpleHealthCheck implements HealthCheck {
 }
 ----
 
-As you can see health check procedures are defined as implementations of the `HealthCheck` 
-interface which are defined as CDI beans with the `@Health` qualifier. `HealthCheck` is 
-a functional interface whose single method `call` returns a `HealthCheckResponse` object 
+As you can see health check procedures are defined as implementations of the `HealthCheck`
+interface which are defined as CDI beans with the `@Health` qualifier. `HealthCheck` is
+a functional interface whose single method `call` returns a `HealthCheckResponse` object
 which can be easily constructed by the fluent builder API shown in the example.
 
-As we have started our Quarkus application in dev mode simply repeat the request 
-to `http://localhost:8080/health` by refreshing your browser window or by using `curl http://localhost:8080/health`. 
+As we have started our Quarkus application in dev mode simply repeat the request
+to `http://localhost:8080/health` by refreshing your browser window or by using `curl http://localhost:8080/health`.
 The new health check procedure is now present in the `checks` array.
 
-Congratulations! You've created your first Quarkus health check procedure. Let's 
+Congratulations! You've created your first Quarkus health check procedure. Let's
 continue by exploring what else can be done with the MicroProfile Health specification.
 
 == Adding user specific data to the health check response
 
-In previous section we saw how to create a simple health check with only the minimal 
-attributes, namely, the health check name and its state (UP or DOWN). However, the 
-MicroProfile specification also provides a way for the applications to supply 
-arbitrary data in the form of key value pairs sent to the consuming end. This can be done by using the 
+In previous section we saw how to create a simple health check with only the minimal
+attributes, namely, the health check name and its state (UP or DOWN). However, the
+MicroProfile specification also provides a way for the applications to supply
+arbitrary data in the form of key value pairs sent to the consuming end. This can be done by using the
 `withData(key, value)` method of the health check response builder API.
 
 Let's create our second health check procedure `org.acme.health.DataHealthCheck`:
@@ -146,15 +146,15 @@ public class DataHealthCheck implements HealthCheck {
 }
 ----
 
-If you rerun the health check procedure again by accessing the `/health` endpoint you can 
-see that the new health check `Health check with data` is present in the `checks` array. 
-This check contains a new attribute called `data` which is a JSON object consisting of 
+If you rerun the health check procedure again by accessing the `/health` endpoint you can
+see that the new health check `Health check with data` is present in the `checks` array.
+This check contains a new attribute called `data` which is a JSON object consisting of
 the properties we have defined in our health check procedure.
 
 == Negative health check procedure
 
-In this section we create another health check procedure which simulates a connection to 
-an external service provider such as a database. For simplicity reasons, we only determine 
+In this section we create another health check procedure which simulates a connection to
+an external service provider such as a database. For simplicity reasons, we only determine
 whether the database is accessible or not by a configuration property.
 
 Create `org.acme.health.DatabaseConnectionHealthCheck` class:
@@ -175,13 +175,13 @@ import javax.inject.Inject;
 @Health
 @ApplicationScoped
 public class DatabaseConnectionHealthCheck implements HealthCheck {
-    
+
     @ConfigProperty(name = "database.up", defaultValue = "false")
     private boolean databaseUp;
-    
+
     @Override
     public HealthCheckResponse call() {
-        
+
         HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Database connection health check");
 
         try {
@@ -204,18 +204,18 @@ public class DatabaseConnectionHealthCheck implements HealthCheck {
 }
 ----
 
-If you now rerun the health check the overall `outcome` should be DOWN and you should 
-see in the `checks` array the newly added `Database connection health check` which is 
+If you now rerun the health check the overall `outcome` should be DOWN and you should
+see in the `checks` array the newly added `Database connection health check` which is
 down and the error message explaining why it failed.
 
-As we shouldn't leave this application with a health check in DOWN state and because we 
-are running Quarkus dev mode you can add `database.up=true` in 
-`src/main/resources/application.properties` and rerun the health check again -- 
+As we shouldn't leave this application with a health check in DOWN state and because we
+are running Quarkus dev mode you can add `database.up=true` in
+`src/main/resources/application.properties` and rerun the health check again --
 it should be up again.
 
 == Conclusion
 
-MicroProfile Health provides a way for your application to distribute information 
+MicroProfile Health provides a way for your application to distribute information
 about its healthness state to state whether or not it is able to function properly.
 
 All that is needed to enable the MicroProfile Health features in Quarkus is:

--- a/_guides/hibernate-search-guide.adoc
+++ b/_guides/hibernate-search-guide.adoc
@@ -25,7 +25,7 @@ To complete this guide, you need:
 
 * less than 20 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * Docker
 * link:building-native-image-guide[GraalVM installed if you want to run in native mode]
@@ -413,7 +413,7 @@ We use:
  * an analyzer called `name` for person names,
  * an analyzer called `english` for book titles,
  * a normalizer called `sort` for our sort fields
- 
+
 but we haven't set them up yet.
 
 Let's see how you can do it with Hibernate Search.
@@ -657,4 +657,3 @@ In the context of Quarkus and to build microservices, we thought the latter woul
 Thus we focused our efforts on it.
 
 We don't have plans to support the Lucene backend in Quarkus for now.
-

--- a/_guides/index2.adoc
+++ b/_guides/index2.adoc
@@ -41,7 +41,7 @@ include::quarkus-intro.adoc[tag=intro]
 
 _Mandatory:_
 
-* https://adoptopenjdk.net/[Java - OpenJDK 1.8+]
+* https://adoptopenjdk.net/[Java - OpenJDK 8 to 11]
 * https://maven.apache.org/install.html[Maven 3.5+]
 
 _Recommended:_
@@ -73,5 +73,3 @@ We are in an incubation phase, so we don't have a 1.0.0 release yet.
 == License
 
 This project is licensed under the Apache Software License 2.0 - see the https://github.com/quarkus-project/quarkus/blob/master/LICENSE.txt[License file] for details.
-
-

--- a/_guides/input-validation-guide.adoc
+++ b/_guides/input-validation-guide.adoc
@@ -9,7 +9,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Architecture
@@ -143,12 +143,12 @@ Let's now create the `Result` class as an inner class:
 [source, java]
 ----
 private class Result {
-        
+
     Result(String message) {
         this.success = true;
         this.message = message;
     }
-        
+
     Result(Set<? extends ConstraintViolation<?>> violations) {
         this.success = false;
         this.message = violations.stream()

--- a/_guides/kafka-guide.adoc
+++ b/_guides/kafka-guide.adoc
@@ -15,7 +15,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * A running Kafka cluster, or Docker Compose to start a development cluster
 * GraalVM installed if you want to run in native mode.

--- a/_guides/kafka-streams-guide.adoc
+++ b/_guides/kafka-streams-guide.adoc
@@ -15,7 +15,7 @@ To complete this guide, you need:
 
 * less than 30 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * Docker Compose to start an Apache Kafka development cluster
 * GraalVM installed if you want to run in native mode.

--- a/_guides/keycloak-guide.adoc
+++ b/_guides/keycloak-guide.adoc
@@ -23,7 +23,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * https://stedolan.github.io/jq/[jq tool]
 * Docker

--- a/_guides/kogito-guide.adoc
+++ b/_guides/kogito-guide.adoc
@@ -21,7 +21,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE (Eclipse is preferred with the BPMN modeller plugin)
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * Docker
 

--- a/_guides/kotlin.adoc
+++ b/_guides/kotlin.adoc
@@ -17,7 +17,7 @@ To complete this guide, you need:
 
 * less than 10 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 

--- a/_guides/metrics-guide.adoc
+++ b/_guides/metrics-guide.adoc
@@ -23,7 +23,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Architecture

--- a/_guides/openapi-swaggerui-guide.adoc
+++ b/_guides/openapi-swaggerui-guide.adoc
@@ -16,7 +16,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Architecture

--- a/_guides/opentracing-guide.adoc
+++ b/_guides/opentracing-guide.adoc
@@ -16,7 +16,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * Docker
 

--- a/_guides/rest-client-guide.adoc
+++ b/_guides/rest-client-guide.adoc
@@ -16,7 +16,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Solution

--- a/_guides/rest-json-guide.adoc
+++ b/_guides/rest-json-guide.adoc
@@ -17,7 +17,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Architecture
@@ -222,7 +222,7 @@ Another common pattern in the JAX-RS world is to use the `Response` object.
 
  * you can return different entity types depending on what happens in your method (a `Legume` or an `Error` for instance);
  * you can set the attributes of the `Response` (the status comes to mind in the case of an error).
- 
+
 Your REST method then looks like this:
 
 [source,JAVA]

--- a/_guides/scheduled-guide.adoc
+++ b/_guides/scheduled-guide.adoc
@@ -16,7 +16,7 @@ To complete this guide, you need:
 
 * less than 10 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 

--- a/_guides/sending-emails.adoc
+++ b/_guides/sending-emails.adoc
@@ -16,7 +16,7 @@ To complete this guide, you need:
 * less than 15 minutes
 * The SMTP hostname, port and credentials, and an email address
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 * GraalVM installed if you want to run in native mode.
 
@@ -231,9 +231,9 @@ class MailTest {
         .when()
         .get("/send-email")
         .then()
-           .statusCode(200)    
+           .statusCode(200)
            .body(is("OK"));
-        
+
         // verify that it was sent
         List<Mail> sent = mailbox.getMessagesSentTo(TO);
         assertThat(sent).hasSize(1);
@@ -271,6 +271,3 @@ You can also create your own instance, and pass your own configuration.
 
 This guide has shown how you can send emails from a Quarkus application.
 The _mailer_ extension works in JVM and native mode.
-
-
-

--- a/_guides/spring-di-guide.adoc
+++ b/_guides/spring-di-guide.adoc
@@ -17,7 +17,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 

--- a/_guides/validation-guide.adoc
+++ b/_guides/validation-guide.adoc
@@ -18,7 +18,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 == Architecture
@@ -152,12 +152,12 @@ Let's now create the `Result` class as an inner class:
 [source, java]
 ----
 private class Result {
-        
+
     Result(String message) {
         this.success = true;
         this.message = message;
     }
-        
+
     Result(Set<? extends ConstraintViolation<?>> violations) {
         this.success = false;
         this.message = violations.stream()

--- a/_guides/websocket-guide.adoc
+++ b/_guides/websocket-guide.adoc
@@ -16,7 +16,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 


### PR DESCRIPTION
This pull request adds a `jdk-version` attribute for the guides on the Quarkus website. It also changes the guides recommended JDK version to be `JDK 8 to 11` to reflect that Quarkus is not able to run on JDK 12.
