### PR TITLE
Introduce code.quarkus.io

### DIFF
--- a/_includes/get-started-band.html
+++ b/_includes/get-started-band.html
@@ -37,9 +37,7 @@
     <div class="number"><div>4</div></div>
     <div class="text">
       <div class="text">
-        Enjoy Quarkus {{ site.data.versions.quarkus.version }}!
-      </div>
-      <div class="text">
+        <a href="https://code.quarkus.io">Start Coding</a>  with Quarkus {{ site.data.versions.quarkus.version }}
         [<a href="{{ site.data.versions.quarkus.announce }}">announce</a>|<a href="https://github.com/quarkusio/quarkus/releases/tag/{{ site.data.versions.quarkus.version }}">changelog</a>]
       </div>
     </div>

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -15,7 +15,7 @@
               <a href="{{site.baseurl}}/guides/" class="{% if page.url contains '/guides/' %}active{% endif %}">Guides</a>
             </li>
             <li>
-              <a href="{{site.baseurl}}/extensions/" class="{% if page.url contains '/extensions/' %}active{% endif %}">Extensions</a>
+              <a href="https://code.quarkus.io">Start Coding</a>
             </li>
             <li>
               <a href="{{site.baseurl}}/community/" class="{% if page.url contains '/community/' %}active{% endif %}">Community</a>

--- a/get-started.md
+++ b/get-started.md
@@ -34,7 +34,7 @@ This guide covers:
 <div class="guide-item" markdown="1">
 ## Quickly Bootstrap Your Application
 
-With <a href="https://code.quarkus.io">code.quarkus.io</a>, in a few click, you can bootstrap your Quarkus application and discover its extension ecosystem.
+With <a href="https://code.quarkus.io">code.quarkus.io</a>, in a few clicks, you can bootstrap your Quarkus application and discover its extension ecosystem.
 
 Explore the wide breadth of technologies Quarkus applications can be made with.
 

--- a/get-started.md
+++ b/get-started.md
@@ -8,7 +8,8 @@ permalink: /get-started/
 ## Table of Contents
 ### Getting Started
 
- - [Creating Your First Application]({{site.baseurl}}/guides/getting-started-guide)
+ - [Be Guided Through First Application]({{site.baseurl}}/guides/getting-started-guide)
+ - [Quickly Bootstrap Your Application](https://code.quarkus.io)
  - [Building Native Images]({{site.baseurl}}/guides/building-native-image-guide)
  - [Using our Tooling]({{site.baseurl}}/guides/tooling)
 
@@ -19,7 +20,7 @@ permalink: /get-started/
 </div>
 <div class="grid__item width-8-12 width-12-12-m gs-content">
 <div class="guide-item" markdown="1">
-## Create Your First Application
+## Be Guided Through Your First Application
 
 This guide covers:
 - Bootstrapping an application
@@ -29,6 +30,15 @@ This guide covers:
 - Packaging of the application
 
 <a href="{{site.baseurl}}/guides/getting-started-guide" class="button-cta secondary">READ THE GUIDE</a>
+</div>
+<div class="guide-item" markdown="1">
+## Quickly Bootstrap Your Application
+
+With <a href="https://code.quarkus.io">code.quarkus.io</a>, in a few click, you can bootstrap your Quarkus application and discover its extension ecosystem.
+
+Explore the wide breadth of technologies Quarkus applications can be made with.
+
+<a href="https://code.quarkus.io" class="button-cta secondary">START CODING</a>
 </div>
 
 <div class="guide-item" markdown="1">


### PR DESCRIPTION
- Change menu to "START CODING" (replacing "EXTENSIONS")
- Change get-started page item 4 to `Start Coding with Quarkus {{version}}` with link.
![image](https://user-images.githubusercontent.com/2223984/63360738-3638f780-c36f-11e9-9fe4-3c9ca5ba8ed3.png)

- Add new section in get-started page "Quickly Bootstrap Your Application"
![image](https://user-images.githubusercontent.com/2223984/63360966-962f9e00-c36f-11e9-809f-d1580e51218f.png)

- Change "Create Your First Application" to  "Be Guided Through Your First Application" to avoid ambiguity between both choices
