### PR TITLE
Fix redirects from *.html pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ setup.sh
 
 org.eclipse.m2e.core.prefs
 npm-debug.log
+
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,4 +96,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -4,7 +4,7 @@
 <!doctype html>
 <html>
     <head>
-	<meta http-equiv="refresh" content="0; url={{site.url}}{{page.newUrl}}">
-	<link rel="canonical" href="{{site.url}}{{page.newUrl}}" />
+        <meta http-equiv="refresh" content="0; url={{site.url}}{{page.newUrl}}">
+        <link rel="canonical" href="{{site.url}}{{page.newUrl}}" />
     </head>
 </html>

--- a/_redirects/guides/amazon-lambda-guide.html
+++ b/_redirects/guides/amazon-lambda-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/amazon-lambda-guide.html
 newUrl: /guides/amazon-lambda
 ---

--- a/_redirects/guides/amazon-lambda-guide.md
+++ b/_redirects/guides/amazon-lambda-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/amazon-lambda-guide/index.html
+newUrl: /guides/amazon-lambda
+---

--- a/_redirects/guides/amazon-lambda-http-guide.html
+++ b/_redirects/guides/amazon-lambda-http-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/amazon-lambda-http-guide.html
 newUrl: /guides/amazon-lambda-http
 ---

--- a/_redirects/guides/amazon-lambda-http-guide.md
+++ b/_redirects/guides/amazon-lambda-http-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/amazon-lambda-http-guide/index.html
+newUrl: /guides/amazon-lambda-http
+---

--- a/_redirects/guides/amqp-guide.html
+++ b/_redirects/guides/amqp-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/amqp-guide.html
 newUrl: /guides/amqp
 ---

--- a/_redirects/guides/amqp-guide.md
+++ b/_redirects/guides/amqp-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/amqp-guide/index.html
+newUrl: /guides/amqp
+---

--- a/_redirects/guides/application-configuration-guide.html
+++ b/_redirects/guides/application-configuration-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/application-configuration-guide.html
 newUrl: /guides/config
 ---

--- a/_redirects/guides/application-configuration-guide.md
+++ b/_redirects/guides/application-configuration-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/application-configuration-guide/index.html
+newUrl: /guides/config
+---

--- a/_redirects/guides/application-lifecycle-events-guide.html
+++ b/_redirects/guides/application-lifecycle-events-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/application-lifecycle-events-guide.html
 newUrl: /guides/lifecycle
 ---

--- a/_redirects/guides/application-lifecycle-events-guide.md
+++ b/_redirects/guides/application-lifecycle-events-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/application-lifecycle-events-guide/index.html
+newUrl: /guides/lifecycle
+---

--- a/_redirects/guides/artemis-jms-guide.html
+++ b/_redirects/guides/artemis-jms-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/artemis-jms-guide.html
 newUrl: /guides/jms
 ---

--- a/_redirects/guides/artemis-jms-guide.md
+++ b/_redirects/guides/artemis-jms-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/artemis-jms-guide/index.html
+newUrl: /guides/jms
+---

--- a/_redirects/guides/async-message-passing.html
+++ b/_redirects/guides/async-message-passing.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/async-message-passing.html
 newUrl: /guides/reactive-messaging
 ---

--- a/_redirects/guides/async-message-passing.md
+++ b/_redirects/guides/async-message-passing.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/async-message-passing/index.html
+newUrl: /guides/reactive-messaging
+---

--- a/_redirects/guides/azure-cloud-guide.html
+++ b/_redirects/guides/azure-cloud-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/azure-cloud-guide.html
 newUrl: /guides/deploying-to-azure-cloud
 ---

--- a/_redirects/guides/azure-cloud-guide.md
+++ b/_redirects/guides/azure-cloud-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/azure-cloud-guide/index.html
+newUrl: /guides/deploying-to-azure-cloud
+---

--- a/_redirects/guides/azure-functions-http-guide.html
+++ b/_redirects/guides/azure-functions-http-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/azure-functions-http-guide.html
 newUrl: /guides/azure-functions-http
 ---

--- a/_redirects/guides/azure-functions-http-guide.md
+++ b/_redirects/guides/azure-functions-http-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/azure-functions-http-guide/index.html
+newUrl: /guides/azure-functions-http
+---

--- a/_redirects/guides/building-native-image-guide.html
+++ b/_redirects/guides/building-native-image-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/building-native-image-guide.html
 newUrl: /guides/building-native-image
 ---

--- a/_redirects/guides/building-native-image-guide.md
+++ b/_redirects/guides/building-native-image-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/building-native-image-guide/index.html
+newUrl: /guides/building-native-image
+---

--- a/_redirects/guides/context-propagation-guide.html
+++ b/_redirects/guides/context-propagation-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/context-propagation-guide.html
 newUrl: /guides/context-propagation
 ---

--- a/_redirects/guides/context-propagation-guide.md
+++ b/_redirects/guides/context-propagation-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/context-propagation-guide/index.html
+newUrl: /guides/context-propagation
+---

--- a/_redirects/guides/datasource-guide.html
+++ b/_redirects/guides/datasource-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/datasource-guide.html
 newUrl: /guides/datasource
 ---

--- a/_redirects/guides/datasource-guide.md
+++ b/_redirects/guides/datasource-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/datasource-guide/index.html
+newUrl: /guides/datasource
+---

--- a/_redirects/guides/dynamodb-guide.html
+++ b/_redirects/guides/dynamodb-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/dynamodb-guide.html
 newUrl: /guides/dynamodb
 ---

--- a/_redirects/guides/dynamodb-guide.md
+++ b/_redirects/guides/dynamodb-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/dynamodb-guide/index.html
+newUrl: /guides/dynamodb
+---

--- a/_redirects/guides/elytron-properties-guide.html
+++ b/_redirects/guides/elytron-properties-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/elytron-properties-guide.html
 newUrl: /guides/security-properties
 ---

--- a/_redirects/guides/elytron-properties-guide.md
+++ b/_redirects/guides/elytron-properties-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/elytron-properties-guide/index.html
+newUrl: /guides/security-properties
+---

--- a/_redirects/guides/extension-authors-guide.html
+++ b/_redirects/guides/extension-authors-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/extension-authors-guide.html
 newUrl: /guides/writing-extensions
 ---

--- a/_redirects/guides/extension-authors-guide.md
+++ b/_redirects/guides/extension-authors-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/extension-authors-guide/index.html
+newUrl: /guides/writing-extensions
+---

--- a/_redirects/guides/fault-tolerance-guide.html
+++ b/_redirects/guides/fault-tolerance-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/fault-tolerance-guide.html
 newUrl: /guides/microprofile-fault-tolerance
 ---

--- a/_redirects/guides/fault-tolerance-guide.md
+++ b/_redirects/guides/fault-tolerance-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/fault-tolerance-guide/index.html
+newUrl: /guides/microprofile-fault-tolerance
+---

--- a/_redirects/guides/flyway-guide.html
+++ b/_redirects/guides/flyway-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/flyway-guide.html
 newUrl: /guides/flyway
 ---

--- a/_redirects/guides/flyway-guide.md
+++ b/_redirects/guides/flyway-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/flyway-guide/index.html
+newUrl: /guides/flyway
+---

--- a/_redirects/guides/getting-started-guide.html
+++ b/_redirects/guides/getting-started-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/getting-started-guide.html
 newUrl: /guides/getting-started
 ---

--- a/_redirects/guides/getting-started-guide.md
+++ b/_redirects/guides/getting-started-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/getting-started-guide/index.html
+newUrl: /guides/getting-started
+---

--- a/_redirects/guides/getting-started-knative-guide.html
+++ b/_redirects/guides/getting-started-knative-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/getting-started-knative-guide.html
 newUrl: /guides/getting-started-knative
 ---

--- a/_redirects/guides/getting-started-knative-guide.md
+++ b/_redirects/guides/getting-started-knative-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/getting-started-knative-guide/index.html
+newUrl: /guides/getting-started-knative
+---

--- a/_redirects/guides/health-guide.html
+++ b/_redirects/guides/health-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/health-guide.html
 newUrl: /guides/microprofile-health
 ---

--- a/_redirects/guides/health-guide.md
+++ b/_redirects/guides/health-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/health-guide/index.html
+newUrl: /guides/microprofile-health
+---

