### PR TITLE
develop: Splitted graalvm-version to docker-centos-quarkus-maven-tag

### DIFF
--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -4,6 +4,7 @@
 :quarkus-version: 1.2.0.Final
 
 :graalvm-version: 19.3.1
+:docker-centos-quarkus-maven-tag: 19.3.1-java8
 :surefire-version: 2.22.0
 :restassured-version: 4.1.2
 

--- a/_guides/building-native-image.adoc
+++ b/_guides/building-native-image.adoc
@@ -347,7 +347,7 @@ In this guide we will use the first stage to generate the native executable usin
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/centos-quarkus-maven:{graalvm-version} AS build
+FROM quay.io/quarkus/centos-quarkus-maven:{docker-centos-quarkus-maven-tag} AS build
 COPY src /usr/src/app/src
 COPY pom.xml /usr/src/app
 USER root

--- a/_guides/deploying-to-openshift-s2i.adoc
+++ b/_guides/deploying-to-openshift-s2i.adoc
@@ -37,7 +37,7 @@ We are going to create an OpenShift `build` executing it:
 [source,shell, subs="attributes"]
 ----
 # To build the image on OpenShift
-oc new-app quay.io/quarkus/ubi-quarkus-native-s2i:{graalvm-version}~{quickstarts-clone-url} --context-dir=getting-started --name=quarkus-quickstart-native
+oc new-app quay.io/quarkus/ubi-quarkus-native-s2i:{docker-centos-quarkus-maven-tag}~{quickstarts-clone-url} --context-dir=getting-started --name=quarkus-quickstart-native
 oc logs -f bc/quarkus-quickstart-native
 
 # To create the route
@@ -111,7 +111,7 @@ The end result is an image that is less than 40 MB in size (compressed) and does
 The minimal build is depending on the S2I build since it is using the output (native runnable application) from the S2I build. However, you do not need to create an application with `oc new-app`. Instead you could use `oc new-build` like this:
 [source, shell, subs="attributes"]
 ----
-oc new-build quay.io/quarkus/ubi-quarkus-native-s2i:{graalvm-version}~{quickstarts-clone-url} \
+oc new-build quay.io/quarkus/ubi-quarkus-native-s2i:{docker-centos-quarkus-maven-tag}~{quickstarts-clone-url} \
     --context-dir=getting-started --name=quarkus-quickstart-native
 ----
 ====

--- a/_guides/native-and-ssl.adoc
+++ b/_guides/native-and-ssl.adoc
@@ -208,7 +208,7 @@ You can for example modify your `Dockerfile.native` as follows to copy the requi
 
 [source, subs=attributes+]
 ----
-FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version} as nativebuilder
+FROM quay.io/quarkus/ubi-quarkus-native-image:{docker-centos-quarkus-maven-tag} as nativebuilder
 RUN mkdir -p /tmp/ssl-libs/lib \
   && cp /opt/graalvm/jre/lib/security/cacerts /tmp/ssl-libs \
   && cp /opt/graalvm/jre/lib/amd64/libsunec.so /tmp/ssl-libs/lib/


### PR DESCRIPTION
Since the Graal-VM Version differs to the available Docker images on https://quay.io/repository/quarkus/centos-quarkus-maven?tag=latest&tab=tags 

bc the -java8  / -java11 was added to the name, i splitted up the graalvm-version 

