### PR TITLE
Mention base extension for VS Code extension

### DIFF
--- a/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
+++ b/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
@@ -11,9 +11,13 @@ author: dakwon
 Earlier this year, we have been introduced to Quarkus, the next-generation, container-first framework for Java applications.
 As expected, such new frameworks and technologies make way for new developer tools focused on making
 the development experience even better.
+
 The recent https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus[Quarkus Tools for Visual Studio Code release]
 aims to do just that,
 by bringing features specific to Quarkus project development within VS Code.
+The VS Code extension was https://github.com/tsurdilo/quarkus-vsc[originally] started as a pet project by
+https://github.com/tsurdilo[Tihomir Surdilovic], from the Business Automation Team at Red Hat and became
+the foundation of today’s version.
 This blog post outlines what Quarkus Tools for Visual Studio Code has to offer so far:
 convenient features for an already convenient Java framework.
 


### PR DESCRIPTION
This PR updates a blog post to mention the extension that Quarkus Tools for Visual Studio Code was based on.

My PR mentions Red Hat, so maybe

> The VS Code extension was originally started as a pet project by Tihomir Surdilovic, from the Business Automation Team at Red Hat and became the foundation of today’s version.

should be changed to

> The VS Code extension was originally started as a pet project by Tihomir Surdilovic and became the foundation of today’s version.

to keep things neutral?
