### PR TITLE
docs: initial POC for publications page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem 'jekyll-asciidoc'
   gem 'jekyll-paginate-v2'
+  gem 'jekyll-scholar'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,19 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     asciidoctor (2.0.10)
+    bibtex-ruby (4.4.7)
+      latex-decode (~> 0.0)
+    citeproc (1.0.9)
+      namae (~> 1.0)
+    citeproc-ruby (1.1.10)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 1.5)
     colorator (1.1.0)
     concurrent-ruby (1.1.5)
+    csl (1.5.0)
+      namae (~> 1.0)
+    csl-styles (1.0.1.9)
+      csl (~> 1.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -37,11 +48,17 @@ GEM
       jekyll (~> 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
+    jekyll-scholar (5.16.0)
+      bibtex-ruby (~> 4.0, >= 4.0.13)
+      citeproc-ruby (~> 1.0)
+      csl-styles (~> 1.0)
+      jekyll (~> 3.0)
     jekyll-seo-tag (2.6.0)
       jekyll (~> 3.3)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (1.17.0)
+    latex-decode (0.3.1)
     liquid (4.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -52,6 +69,7 @@ GEM
       jekyll (~> 3.5)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
+    namae (1.0.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
@@ -75,8 +93,9 @@ DEPENDENCIES
   jekyll-asciidoc
   jekyll-feed (~> 0.6)
   jekyll-paginate-v2
+  jekyll-scholar
   minima (~> 2.0)
   tzinfo-data
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/_bibliography/publications.bib
+++ b/_bibliography/publications.bib
@@ -135,3 +135,13 @@ Publications
   url = "https://medium.com/@yazidaqel/quarkus-configuration-using-consul-d077dc6d5d3",
   urldate = "2019-09-24"
 }
+
+@Article {HomeofQuarkusCheatSheet-2019-08-31,
+  title = "Quarkus Cheat-Sheet",
+  date = "2019-08-31",
+  author = "Alex Soto",
+  affiliation = "Red Hat",
+  note = "Alex Soto created a cheatsheet with tips/tricks on how to make things happen in Quarkus.",
+  url = "https://lordofthejars.github.io/quarkus-cheat-sheet/",
+  urldate = "2019-09-26"
+}

--- a/_bibliography/publications.bib
+++ b/_bibliography/publications.bib
@@ -1,0 +1,137 @@
+---
+### This file is a list of interesting article around Quarkus in bibtex format.
+### Recommended to use https://github.com/maxandersen/html2biblatex as bookmarklet to
+### create a entry for a page in your webbrowser.
+---
+Publications
+============
+
+@Podcast {QuarkusistheOppositeofWildflyairhacksfmpodcastAdamBiensWeblog-2019-09-21,
+  title = "Quarkus is the Opposite of Wildfly",
+  date = "2019-08-06",
+  author = "Adam Bien, Dimitris Andreadis",
+  affiliation = "airhacks.fm",
+  url = "http://www.adam-bien.com/roller/abien/entry/quarkus_is_the_opposite_of",
+  urldate = "2019-09-21",
+  note = "Adam Bien sits down with Dimitris, manager of the Quarkus Red Hat team. Talks on how Dimitris started in IT and his thoughts on Quarkus."
+}
+
+@Podcast {TheFirstLineofQuarkusairhacksfmPodcastAdamBiensWeblog-2019-09-21,
+  title = "The First Line of Quarkus",
+  date = "2019-09-03",
+  author = "Adam Bien, Emmanuel Bernard",
+  affiliation = "airhacks.fm",
+  note = "Adam Bien talks with Emmmanuel Bernard co-lead of Quarkus on how he got from his first computer to the first line of Quarkus.",
+  url = "http://adambien.blog/roller/abien/entry/the_first_line_of_quarkus",
+  urldate = "2019-09-21"
+}
+
+@Article {QuarkusandInstanaLightspeedMonitoringforSupersonicJavaInstana-2019-09-17,
+  title = "Quarkus and Instana: Lightspeed Monitoring for Supersonic Java",
+  date = "2019-07-30",
+  author = "Tim Riemer",
+  affiliation = "Vorwerk Group/Instana", 
+  url = "https://www.instana.com/blog/quarkus-and-instana-lightspeed-monitoring-for-supersonic-java/",
+  urldate = "2019-09-21",
+  note = "Tim from Vorwerk Group writes on how to utilize Quarkus OpenTracing together with Instana Java OpenTracing."
+}
+
+@Article {RedHatsQuarkusBringsNativelyCompiledJavatoKubernetesTheNewStack-2019-09-21,
+  title = "Red Hat's Quarkus Brings Natively Compiled Java to Kubernetes - The New Stack",
+  date = "2019-04-16",
+  author = "Mike Melanson",
+  affiliation = "The New Stack",
+  note = "News article covering the launch of Quarkus",
+  url = "https://thenewstack.io/red-hats-quarkus-brings-natively-compiled-java-to-kubernetes",
+  urldate = "2019-09-21"
+}
+
+@Video {TurbochargedJavawithQuarkusJakartaOneLivestreamYouTube-2019-09-21,
+  title = "Turbocharged Java with Quarkus",
+  date = "2019-09-11",
+  author = "Marcus Biel",
+  affiliation = "Eclipse Foundation",
+  url = "https://www.youtube.com/watch?time_continue=42&v=oJx2Dd8yrG4",
+  urldate = "2019-09-21",
+  note = "Marcus shows how to create native executable with Quarkus and how fast it scales. Part of JakartaOne online web conference."
+}
+
+
+@Article {ThoughtsonQuarkusDZoneJava-2019-09-21,
+  title = "Thoughts on Quarkus - DZone Java",
+  date = "2019-04-19",
+  author = "Sebastian Daschner",
+  url = "https://dzone.com/articles/thoughts-on-quarkus",
+  urldate = "2019-09-21",
+  note = "Sebastian from Dzone gives his analysis of Quarkus."
+}
+
+@Article {TomEEvsSpringBootvsQuarkusBaptistaInternet-2019-09-21,
+  title = "TomEE vs SpringBoot vs Quarkus – Baptista @ Internet",
+  date = "2019-03-12",
+  author = "Bruno Baptista",
+  affiliation = "Personal Blog",
+  url = "https://brunobat.com/2019/03/12/tomee-vs-spring-boot-vs-quarkus/",
+  urldate = "2019-09-21",
+  note = "Bruno Baptista makes a comparison of startup and memory usage of three major runtimes."
+}
+
+@Article {GuidetoQuarkusIOBaeldung-2019-09-21,
+  title = "Guide to QuarkusIO",
+  date = "2019-08-13",
+  author = "Rodrigo Graciano",
+  affiliation = "Baeldung",
+  note = "Spring author Rodrigo wrote a nice introductury article for Quarkus.",
+  url = "https://www.baeldung.com/quarkus-io",
+  urldate = "2019-09-21"
+}
+
+@Article {QuarkusaKubernetesNativeJavaFramework-2019-09-21,
+  title = "Quarkus, a Kubernetes Native Java Framework",
+  date = "2019-03-25",
+  author = "Diogo Carleto",
+  affiliation = "InfoQ",
+  note = "News article on InfoQ on the launch of Quarkus",
+  url = "https://www.infoq.com/news/2019/03/redhat-release-quarkus/",
+  urldate = "2019-09-21"
+}
+
+@Article {IntroducingQuarkusanextgenerationKubernetesnativeJavaframeworkRedHatDeveloper-2019-09-21,
+  title = "Introducing Quarkus: a next-generation Kubernetes native Java framework - Red Hat Developer",
+  date = "2019-03-07",
+  author = "Jason Greene",
+  affiliation = "Red Hat",
+  note = "Jason Greene introducing Quarkus to the world.",
+  url = "https://developers.redhat.com/blog/2019/03/07/quarkus-next-generation-kubernetes-native-java-framework/",
+  urldate = "2019-09-21"
+}
+
+@Video {QuarkusandGraalVMBootingHibernateatSupersonicSpeedSubatomicSize-2019-09-22,
+  title = "Quarkus and GraalVM: Booting Hibernate at Supersonic Speed, Subatomic Size",
+  date = "2019-09-11",
+  author = "Sanne Grinovero",
+  affiliation = "QCon Sao Paulo 2019",
+  note = "Sanne did a talk at Qcon Sao Paulo on Quarkus & GraalVM.",
+  url = "https://www.infoq.com/presentations/quarkus-graalvm-sao-paulo-2019/?utm_source=twitter&utm_medium=link&utm_campaign=calendar",
+  urldate = "2019-09-22"
+}
+
+@Article {QuarkusVertxapowerfullcombinationPart1Introduction-2019-09-24,
+  title = "Quarkus & Vertx, a powerfull combination — Part 1 Introduction",
+  date = "2019-04-21",
+  author = "yazid aqel",
+  affiliation = "Personal Blog",
+  note = "Yazid made an introductury series blog on how to use Kafka and Eclipse Vert.x with Quarkus.",
+  url = "https://medium.com/@yazidaqel/quarkus-vertx-a-powerfull-combination-part-1-introduction-b039b911686",
+  urldate = "2019-09-24"
+}
+
+@Article {QuarkusconfigurationusingConsulyazidaqelMedium-2019-09-24,
+  title = "Quarkus configuration using Consul - yazid aqel - Medium",
+  date = "2019-05-04",
+  author = "yazid aqel",
+  affiliation = "Personal Blog",
+  note = "Yazid writes about how to use HashiCorp Consul with Quarkus",
+  url = "https://medium.com/@yazidaqel/quarkus-configuration-using-consul-d077dc6d5d3",
+  urldate = "2019-09-24"
+}

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll/scholar
 
 sass:
   style: compressed
@@ -129,3 +130,19 @@ pagination:
   # indexpage: 'index'
 
 ############################################################
+
+# Scholar / Bibliography
+scholar: 
+##  style: _bibliography/quarkus-style.csl
+  bibliography_template: bibliography
+  bibliography: publications.bib
+  group_by: type
+  sort_by: date
+  order: descending
+  group_order: type
+  type_order: [article, video, podcast]
+  type_names: 
+    article: Article & Blogs
+    podcast: Podcasts
+    video: Videos
+    

--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -131,3 +131,10 @@ dakwon:
   job_title: "Software Engineering Intern"
   twitter: ""
   bio: "Intern at Red Hat working on developer tools."
+maxandersen:
+  name: "Max Rydahl Andersen"
+  email: "manderse@redhat.com"
+  emailhash: "9ac47c2c99739d75d633f4d9b73eef35"
+  job_title: Distinguished Engineer
+  twitter: "maxandersen"
+  bio: "Danish guy enjoying working on open source software. Making things happen at Red Hat as Distinguished Engineer. Currently works on Quarkus. Worked before as manager and technical lead of openshift.io, JBoss Tools and Developer Studio. In past also involved in Hibernate, WildFly, Seam and more."

--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -11,6 +11,7 @@
 :quarkus-home-url: https://quarkus.io
 :quarkus-site-getting-started: /get-started
 :quarkus-site-extension-authors-guide: /guides/extension-authors-guide
+:quarkus-site-publications: /publications
 :quarkus-org-url: https://github.com/quarkusio
 :quarkus-base-url: https://github.com/quarkusio/quarkus
 :quarkus-clone-url: https://github.com/quarkusio/quarkus.git

--- a/_guides/topic/community.adoc
+++ b/_guides/topic/community.adoc
@@ -25,6 +25,10 @@ Live chat on Zulip::
 
 If you prefer live chat with the developers, we have a {quarkus-chat-url}[Zulip chat] where we all hang out.
 
+== Publications
+
+We are actively collection interesting blogs, articles, videos and other interesting publications. You can find those on link:{quarkus-site-publications}[Publications] page.
+
 == An Open Project
 
 {project-name} is an Open Source project licensed under the https://www.apache.org/licenses/LICENSE-2.0[Apache License version 2.0]. First and foremost, it is an open community where contributions, ideas and discussions are done in the open and welcome contributors. Let's join forces in building the future of Java applications.

--- a/_guides/topic/publications.adoc
+++ b/_guides/topic/publications.adoc
@@ -1,26 +1,10 @@
 ---
-layout: community
+layout: publications
 permalink: /publications/
 ---
 include::../attributes.adoc[]
 = {project-name} - Publications
 
-Below is a list of articles, blogs, podcast and other tidbits published online around Quarkus.
+Below is a list of articles, blogs, podcast and other tidbits published online around {project-name}.
 
-[%header,format=csv]
-|===
-Date, Title,Author, Affiliation, Kind
-2019-06-08, http://www.adam-bien.com/roller/abien/entry/quarkus_is_the_opposite_of[Quarkus is the opposite of WildFly], Adam Bien/Dimitris Andreadis, Adam Bien, Podcast
-2019-09-03, http://adambien.blog/roller/abien/entry/the_first_line_of_quarkus[The First Line of Quarkuus], Adam Bien/Emmanuel Bernard, Adam Bien, Podcast
-2019-07-30, https://www.instana.com/blog/quarkus-and-instana-lightspeed-monitoring-for-supersonic-java/[Quarkus and Instana: Lightspeed Monitoring for Supersonic Java], Chis Engelbert, Instana, Article 
-2019-04-16, https://thenewstack.io/red-hats-quarkus-brings-natively-compiled-java-to-kubernetes[Red Hat's Quarkus Brings Natively Compiled Java to Kubernetes], Mike Melanson, TheNewStack, Article 
-2019-09-13, https://www.youtube.com/watch?time_continue=42&v=oJx2Dd8yrG4[Turbocharged Java with Quarkus], Marcus Biel/Adam Bien, JakartaOne/Eclipse Foundation, Video
-2019-09-19, https://www.youtube.com/watch?v=pqMIDJ58Fco[Getting started with Quarkus and Kogito], ??, ??, Video
-2019-08-29, https://dzone.com/articles/quick-guide-to-microservices-with-quarkus-on-opens[Quick Guide to Microservices With Quarkus on OpenShift], Piotr Mińkowski, DZone, Article
-2019-04-19, https://dzone.com/articles/thoughts-on-quarkus[Thoughts on Quarkus], Sebastian Daschner, Dzone, Article
-2019-03-12, https://brunobat.com/2019/03/12/tomee-vs-spring-boot-vs-quarkus/[TomEE vs SpringBoot vs Quarkus], Bruno Baptista, Personal, Blog
-2019-08-13, https://www.baeldung.com/quarkus-io[Guide to QuarkusIO], Rodrigo Graciano, Baeldung, Blog
-2019-08-13, https://opensourceforu.com/2019/08/quarkus-supersonic-and-subatomic/[Quarkus Supersonic and Subatomic], Jaydeep Chakrabarty, opensourceforu.com, Article
-2019-03-25, https://www.infoq.com/news/2019/03/redhat-release-quarkus/[Quarkus - a Kubernetes Native Java Framework], Diogo Carleto, InfoQ, Article
-2019-07-03, https://developers.redhat.com/blog/2019/03/07/quarkus-next-generation-kubernetes-native-java-framework/[Introducing Quarkus: a next-generation Kubernetes  native Java Frameowrk], Jason Greene, Red Hat, Blog
-|===
+If you believe we are missing an article, blog or video https://github.com/quarkusio/quarkusio.github.io[submit an issue].

--- a/_guides/topic/publications.adoc
+++ b/_guides/topic/publications.adoc
@@ -1,0 +1,26 @@
+---
+layout: community
+permalink: /publications/
+---
+include::../attributes.adoc[]
+= {project-name} - Publications
+
+Below is a list of articles, blogs, podcast and other tidbits published online around Quarkus.
+
+[%header,format=csv]
+|===
+Date, Title,Author, Affiliation, Kind
+2019-06-08, http://www.adam-bien.com/roller/abien/entry/quarkus_is_the_opposite_of[Quarkus is the opposite of WildFly], Adam Bien/Dimitris Andreadis, Adam Bien, Podcast
+2019-09-03, http://adambien.blog/roller/abien/entry/the_first_line_of_quarkus[The First Line of Quarkuus], Adam Bien/Emmanuel Bernard, Adam Bien, Podcast
+2019-07-30, https://www.instana.com/blog/quarkus-and-instana-lightspeed-monitoring-for-supersonic-java/[Quarkus and Instana: Lightspeed Monitoring for Supersonic Java], Chis Engelbert, Instana, Article 
+2019-04-16, https://thenewstack.io/red-hats-quarkus-brings-natively-compiled-java-to-kubernetes[Red Hat's Quarkus Brings Natively Compiled Java to Kubernetes], Mike Melanson, TheNewStack, Article 
+2019-09-13, https://www.youtube.com/watch?time_continue=42&v=oJx2Dd8yrG4[Turbocharged Java with Quarkus], Marcus Biel/Adam Bien, JakartaOne/Eclipse Foundation, Video
+2019-09-19, https://www.youtube.com/watch?v=pqMIDJ58Fco[Getting started with Quarkus and Kogito], ??, ??, Video
+2019-08-29, https://dzone.com/articles/quick-guide-to-microservices-with-quarkus-on-opens[Quick Guide to Microservices With Quarkus on OpenShift], Piotr Mińkowski, DZone, Article
+2019-04-19, https://dzone.com/articles/thoughts-on-quarkus[Thoughts on Quarkus], Sebastian Daschner, Dzone, Article
+2019-03-12, https://brunobat.com/2019/03/12/tomee-vs-spring-boot-vs-quarkus/[TomEE vs SpringBoot vs Quarkus], Bruno Baptista, Personal, Blog
+2019-08-13, https://www.baeldung.com/quarkus-io[Guide to QuarkusIO], Rodrigo Graciano, Baeldung, Blog
+2019-08-13, https://opensourceforu.com/2019/08/quarkus-supersonic-and-subatomic/[Quarkus Supersonic and Subatomic], Jaydeep Chakrabarty, opensourceforu.com, Article
+2019-03-25, https://www.infoq.com/news/2019/03/redhat-release-quarkus/[Quarkus - a Kubernetes Native Java Framework], Diogo Carleto, InfoQ, Article
+2019-07-03, https://developers.redhat.com/blog/2019/03/07/quarkus-next-generation-kubernetes-native-java-framework/[Introducing Quarkus: a next-generation Kubernetes  native Java Frameowrk], Jason Greene, Red Hat, Blog
+|===

--- a/_layouts/bibliography.html
+++ b/_layouts/bibliography.html
@@ -1,0 +1,11 @@
+---
+---
+{% if entry.note %}
+{{ entry.note }}
+{% endif %}
+</br>
+<a href="{{entry.url}}">{{entry.title}}</a>
+{% if entry.affiliation %}
+from {{entry.affiliation}}
+{% endif %}
+by <b>{{entry.author}}</b> posted {{entry.date | date: "%-d. %B %Y" }}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -36,10 +36,10 @@ layout: base
         {% endif %}
         {% if paginator.next_page %}
           <a href="{{ paginator.next_page_path | prepend: site.baseurl }}" class="button-cta secondary">Older Posts</a>
-        {% endif %}
+          {% endif %}
       </div>
-    {% endif %}
+      {% endif %}
   </div>
-
+  
   <div class="grid__item width-2-12"></div>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,10 @@ layout: base
       </div>
       <div class="grid__item width-4-12 width-12-12-m">{% include share-page.html url=page.url title=page.title %}</div>
       <div class="grid__item width-12-12">
-        {{ content }}
+          {{ content }}
+          {% if page.bibquery %}
+          {% bibliography --query {{page.bibquery}} %}
+          {% endif %}
       </div>
     </div>
   </div>

--- a/_layouts/publications.html
+++ b/_layouts/publications.html
@@ -1,0 +1,9 @@
+---
+layout: vision
+---
+
+<div>
+    {{ content }}
+
+    {% bibliography %}
+</div>

--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -365,3 +365,8 @@ div.guides img {
   margin: auto;
   padding: 5px;
 }
+
+ol.bibliography {
+    list-style: none;
+
+}


### PR DESCRIPTION
Will be on http://localhost:4000/publications when you run jekyll.

While learning about Quarkus I browsed randomly online to see what else was out there and
thought it would be cool if we actually had a page to gather external publications related to Quarkus.

This is my first go on taking links I visited recently and see how it would look in a table.

After having done it I think better approach would be to create _publications/* folder like _posts so we
can sort/redner it as we want rather than a massive big CSV file.

Could also be used for a monthly or even weekly "Quarkus News" style blog post linking the latest entries.

WDYT?



** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **