### PR TITLE
Extensions for amazon-dynamodb, elytron-security-oauth2, smallrye-reactive-type-converters

### DIFF
--- a/_data/extensions.yaml
+++ b/_data/extensions.yaml
@@ -238,6 +238,15 @@ categories:
         - nosql
         groupId: io.quarkus
         artifactId: quarkus-neo4j
+      - name: Amazon DynamoDB client
+        description: "A client for the Amazon DynamoDB datastore"
+        labels:
+        - dynamodb
+        - dynamo
+        - aws
+        - amazon
+        groupId: io.quarkus
+        artifactId: quarkus-amazon-dynamodb
   - category: Messaging
     cat-id: messaging
     extensions:
@@ -304,6 +313,17 @@ categories:
         - reactive
         groupId: io.quarkus
         artifactId: quarkus-smallrye-reactive-streams-operators
+      - name: SmallRye Reactive Type Converters
+        description: "Converters for reactive types from various reactive programming libraries"
+        labels:
+        - smallrye-reactive-type-converters
+        - reactive-type-converters
+        - reactive-streams-operators
+        - reactive-streams
+        - microprofile-reactive-streams
+        - reactive
+        groupId: io.quarkus
+        artifactId: quarkus-smallrye-reactive-type-converters
       - name: SmallRye Context Propagation
         description: "SmallRye Context Propagation"
         labels:
@@ -427,6 +447,13 @@ categories:
         - openid-connect
         groupId: io.quarkus
         artifactId: quarkus-keycloak
+      - name: Elytron Security OAuth 2.0
+        description: "Secure your applications with OAuth2 opaque tokens"
+        labels:
+        - security
+        - oauth2
+        groupId: io.quarkus
+        artifactId: quarkus-elytron-security-oauth2
   - category: Serialization
     cat-id: serialization
     extensions:


### PR DESCRIPTION
Details for existing extensions:
 * amazon-dynamodb
 * elytron-security-oauth2
 * smallrye-reactive-type-converters

