### PR TITLE
wrong test url for 'Create the Configuration'

### DIFF
--- a/_guides/application-configuration-guide.adoc
+++ b/_guides/application-configuration-guide.adoc
@@ -109,7 +109,7 @@ Once set, check the application with:
 
 [source,shell]
 ----
-$ curl http://localhost:8080/greeting
+$ curl http://localhost:8080/hello
 hello quarkus!
 ----
 
@@ -120,7 +120,6 @@ So you can quickly know when your configuration is complete.
 
 We also need to update the functional test to reflect the changes made to endpoint.
 Edit the `src/test/java/org/acme/config/GreetingResourceTest.java` file and change the content of the `testHelloEndpoint` method to:
-
 
 [source,java]
 ----


### PR DESCRIPTION
The test url for section 'Create the Configuration' is wrong. It should be ```http://localhost:8080/hello``` instead of ```http://localhost:8080/greeting```

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
