### PR TITLE
Add JDK and Maven Attributes

### DIFF
--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -7,7 +7,7 @@
 :surefire-version: 2.22.0
 :restassured-version: 3.3.0
 :jdk-version: JDK 8 or 11
-:maven-version: Maven 3.5.4+
+:maven-version: Apache Maven 3.5.4+
 
 :quarkus-home-url: https://quarkus.io
 :quarkus-site-getting-started: /get-started

--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -6,6 +6,8 @@
 :graalvm-version: 19.0.2
 :surefire-version: 2.22.0
 :restassured-version: 3.3.0
+:jdk-version: JDK 8 or 11
+:maven-version: Maven 3.5.4+
 
 :quarkus-home-url: https://quarkus.io
 :quarkus-site-getting-started: /get-started

--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -7,7 +7,7 @@
 :surefire-version: 2.22.0
 :restassured-version: 3.3.0
 :jdk-version: JDK 8 or 11
-:maven-version: Apache Maven 3.5.4+
+:maven-version: Apache Maven 3.5.3+
 
 :quarkus-home-url: https://quarkus.io
 :quarkus-site-getting-started: /get-started


### PR DESCRIPTION
This pull request adds both a `JDK` and `Maven` version attribute to use with Guides in the `Quarkus` main repository. 

This will help with maintaining `JDK` and `Maven` versions in docs moving forward. As of now, the text for both `JDK` and `Maven` is written in every doc, but that will need to change in the future.

Updating the actual guides with the new attributes and updating the `README` with Guide attributes will be done in the `Quarkus` repo.