### PR TITLE
Canonical headers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,6 +68,7 @@ defaults:
       type: "guides" # previously `post` in Jekyll 2.2.
     values:
       layout: "guides"
+      permalink: /guides/:name
   -
     scope:
       type: "posts"

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,6 +12,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  <link rel="canonical" href="{{ page.url | prepend: site.url }}">
   <link rel="shortcut icon" type="image/png" href="{{ "/favicon.ico" | prepend: site.baseurl }}" >
   <link rel="stylesheet" href="{{ site.url }}/guides/stylesheet/config.css" />
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />


### PR DESCRIPTION
Also needed to fix the guides not having a permalink, or the preference was being given to the links with .html postfix.

Fixes #352