--- a/_redirects/guides/hibernate-orm-guide.html
+++ b/_redirects/guides/hibernate-orm-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/hibernate-orm-guide.html
 newUrl: /guides/hibernate-orm
 ---

--- a/_redirects/guides/hibernate-orm-guide.md
+++ b/_redirects/guides/hibernate-orm-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/hibernate-orm-guide/index.html
+newUrl: /guides/hibernate-orm
+---

--- a/_redirects/guides/hibernate-orm-panache-guide.html
+++ b/_redirects/guides/hibernate-orm-panache-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/hibernate-orm-panache-guide.html
 newUrl: /guides/hibernate-orm-panache
 ---

--- a/_redirects/guides/hibernate-orm-panache-guide.md
+++ b/_redirects/guides/hibernate-orm-panache-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/hibernate-orm-panache-guide/index.html
+newUrl: /guides/hibernate-orm-panache
+---

--- a/_redirects/guides/hibernate-search-guide.html
+++ b/_redirects/guides/hibernate-search-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/hibernate-search-guide.html
 newUrl: /guides/hibernate-search-elasticsearch
 ---

--- a/_redirects/guides/hibernate-search-guide.md
+++ b/_redirects/guides/hibernate-search-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/hibernate-search-guide/index.html
+newUrl: /guides/hibernate-search-elasticsearch
+---

--- a/_redirects/guides/infinispan-client-guide.html
+++ b/_redirects/guides/infinispan-client-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/infinispan-client-guide.html
 newUrl: /guides/infinispan-client
 ---

--- a/_redirects/guides/infinispan-client-guide.md
+++ b/_redirects/guides/infinispan-client-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/infinispan-client-guide/index.html
+newUrl: /guides/infinispan-client
+---

--- a/_redirects/guides/infinispan-embedded-guide.html
+++ b/_redirects/guides/infinispan-embedded-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/infinispan-embedded-guide.html
 newUrl: /guides/infinispan-embedded
 ---

--- a/_redirects/guides/infinispan-embedded-guide.md
+++ b/_redirects/guides/infinispan-embedded-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/infinispan-embedded-guide/index.html
+newUrl: /guides/infinispan-embedded
+---

--- a/_redirects/guides/jwt-guide.html
+++ b/_redirects/guides/jwt-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/jwt-guide.html
 newUrl: /guides/security-jwt
 ---

--- a/_redirects/guides/jwt-guide.md
+++ b/_redirects/guides/jwt-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/jwt-guide/index.html
+newUrl: /guides/security-jwt
+---

--- a/_redirects/guides/kafka-guide.html
+++ b/_redirects/guides/kafka-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/kafka-guide.html
 newUrl: /guides/kafka
 ---

--- a/_redirects/guides/kafka-guide.md
+++ b/_redirects/guides/kafka-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/kafka-guide/index.html
+newUrl: /guides/kafka
+---

--- a/_redirects/guides/kafka-streams-guide.html
+++ b/_redirects/guides/kafka-streams-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/kafka-streams-guide.html
 newUrl: /guides/kafka-streams
 ---

--- a/_redirects/guides/kafka-streams-guide.md
+++ b/_redirects/guides/kafka-streams-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/kafka-streams-guide/index.html
+newUrl: /guides/kafka-streams
+---

--- a/_redirects/guides/keycloak-authorization-guide.html
+++ b/_redirects/guides/keycloak-authorization-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/keycloak-authorization-guide.html
 newUrl: /guides/security-keycloak-authorization
 ---

--- a/_redirects/guides/keycloak-authorization-guide.md
+++ b/_redirects/guides/keycloak-authorization-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/keycloak-authorization-guide/index.html
+newUrl: /guides/security-keycloak-authorization
+---

--- a/_redirects/guides/kogito-guide.html
+++ b/_redirects/guides/kogito-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/kogito-guide.html
 newUrl: /guides/kogito
 ---

--- a/_redirects/guides/kogito-guide.md
+++ b/_redirects/guides/kogito-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/kogito-guide/index.html
+newUrl: /guides/kogito
+---

--- a/_redirects/guides/kubernetes-guide.html
+++ b/_redirects/guides/kubernetes-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/kubernetes-guide.html
 newUrl: /guides/deploying-to-kubernetes
 ---

