### PR TITLE
Fix invalid XML in feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -17,7 +17,7 @@ layout: null
                 {{ post.url | prepend: site.url }}
             </link>
             <description>
-                {{ post.content | escape | truncate: '400' }}
+                {{ post.content | strip_html | truncate: '400'  }}
             </description>
             <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
             <guid>


### PR DESCRIPTION
Hi there! I wanted to follow your RSS feed but it could not be parsed by my RSS reader due to invalid XML (see [feed validator](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fquarkus.io%2F%2Ffeed.xml)).

`post.content` contains HTML. Truncating it arbitrarily at 400 chars
could result in raw `&` characters for example to end up in the feed.

This commit simply strips HTML and then truncates as suggested in #213.
