### PR TITLE
SmallRye REST Client was renamed to REST Client

### DIFF
--- a/_data/extensions.yaml
+++ b/_data/extensions.yaml
@@ -76,15 +76,14 @@ categories:
         - swagger-ui
         groupId: io.quarkus
         artifactId: quarkus-smallrye-openapi
-      - name: SmallRye REST Client
+      - name: REST Client
         description: "Call REST services"
         labels:
-        - smallrye-rest-client
         - rest-client
         - web-client
         - microprofile-rest-client
         groupId: io.quarkus
-        artifactId: quarkus-smallrye-rest-client
+        artifactId: quarkus-rest-client
       - name: Undertow Servlet
         description: "Support for servlets"
         labels:


### PR DESCRIPTION
SmallRye REST Client was renamed to REST Client in Quarkus 0.20.0

https://mvnrepository.com/artifact/io.quarkus/quarkus-rest-client