--- a/_redirects/guides/kubernetes-guide.md
+++ b/_redirects/guides/kubernetes-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/kubernetes-guide/index.html
+newUrl: /guides/deploying-to-kubernetes
+---

--- a/_redirects/guides/kubernetes-resources.html
+++ b/_redirects/guides/kubernetes-resources.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/kubernetes-resources.html
 newUrl: /guides/kubernetes
 ---

--- a/_redirects/guides/kubernetes-resources.md
+++ b/_redirects/guides/kubernetes-resources.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/kubernetes-resources/index.html
+newUrl: /guides/kubernetes
+---

--- a/_redirects/guides/logging-guide.html
+++ b/_redirects/guides/logging-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/logging-guide.html
 newUrl: /guides/logging
 ---

--- a/_redirects/guides/logging-guide.md
+++ b/_redirects/guides/logging-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/logging-guide/index.html
+newUrl: /guides/logging
+---

--- a/_redirects/guides/metrics-guide.html
+++ b/_redirects/guides/metrics-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/metrics-guide.html
 newUrl: /guides/microprofile-metrics
 ---

--- a/_redirects/guides/metrics-guide.md
+++ b/_redirects/guides/metrics-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/metrics-guide/index.html
+newUrl: /guides/microprofile-metrics
+---

--- a/_redirects/guides/mongo-guide.html
+++ b/_redirects/guides/mongo-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/mongo-guide.html
 newUrl: /guides/mongodb
 ---

--- a/_redirects/guides/mongo-guide.md
+++ b/_redirects/guides/mongo-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/mongo-guide/index.html
+newUrl: /guides/mongodb
+---

--- a/_redirects/guides/mongodb-panache-guide.html
+++ b/_redirects/guides/mongodb-panache-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/mongodb-panache-guide.html
 newUrl: /guides/mongodb-panache
 ---

--- a/_redirects/guides/mongodb-panache-guide.md
+++ b/_redirects/guides/mongodb-panache-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/mongodb-panache-guide/index.html
+newUrl: /guides/mongodb-panache
+---

--- a/_redirects/guides/native-and-ssl-guide.html
+++ b/_redirects/guides/native-and-ssl-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/native-and-ssl-guide.html
 newUrl: /guides/native-and-ssl
 ---

--- a/_redirects/guides/native-and-ssl-guide.md
+++ b/_redirects/guides/native-and-ssl-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/native-and-ssl-guide/index.html
+newUrl: /guides/native-and-ssl
+---

--- a/_redirects/guides/neo4j-guide.html
+++ b/_redirects/guides/neo4j-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/neo4j-guide.html
 newUrl: /guides/neo4j
 ---

--- a/_redirects/guides/neo4j-guide.md
+++ b/_redirects/guides/neo4j-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/neo4j-guide/index.html
+newUrl: /guides/neo4j
+---

--- a/_redirects/guides/oauth2-guide.html
+++ b/_redirects/guides/oauth2-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/oauth2-guide.html
 newUrl: /guides/security-oauth2
 ---

--- a/_redirects/guides/oauth2-guide.md
+++ b/_redirects/guides/oauth2-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/oauth2-guide/index.html
+newUrl: /guides/security-oauth2
+---

--- a/_redirects/guides/oidc-guide.html
+++ b/_redirects/guides/oidc-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/oidc-guide.html
 newUrl: /guides/security-openid-connect
 ---

--- a/_redirects/guides/oidc-guide.md
+++ b/_redirects/guides/oidc-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/oidc-guide/index.html
+newUrl: /guides/security-openid-connect
+---

--- a/_redirects/guides/oidc-web-app-guide.html
+++ b/_redirects/guides/oidc-web-app-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/oidc-web-app-guide.html
 newUrl: /guides/security-openid-connect-web-authentication
 ---

--- a/_redirects/guides/oidc-web-app-guide.md
+++ b/_redirects/guides/oidc-web-app-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/oidc-web-app-guide/index.html
+newUrl: /guides/security-openid-connect-web-authentication
+---

--- a/_redirects/guides/openapi-swaggerui-guide.html
+++ b/_redirects/guides/openapi-swaggerui-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/openapi-swaggerui-guide.html
 newUrl: /guides/openapi-swaggerui
 ---

--- a/_redirects/guides/openapi-swaggerui-guide.md
+++ b/_redirects/guides/openapi-swaggerui-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/openapi-swaggerui-guide/index.html
+newUrl: /guides/openapi-swaggerui
+---

--- a/_redirects/guides/openshift-s2i-guide.html
+++ b/_redirects/guides/openshift-s2i-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/openshift-s2i-guide.html
 newUrl: /guides/deploying-to-openshift-s2i
 ---

--- a/_redirects/guides/openshift-s2i-guide.md
+++ b/_redirects/guides/openshift-s2i-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/openshift-s2i-guide/index.html
+newUrl: /guides/deploying-to-openshift-s2i
+---

--- a/_redirects/guides/opentracing-guide.html
+++ b/_redirects/guides/opentracing-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/opentracing-guide.html
 newUrl: /guides/opentracing
 ---

--- a/_redirects/guides/opentracing-guide.md
+++ b/_redirects/guides/opentracing-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/opentracing-guide/index.html
+newUrl: /guides/opentracing
+---

--- a/_redirects/guides/reactive-routes-guide.html
+++ b/_redirects/guides/reactive-routes-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/reactive-routes-guide.html
 newUrl: /guides/reactive-routes
 ---

--- a/_redirects/guides/reactive-routes-guide.md
+++ b/_redirects/guides/reactive-routes-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/reactive-routes-guide/index.html
+newUrl: /guides/reactive-routes
+---

--- a/_redirects/guides/rest-client-guide.html
+++ b/_redirects/guides/rest-client-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/rest-client-guide.html
 newUrl: /guides/rest-client
 ---

--- a/_redirects/guides/rest-client-guide.md
+++ b/_redirects/guides/rest-client-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/rest-client-guide/index.html
+newUrl: /guides/rest-client
+---

--- a/_redirects/guides/rest-client-multipart-guide.html
+++ b/_redirects/guides/rest-client-multipart-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/rest-client-multipart-guide.html
 newUrl: /guides/rest-client-multipart
 ---

--- a/_redirects/guides/rest-client-multipart-guide.md
+++ b/_redirects/guides/rest-client-multipart-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/rest-client-multipart-guide/index.html
+newUrl: /guides/rest-client-multipart
+---

--- a/_redirects/guides/rest-json-guide.html
+++ b/_redirects/guides/rest-json-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/rest-json-guide.html
 newUrl: /guides/rest-json
 ---

--- a/_redirects/guides/rest-json-guide.md
+++ b/_redirects/guides/rest-json-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/rest-json-guide/index.html
+newUrl: /guides/rest-json
+---

--- a/_redirects/guides/scheduled-guide.html
+++ b/_redirects/guides/scheduled-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/scheduled-guide.html
 newUrl: /guides/scheduler
 ---

--- a/_redirects/guides/scheduled-guide.md
+++ b/_redirects/guides/scheduled-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/scheduled-guide/index.html
+newUrl: /guides/scheduler
+---

--- a/_redirects/guides/security-guide.html
+++ b/_redirects/guides/security-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/security-guide.html
 newUrl: /guides/security
 ---

--- a/_redirects/guides/security-guide.md
+++ b/_redirects/guides/security-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-guide/index.html
+newUrl: /guides/security
+---

--- a/_redirects/guides/security-jdbc-guide.html
+++ b/_redirects/guides/security-jdbc-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/security-jdbc-guide.html
 newUrl: /guides/security-jdbc
 ---

--- a/_redirects/guides/security-jdbc-guide.md
+++ b/_redirects/guides/security-jdbc-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-jdbc-guide/index.html
+newUrl: /guides/security-jdbc
+---

--- a/_redirects/guides/sending-emails.html
+++ b/_redirects/guides/sending-emails.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/sending-emails.html
 newUrl: /guides/mailer
 ---

--- a/_redirects/guides/sending-emails.md
+++ b/_redirects/guides/sending-emails.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/sending-emails/index.html
+newUrl: /guides/mailer
+---

--- a/_redirects/guides/spring-data-jpa-guide.html
+++ b/_redirects/guides/spring-data-jpa-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/spring-data-jpa-guide.html
 newUrl: /guides/spring-data-jpa
 ---

--- a/_redirects/guides/spring-data-jpa-guide.md
+++ b/_redirects/guides/spring-data-jpa-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/spring-data-jpa-guide/index.html
+newUrl: /guides/spring-data-jpa
+---

--- a/_redirects/guides/spring-di-guide.html
+++ b/_redirects/guides/spring-di-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/spring-di-guide.html
 newUrl: /guides/spring-di
 ---

--- a/_redirects/guides/spring-di-guide.md
+++ b/_redirects/guides/spring-di-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/spring-di-guide/index.html
+newUrl: /guides/spring-di
+---

--- a/_redirects/guides/spring-web-guide.html
+++ b/_redirects/guides/spring-web-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/spring-web-guide.html
 newUrl: /guides/spring-web
 ---

--- a/_redirects/guides/spring-web-guide.md
+++ b/_redirects/guides/spring-web-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/spring-web-guide/index.html
+newUrl: /guides/spring-web
+---

--- a/_redirects/guides/stm-guide.html
+++ b/_redirects/guides/stm-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/stm-guide.html
 newUrl: /guides/software-transactional-memory
 ---

--- a/_redirects/guides/stm-guide.md
+++ b/_redirects/guides/stm-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/stm-guide/index.html
+newUrl: /guides/software-transactional-memory
+---

--- a/_redirects/guides/tests-with-coverage-guide.html
+++ b/_redirects/guides/tests-with-coverage-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/tests-with-coverage-guide.html
 newUrl: /guides/tests-with-coverage
 ---

--- a/_redirects/guides/tests-with-coverage-guide.md
+++ b/_redirects/guides/tests-with-coverage-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/tests-with-coverage-guide/index.html
+newUrl: /guides/tests-with-coverage
+---

--- a/_redirects/guides/tika-guide.html
+++ b/_redirects/guides/tika-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/tika-guide.html
 newUrl: /guides/tika
 ---

--- a/_redirects/guides/tika-guide.md
+++ b/_redirects/guides/tika-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/tika-guide/index.html
+newUrl: /guides/tika
+---

--- a/_redirects/guides/transaction-guide.html
+++ b/_redirects/guides/transaction-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/transaction-guide.html
 newUrl: /guides/transaction
 ---

--- a/_redirects/guides/transaction-guide.md
+++ b/_redirects/guides/transaction-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/transaction-guide/index.html
+newUrl: /guides/transaction
+---

--- a/_redirects/guides/undertow-reference.html
+++ b/_redirects/guides/undertow-reference.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/undertow-reference.html
 newUrl: /guides/http-reference
 ---

--- a/_redirects/guides/undertow-reference.md
+++ b/_redirects/guides/undertow-reference.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/undertow-reference/index.html
+newUrl: /guides/http-reference
+---

--- a/_redirects/guides/using-vertx.html
+++ b/_redirects/guides/using-vertx.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/using-vertx.html
 newUrl: /guides/vertx
 ---

--- a/_redirects/guides/using-vertx.md
+++ b/_redirects/guides/using-vertx.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/using-vertx/index.html
+newUrl: /guides/vertx
+---

--- a/_redirects/guides/validation-guide.html
+++ b/_redirects/guides/validation-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/validation-guide.html
 newUrl: /guides/validation
 ---

--- a/_redirects/guides/validation-guide.md
+++ b/_redirects/guides/validation-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/validation-guide/index.html
+newUrl: /guides/validation
+---

--- a/_redirects/guides/vault-guide.html
+++ b/_redirects/guides/vault-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/vault-guide.html
 newUrl: /guides/vault
 ---

--- a/_redirects/guides/vault-guide.md
+++ b/_redirects/guides/vault-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/vault-guide/index.html
+newUrl: /guides/vault
+---

--- a/_redirects/guides/websocket-guide.html
+++ b/_redirects/guides/websocket-guide.html
@@ -1,3 +1,4 @@
 ---
+permalink: /guides/websocket-guide.html
 newUrl: /guides/websockets
 ---

--- a/_redirects/guides/websocket-guide.md
+++ b/_redirects/guides/websocket-guide.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/websocket-guide/index.html
+newUrl: /guides/websockets
+---


### PR DESCRIPTION
Apparently some .html URLs were indexed by Google, and we're getting 404 status pages when clicking on the Google search results. This fixes the problem.