### PR TITLE
initial tag archiving pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ org.eclipse.m2e.core.prefs
 npm-debug.log
 
 .idea
+.vscode

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem 'jekyll-asciidoc'
   gem 'jekyll-paginate-v2'
+  gem 'jekyll-archives'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-archives (2.2.1)
+      jekyll (>= 3.6, < 5.0)
     jekyll-asciidoc (3.0.0)
       asciidoctor (>= 1.5.0)
       jekyll (>= 3.0.0)
@@ -70,6 +72,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 3.8.3)
+  jekyll-archives
   jekyll-asciidoc
   jekyll-feed (~> 0.6)
   jekyll-paginate-v2
@@ -77,4 +80,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -39,10 +39,17 @@ These instructions will get you a copy of the Quarkus.io website up and running 
 
 To write a blog:
 
-- create an author ent ry in [_data/authors.yaml](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/authors.yaml)
+- create an author entry in [_data/authors.yaml](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/authors.yaml)
     - `emailhash` is used to fetch your picture form the Gravatar service
 - create an blog entry under [_posts](https://github.com/quarkusio/quarkusio.github.io/tree/develop/_posts)
     -the file name is `yyyy-mm-dd-slug.adoc`
+- `tags` should be used with some care as an archive page is created for of them. Below are some basic rules to try follow:
+  - `quarkus-release` used for Quarkus release blogs
+  - `announcement` used for general announcement with some impact.
+  - `extension` used for blogs related to a specific extension.
+  - `user-story` used for stories from users/companies adopting Quarkus.
+  - `development-tips` used for blogs with tips to develop using Quarkus or Quarkus itself. 
+  - add a tech specific, like `kafka`, if your post has a signficant mention/relevance to that technology.
 - it's in asciidoc format, there is an example as shown with [2019-06-05-quarkus-and-web-ui-development-mode.adoc](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc)
 - send a pull request against the develop branch and voilà
 

--- a/_config.yml
+++ b/_config.yml
@@ -164,9 +164,5 @@ jekyll-archives:
   layouts: 
     tag: tag-archive
   permalinks:
-    year: '/:year/'
-    month: '/:year/:month/'
-    day: '/:year/:month/:day/'
-    tag: '/tag/:name/'
-    category: '/category/:name/'
-
+    tag: '/blog/tag/:name/'
+  

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-archives
 
 sass:
   style: compressed
@@ -153,3 +154,19 @@ publication:
     video: Videos
     training: Training
     book: Books
+
+############################################################
+
+# https://github.com/jekyll/jekyll-archives/blob/master/docs/configuration.md
+jekyll-archives:
+  enabled: 
+    - tags
+  layouts: 
+    tag: tag-archive
+  permalinks:
+    year: '/:year/'
+    month: '/:year/:month/'
+    day: '/:year/:month/:day/'
+    tag: '/tag/:name/'
+    category: '/category/:name/'
+

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -14,11 +14,7 @@ layout: base
     {% for post in paginator.posts %}
       {% assign author = site.data.authors[post.author] %}
       <div class="blog-list-item grid-wrapper">
-        <div class="post-date grid__item width-12-12">{{ post.date | date: '%B %d, %Y' }}
-          {% for tag in post.tags %}
-          <a href="{{site.baseurl}}/tag/{{ tag }}">#{{tag}}</a>
-          {% endfor %}
-        </div>
+        <div class="post-date grid__item width-12-12">{{ post.date | date: '%B %d, %Y' }}</div>
         <div class="post-title grid__item width-12-12">
           <a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a>
         </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -14,7 +14,11 @@ layout: base
     {% for post in paginator.posts %}
       {% assign author = site.data.authors[post.author] %}
       <div class="blog-list-item grid-wrapper">
-        <div class="post-date grid__item width-12-12">{{ post.date | date: '%B %d, %Y' }}</div>
+        <div class="post-date grid__item width-12-12">{{ post.date | date: '%B %d, %Y' }}
+          {% for tag in post.tags %}
+          <a href="{{site.baseurl}}/tag/{{ tag }}">#{{tag}}</a>
+          {% endfor %}
+        </div>
         <div class="post-title grid__item width-12-12">
           <a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a>
         </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,11 +4,7 @@ layout: base
 
 <div class="post-page grid-wrapper">
   <div class="grid__item width-10-12 width-12-12-m doc-content">
-    <div class="post-date">{{ page.date | date: '%B %d, %Y' }}
-      {% for tag in page.tags %}
-          <a href="{{site.baseurl}}/tag/{{ tag }}">#{{tag}}</a>
-      {% endfor %}
-    </div>
+    <div class="post-date">{{ page.date | date: '%B %d, %Y' }}</div>
     <h1>{{ page.title }}</h1>
     <div class="grid-wrapper">
       <div class="grid__item width-8-12 width-12-12-m byline-wrapper">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,11 @@ layout: base
 
 <div class="post-page grid-wrapper">
   <div class="grid__item width-10-12 width-12-12-m doc-content">
-    <div class="post-date">{{ page.date | date: '%B %d, %Y' }}</div>
+    <div class="post-date">{{ page.date | date: '%B %d, %Y' }}
+      {% for tag in page.tags %}
+          <a href="{{site.baseurl}}/tag/{{ tag }}">#{{tag}}</a>
+      {% endfor %}
+    </div>
     <h1>{{ page.title }}</h1>
     <div class="grid-wrapper">
       <div class="grid__item width-8-12 width-12-12-m byline-wrapper">

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -1,0 +1,13 @@
+---
+layout: base
+---
+
+<h1>Archive of posts with {{ page.type }} '{{ page.title }}'</h1>
+<ul class="posts">
+  {% for post in page.posts %}
+    <li>
+      <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+      <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+    </li>
+  {% endfor %}
+</ul>

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-<h1>Archive of posts with {{ page.type }} '{{ page.title }}'</h1>
+<h1>Posts with {{ page.type }} '{{ page.title }}'</h1>
 <ul class="posts">
   {% for post in page.posts %}
     <li>

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -6,7 +6,7 @@ layout: base
 <ul class="posts">
   {% for post in page.posts %}
     <li>
-      <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+      <span class="post-date">{{ post.date | date: '%B %d, %Y' }}</span>
       <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
     </li>
   {% endfor %}

--- a/_posts/2019-05-05-quarkus-has-a-new-logo.adoc
+++ b/_posts/2019-05-05-quarkus-has-a-new-logo.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus has a new logo
 date: 2019-05-08 14:00:00.000 -0600
-tags: quarkus logo announcement
+tags: logo announcement
 author: jcobb
 ---
 

--- a/_posts/2019-05-05-quarkus-has-a-new-logo.adoc
+++ b/_posts/2019-05-05-quarkus-has-a-new-logo.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus has a new logo
 date: 2019-05-08 14:00:00.000 -0600
-tags: logo announcement
+tags: announcement
 author: jcobb
 ---
 

--- a/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc
+++ b/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus and Web UI Development
 date: 2019-06-05 14:00:00.000 -0600
-tags: quarkus ui development
+tags: ui development
 author: kkhan
 ---
 

--- a/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc
+++ b/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus and Web UI Development
 date: 2019-06-05 14:00:00.000 -0600
-tags: ui development
+tags: development-tips
 author: kkhan
 ---
 

--- a/_posts/2019-06-18-hibernate-search-extension.adoc
+++ b/_posts/2019-06-18-hibernate-search-extension.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'New extension: Hibernate Search + Elasticsearch'
 date: 2019-06-18
-tags: hibernate elasticsearch
+tags: extension hibernate elasticsearch
 author: gsmet
 ---
 

--- a/_posts/2019-06-18-hibernate-search-extension.adoc
+++ b/_posts/2019-06-18-hibernate-search-extension.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'New extension: Hibernate Search + Elasticsearch'
 date: 2019-06-18
-tags: quarkus hibernate elasticsearch
+tags: hibernate elasticsearch
 author: gsmet
 ---
 

--- a/_posts/2019-06-26-kafka-streams-applications-with-quarkus-and-microprofile.adoc
+++ b/_posts/2019-06-26-kafka-streams-applications-with-quarkus-and-microprofile.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Building Kafka Streams applications with Quarkus and Eclipse MicroProfile'
 date: 2019-06-26
-tags: quarkus kafka kafka-streams microprofile
+tags: kafka kafka-streams microprofile
 author: gmorling
 ---
 

--- a/_posts/2019-06-26-kafka-streams-applications-with-quarkus-and-microprofile.adoc
+++ b/_posts/2019-06-26-kafka-streams-applications-with-quarkus-and-microprofile.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Building Kafka Streams applications with Quarkus and Eclipse MicroProfile'
 date: 2019-06-26
-tags: kafka kafka-streams microprofile
+tags: kafka microprofile
 author: gmorling
 ---
 

--- a/_posts/2019-06-27-quarkus-0-18-released.adoc
+++ b/_posts/2019-06-27-quarkus-0-18-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.18.0 released'
 date: 2019-06-27
-tags: quarkus-release
+tags: release
 author: gsmet
 ---
 

--- a/_posts/2019-06-27-quarkus-0-18-released.adoc
+++ b/_posts/2019-06-27-quarkus-0-18-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.18.0 released'
 date: 2019-06-27
-tags: quarkus release
+tags: quarkus-release
 author: gsmet
 ---
 

--- a/_posts/2019-07-08-runtime-performance.adoc
+++ b/_posts/2019-07-08-runtime-performance.adoc
@@ -2,6 +2,7 @@
 layout: post
 date:   2019-07-08 00:00 +0100
 author: johara
+tags: development-tips
 synopsis: Quarkus has so far been focused on start-up time and memory footprint, but runtime performance is important as well. Find out how well Quarkus performs in both Native and JVM modes.
 ---
 

--- a/_posts/2019-07-11-quarkus-0-19.1-released.adoc
+++ b/_posts/2019-07-11-quarkus-0-19.1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.19.1 released'
 date: 2019-07-11
-tags: quarkus release
+tags: quarkus-release
 author: gsmet
 ---
 

--- a/_posts/2019-07-11-quarkus-0-19.1-released.adoc
+++ b/_posts/2019-07-11-quarkus-0-19.1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.19.1 released'
 date: 2019-07-11
-tags: quarkus-release
+tags: release
 author: gsmet
 ---
 

--- a/_posts/2019-07-25-quarkus-dependency-injection.adoc
+++ b/_posts/2019-07-25-quarkus-dependency-injection.adoc
@@ -2,6 +2,7 @@
 layout: post
 date:   2019-07-25 00:00 +0100
 author: mkouba
+tags: extension arc development-tips 
 synopsis: Quarkus ArC is a build-time oriented dependency injection based on CDI 2.0. But what does it actually mean and what benefits does a build-time processing DI bring?
 ---
 

--- a/_posts/2019-07-31-quarkus-0-20-0-released.adoc
+++ b/_posts/2019-07-31-quarkus-0-20-0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.20.0 released'
 date: 2019-07-31
-tags: quarkus-release
+tags: release
 author: gsmet
 ---
 

--- a/_posts/2019-07-31-quarkus-0-20-0-released.adoc
+++ b/_posts/2019-07-31-quarkus-0-20-0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.20.0 released'
 date: 2019-07-31
-tags: quarkus release
+tags: quarkus-release
 author: gsmet
 ---
 

--- a/_posts/2019-08-01-hibernate-orm-config-profiles.adoc
+++ b/_posts/2019-08-01-hibernate-orm-config-profiles.adoc
@@ -3,7 +3,7 @@ layout: post
 title: Tips to use Hibernate ORM with Quarkus profiles and live coding mode
 date: 2019-08-01 14:00:00.000 +0200
 synopsis: Hibernate ORM lets you generate or update the database schema. Let's explore when to use such option in combination with live coding.
-tags: hibernate
+tags: extension hibernate development-tips
 author: ebernard
 ---
 

--- a/_posts/2019-08-01-quarkus-app-circleci-build.adoc
+++ b/_posts/2019-08-01-quarkus-app-circleci-build.adoc
@@ -2,6 +2,7 @@
 layout: post
 date:   2019-08-01
 author: ewittman
+tips: development-tips
 synopsis: With a little bit of config mojo, it is possible (and useful) to build a native Quarkus application in CircleCI.
 ---
 

--- a/_posts/2019-08-15-quarkus-0-21-1-released.adoc
+++ b/_posts/2019-08-15-quarkus-0-21-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.21.1 released'
 date: 2019-08-15
-tags: quarkus-release
+tags: release
 author: gsmet
 ---
 

--- a/_posts/2019-08-15-quarkus-0-21-1-released.adoc
+++ b/_posts/2019-08-15-quarkus-0-21-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.21.1 released'
 date: 2019-08-15
-tags: quarkus release
+tags: quarkus-release
 author: gsmet
 ---
 

--- a/_posts/2019-09-05-quarkus-0-21-2-released.adoc
+++ b/_posts/2019-09-05-quarkus-0-21-2-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.21.2 released'
 date: 2019-09-05
-tags: quarkus-release
+tags: release
 synopsis: We just released Quarkus 0.21.2 fixing several bugs and usability issues. Time to upgrade.
 author: gsmet
 ---

--- a/_posts/2019-09-05-quarkus-0-21-2-released.adoc
+++ b/_posts/2019-09-05-quarkus-0-21-2-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.21.2 released'
 date: 2019-09-05
-tags: quarkus release
+tags: quarkus-release
 synopsis: We just released Quarkus 0.21.2 fixing several bugs and usability issues. Time to upgrade.
 author: gsmet
 ---

--- a/_posts/2019-09-16-quarkus-0-22-0-released.adoc
+++ b/_posts/2019-09-16-quarkus-0-22-0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.22.0 released'
 date: 2019-09-16
-tags: quarkus release
+tags: quarkus-release
 synopsis: We just released Quarkus 0.22.0 with improved Spring API support.
 author: gsmet
 ---

--- a/_posts/2019-09-16-quarkus-0-22-0-released.adoc
+++ b/_posts/2019-09-16-quarkus-0-22-0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.22.0 released'
 date: 2019-09-16
-tags: quarkus-release
+tags: release
 synopsis: We just released Quarkus 0.22.0 with improved Spring API support.
 author: gsmet
 ---

--- a/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
+++ b/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: 'Quarkus developer joy for VS Code'
+tags: announcement vscode ide
 date: 2019-09-23
 synopsis: Showcasing the new Quarkus VS Code extension.
 author: dakwon

--- a/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
+++ b/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Quarkus developer joy for VS Code'
-tags: announcement vscode ide
+tags: announcement  ide
 date: 2019-09-23
 synopsis: Showcasing the new Quarkus VS Code extension.
 author: dakwon

--- a/_posts/2019-09-26-quarkus-0-23-1-released.adoc
+++ b/_posts/2019-09-26-quarkus-0-23-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.23.1 released - Paving the way to our new HTTP layer'
 date: 2019-09-26
-tags: quarkus-release
+tags: release
 synopsis: 0.23.1 had a regression, please use 0.23.2.
 author: gsmet
 ---

--- a/_posts/2019-09-26-quarkus-0-23-1-released.adoc
+++ b/_posts/2019-09-26-quarkus-0-23-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.23.1 released - Paving the way to our new HTTP layer'
 date: 2019-09-26
-tags: quarkus release
+tags: quarkus-release
 synopsis: 0.23.1 had a regression, please use 0.23.2.
 author: gsmet
 ---

--- a/_posts/2019-10-01-quarkus-newsletter-1.adoc
+++ b/_posts/2019-10-01-quarkus-newsletter-1.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus Newsletter #1'
 date: 2019-10-01
-tags: quarkus newsletter
+tags: newsletter
 synopsis: Latest online content in and around Quarkus.
 author: maxandersen
 bibquery: "pub.date <= '2019-10-01'"

--- a/_posts/2019-10-02-quarkus-0-23-2-released.adoc
+++ b/_posts/2019-10-02-quarkus-0-23-2-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.23.2 released - Back on track'
 date: 2019-10-02
-tags: quarkus-release
+tags: release
 synopsis: 0.23.2 fixes the memory usage increase observed in 0.23.
 author: gsmet
 ---

--- a/_posts/2019-10-02-quarkus-0-23-2-released.adoc
+++ b/_posts/2019-10-02-quarkus-0-23-2-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.23.2 released - Back on track'
 date: 2019-10-02
-tags: quarkus release
+tags: quarkus-release
 synopsis: 0.23.2 fixes the memory usage increase observed in 0.23.
 author: gsmet
 ---

--- a/_posts/2019-10-12-quarkus-0-24.0-released.adoc
+++ b/_posts/2019-10-12-quarkus-0-24.0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.24.0 released - Vert.x everywhere'
 date: 2019-10-12
-tags: quarkus release
+tags: quarkus-release
 synopsis: 0.24.0 relies on Eclipse Vert.x to serve your REST requests and introduces a new security layer.
 author: gsmet
 ---

--- a/_posts/2019-10-12-quarkus-0-24.0-released.adoc
+++ b/_posts/2019-10-12-quarkus-0-24.0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.24.0 released - Vert.x everywhere'
 date: 2019-10-12
-tags: quarkus-release
+tags: release
 synopsis: 0.24.0 relies on Eclipse Vert.x to serve your REST requests and introduces a new security layer.
 author: gsmet
 ---

--- a/_posts/2019-10-16-quarkus-0-25.0-released.adoc
+++ b/_posts/2019-10-16-quarkus-0-25.0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.25.0 released - Security layer updated'
 date: 2019-10-16
-tags: quarkus release
+tags: quarkus-release
 synopsis: We continue on our journey to rewrite the security layer.
 author: gsmet
 ---

--- a/_posts/2019-10-16-quarkus-0-25.0-released.adoc
+++ b/_posts/2019-10-16-quarkus-0-25.0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.25.0 released - Security layer updated'
 date: 2019-10-16
-tags: quarkus-release
+tags: release
 synopsis: We continue on our journey to rewrite the security layer.
 author: gsmet
 ---

--- a/_posts/2019-10-23-quarkus-0-26-1-released.adoc
+++ b/_posts/2019-10-23-quarkus-0-26-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.26.1 released - Stabilizing things and adding Vault support'
 date: 2019-10-23
-tags: quarkus-release
+tags: release
 synopsis: Quarkus 0.26.1 comes with bugfixes and doc improvements. It also adds an extension for Vault support.
 author: gsmet
 ---

--- a/_posts/2019-10-23-quarkus-0-26-1-released.adoc
+++ b/_posts/2019-10-23-quarkus-0-26-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.26.1 released - Stabilizing things and adding Vault support'
 date: 2019-10-23
-tags: quarkus release
+tags: quarkus-release
 synopsis: Quarkus 0.26.1 comes with bugfixes and doc improvements. It also adds an extension for Vault support.
 author: gsmet
 ---

--- a/_posts/2019-10-30-quarkus-0-27-0-released.adoc
+++ b/_posts/2019-10-30-quarkus-0-27-0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.27.0 released - More Amazon Lambda goodness'
 date: 2019-10-30
-tags: quarkus-release
+tags: release
 synopsis: More Amazon Lambda features, move to Jakarta, usability fixes, go find out what we baked for you.
 author: gsmet
 ---

--- a/_posts/2019-10-30-quarkus-0-27-0-released.adoc
+++ b/_posts/2019-10-30-quarkus-0-27-0-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.27.0 released - More Amazon Lambda goodness'
 date: 2019-10-30
-tags: quarkus release
+tags: quarkus-release
 synopsis: More Amazon Lambda features, move to Jakarta, usability fixes, go find out what we baked for you.
 author: gsmet
 ---

--- a/_posts/2019-10-31-vscode-quarkus-1.1.0.adoc
+++ b/_posts/2019-10-31-vscode-quarkus-1.1.0.adoc
@@ -4,7 +4,7 @@ title: 'Quarkus Tools for Visual Studio Code - 1.1.0 release'
 date: 2019-10-31
 synopsis: New features for Quarkus Tools for Visual Studio Code.
 author: dakwon
-tags: vscode ide
+tags:  ide
 ---
 :blank: pass:[ +] 
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.1.0

--- a/_posts/2019-10-31-vscode-quarkus-1.1.0.adoc
+++ b/_posts/2019-10-31-vscode-quarkus-1.1.0.adoc
@@ -4,6 +4,7 @@ title: 'Quarkus Tools for Visual Studio Code - 1.1.0 release'
 date: 2019-10-31
 synopsis: New features for Quarkus Tools for Visual Studio Code.
 author: dakwon
+tags: vscode ide
 ---
 :blank: pass:[ +] 
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.1.0

--- a/_posts/2019-11-04-quarkus-0-28-1-released.adoc
+++ b/_posts/2019-11-04-quarkus-0-28-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.28.1 released - Some more bugfixes, help us squash 404s'
 date: 2019-11-04
-tags: quarkus-release
+tags: release
 synopsis: 0.28.1 is a bugfix release. We also made some changes to the guides and quickstarts URLs.
 author: gsmet
 ---

--- a/_posts/2019-11-04-quarkus-0-28-1-released.adoc
+++ b/_posts/2019-11-04-quarkus-0-28-1-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 0.28.1 released - Some more bugfixes, help us squash 404s'
 date: 2019-11-04
-tags: quarkus release
+tags: quarkus-release
 synopsis: 0.28.1 is a bugfix release. We also made some changes to the guides and quickstarts URLs.
 author: gsmet
 ---

--- a/_posts/2019-11-06-announcing-quarkus-1-0.adoc
+++ b/_posts/2019-11-06-announcing-quarkus-1-0.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Announcing Quarkus 1.0'
 date: 2019-11-06
-tags: quarkus-release
+tags: announcement
 synopsis: Today marks a real milestone for the Quarkus community and the Java community at large. Quarkus 1.0 Candidate Release 1 is out and it will shortly be followed by a 1.0 Final version.
 author: ebernard
 ---

--- a/_posts/2019-11-06-announcing-quarkus-1-0.adoc
+++ b/_posts/2019-11-06-announcing-quarkus-1-0.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Announcing Quarkus 1.0'
 date: 2019-11-06
-tags: quarkus release
+tags: quarkus-release
 synopsis: Today marks a real milestone for the Quarkus community and the Java community at large. Quarkus 1.0 Candidate Release 1 is out and it will shortly be followed by a 1.0 Final version.
 author: ebernard
 ---

--- a/_posts/2019-11-06-gowithflow-chooses-quarkus-to-deliver-fast-to-production.adoc
+++ b/_posts/2019-11-06-gowithflow-chooses-quarkus-to-deliver-fast-to-production.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: GoWithFlow chooses Quarkus to deliver fast to production with minimal risk
 date: 2019-11-06
-tags: quarkus user story
+tags: quarkus user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/gowithflow

--- a/_posts/2019-11-06-gowithflow-chooses-quarkus-to-deliver-fast-to-production.adoc
+++ b/_posts/2019-11-06-gowithflow-chooses-quarkus-to-deliver-fast-to-production.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: GoWithFlow chooses Quarkus to deliver fast to production with minimal risk
 date: 2019-11-06
-tags: quarkus user-story
+tags: user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/gowithflow

--- a/_posts/2019-11-08-quarkus-for-spring-developers.adoc
+++ b/_posts/2019-11-08-quarkus-for-spring-developers.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus for Spring Developers
 date: 2019-11-12
-tags: quarkus spring microprofile
+tags: spring microprofile
 author: jclingan
 ---
 :imagesdir: /assets/images/posts/quarkus-for-spring-developers

--- a/_posts/2019-11-08-quarkus-for-spring-developers.adoc
+++ b/_posts/2019-11-08-quarkus-for-spring-developers.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus for Spring Developers
 date: 2019-11-12
-tags: spring microprofile
+tags: extension spring microprofile
 author: jclingan
 ---
 :imagesdir: /assets/images/posts/quarkus-for-spring-developers

--- a/_posts/2019-11-13-vodafone-greece-replaces-spring-boot.adoc
+++ b/_posts/2019-11-13-vodafone-greece-replaces-spring-boot.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Vodafone Greece replaces Spring Boot with Quarkus
 date: 2019-11-13
-tags: quarkus user story
+tags: quarkus user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/vodafonegreece

--- a/_posts/2019-11-13-vodafone-greece-replaces-spring-boot.adoc
+++ b/_posts/2019-11-13-vodafone-greece-replaces-spring-boot.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Vodafone Greece replaces Spring Boot with Quarkus
 date: 2019-11-13
-tags: quarkus user-story
+tags: user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/vodafonegreece

--- a/_posts/2019-11-18-quarkus-newsletter-2.adoc
+++ b/_posts/2019-11-18-quarkus-newsletter-2.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus Newsletter #2'
 date: 2019-11-18
-tags: quarkus newsletter
+tags: newsletter
 synopsis: Latest online content in and around Quarkus.
 author: maxandersen
 bibquery: ["pub.urldate >= '2019-10-01'", "pub.urldate <= '2019-11-19'"]

--- a/_posts/2019-11-20-quarkus-1-0-0-CR2-released.adoc
+++ b/_posts/2019-11-20-quarkus-1-0-0-CR2-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.0.0.CR2 released - Last stop before Final'
 date: 2019-11-20
-tags: quarkus release
+tags: quarkus-release
 synopsis: We just released Quarkus 1.0.0.CR2 which is our last candidate release before Final. We plan to release Final on Monday 25th.
 author: gsmet
 ---

--- a/_posts/2019-11-20-quarkus-1-0-0-CR2-released.adoc
+++ b/_posts/2019-11-20-quarkus-1-0-0-CR2-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.0.0.CR2 released - Last stop before Final'
 date: 2019-11-20
-tags: quarkus-release
+tags: release
 synopsis: We just released Quarkus 1.0.0.CR2 which is our last candidate release before Final. We plan to release Final on Monday 25th.
 author: gsmet
 ---

--- a/_posts/2019-11-21-vscode-quarkus-1.2.0.adoc
+++ b/_posts/2019-11-21-vscode-quarkus-1.2.0.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus Tools for Visual Studio Code - 1.2.0 release'
 date: 2019-11-21
-tags: ide vscode
+tags: ide 
 author: dakwon
 ---
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.2.0

--- a/_posts/2019-11-21-vscode-quarkus-1.2.0.adoc
+++ b/_posts/2019-11-21-vscode-quarkus-1.2.0.adoc
@@ -2,6 +2,7 @@
 layout: post
 title: 'Quarkus Tools for Visual Studio Code - 1.2.0 release'
 date: 2019-11-21
+tags: ide vscode
 author: dakwon
 ---
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.2.0

--- a/_posts/2019-11-25-quarkus-1-0-0-Final-bits-are-here.adoc
+++ b/_posts/2019-11-25-quarkus-1-0-0-Final-bits-are-here.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.0.0.Final bits are here'
 date: 2019-11-25
-tags: quarkus release
+tags: quarkus-release
 synopsis: After two release candidates, we are happy to announce that Quarkus 1.0.0.Final has been released.
 author: gsmet
 ---

--- a/_posts/2019-11-25-quarkus-1-0-0-Final-bits-are-here.adoc
+++ b/_posts/2019-11-25-quarkus-1-0-0-Final-bits-are-here.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.0.0.Final bits are here'
 date: 2019-11-25
-tags: quarkus-release
+tags: release
 synopsis: After two release candidates, we are happy to announce that Quarkus 1.0.0.Final has been released.
 author: gsmet
 ---

--- a/_posts/2019-11-28-quarkus-1-0-1-final-released.adoc
+++ b/_posts/2019-11-28-quarkus-1-0-1-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.0.1.Final released - Important security fix'
 date: 2019-11-28
-tags: quarkus-release
+tags: release
 synopsis: 1.0.1.Final fixes an important security issue. Upgrade highly recommended.
 author: gsmet
 ---

--- a/_posts/2019-11-28-quarkus-1-0-1-final-released.adoc
+++ b/_posts/2019-11-28-quarkus-1-0-1-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.0.1.Final released - Important security fix'
 date: 2019-11-28
-tags: quarkus release
+tags: quarkus-release
 synopsis: 1.0.1.Final fixes an important security issue. Upgrade highly recommended.
 author: gsmet
 ---

--- a/_posts/2019-12-11-talkdesk-chooses-quarkus-for-fast-innovation.adoc
+++ b/_posts/2019-12-11-talkdesk-chooses-quarkus-for-fast-innovation.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: For fast innovation and to stay ahead of the competition, Talkdesk chooses Quarkus
 date: 2019-12-11 00:00:00.000 -0600
-tags: quarkus user story
+tags: quarkus user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/talkdesk

--- a/_posts/2019-12-11-talkdesk-chooses-quarkus-for-fast-innovation.adoc
+++ b/_posts/2019-12-11-talkdesk-chooses-quarkus-for-fast-innovation.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: For fast innovation and to stay ahead of the competition, Talkdesk chooses Quarkus
 date: 2019-12-11 00:00:00.000 -0600
-tags: quarkus user-story
+tags: user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/talkdesk

--- a/_posts/2019-12-16-quarkus-newsletter-3.adoc
+++ b/_posts/2019-12-16-quarkus-newsletter-3.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus Newsletter #3'
 date: 2019-12-16
-tags: quarkus newsletter
+tags: newsletter
 synopsis: Latest online content in and around Quarkus.
 author: maxandersen
 bibquery: ["pub.urldate >= '2019-11-20'", "pub.urldate <= '2019-12-16'"]

--- a/_posts/2019-12-18-why-graalvm-19-2.adoc
+++ b/_posts/2019-12-18-why-graalvm-19-2.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Delay in GraalVM 19.3 support - planned for Quarkus 1.2 - here is why'
 date: 2019-12-18
-tags: 
+tags: announcement graalvm
 synopsis: For Quarkus 1.1.0.Final, we had to take the hard decision to go back to GraalVM 19.2 while our CR1 used 19.3. Here is why.
 author: ebernard
 ---

--- a/_posts/2019-12-18-why-graalvm-19-2.adoc
+++ b/_posts/2019-12-18-why-graalvm-19-2.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Delay in GraalVM 19.3 support - planned for Quarkus 1.2 - here is why'
 date: 2019-12-18
-tags: quarkus
+tags: 
 synopsis: For Quarkus 1.1.0.Final, we had to take the hard decision to go back to GraalVM 19.2 while our CR1 used 19.3. Here is why.
 author: ebernard
 ---

--- a/_posts/2019-12-23-quarkus-1-1-0-final-released.adoc
+++ b/_posts/2019-12-23-quarkus-1-1-0-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.1.0.Final released - Template engine, YAML configuration, and more'
 date: 2019-12-23
-tags: quarkus release
+tags: quarkus-release
 synopsis: Template engine, YAML configuration, Gradle improvements... learn more about what we have baked for you in 1.1.
 author: gsmet
 ---

--- a/_posts/2019-12-23-quarkus-1-1-0-final-released.adoc
+++ b/_posts/2019-12-23-quarkus-1-1-0-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.1.0.Final released - Template engine, YAML configuration, and more'
 date: 2019-12-23
-tags: quarkus-release
+tags: release
 synopsis: Template engine, YAML configuration, Gradle improvements... learn more about what we have baked for you in 1.1.
 author: gsmet
 ---

--- a/_posts/2020-01-07-quarkus-1-1-1-final-released.adoc
+++ b/_posts/2020-01-07-quarkus-1-1-1-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.1.1.Final released - Bugfixes only'
 date: 2020-01-07
-tags: quarkus release
+tags: quarkus-release
 synopsis: 1.1.1.Final fixes several issues mostly in our Kotlin and Gradle support.
 author: gsmet
 ---

--- a/_posts/2020-01-07-quarkus-1-1-1-final-released.adoc
+++ b/_posts/2020-01-07-quarkus-1-1-1-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.1.1.Final released - Bugfixes only'
 date: 2020-01-07
-tags: quarkus-release
+tags: release
 synopsis: 1.1.1.Final fixes several issues mostly in our Kotlin and Gradle support.
 author: gsmet
 ---

--- a/_posts/2020-01-14-quarkus-newsletter-4.adoc
+++ b/_posts/2020-01-14-quarkus-newsletter-4.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus Newsletter #4'
 date: 2020-01-14
-tags: quarkus newsletter
+tags: newsletter
 synopsis: Latest online content in and around Quarkus.
 author: maxandersen
 bibquery: ["pub.urldate >= '2019-12-17'", "pub.urldate <= '2020-01-14'"]

--- a/_posts/2020-01-20-sentry-the-guardian-of-your-quarkus-app.adoc
+++ b/_posts/2020-01-20-sentry-the-guardian-of-your-quarkus-app.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Sentry Error Tracker - A guardian of your Quarkus application'
 date: 2020-01-20
-tags: tracing sentry
+tags: extension sentry tracing
 author: adamevin
 ---
 

--- a/_posts/2020-01-20-sentry-the-guardian-of-your-quarkus-app.adoc
+++ b/_posts/2020-01-20-sentry-the-guardian-of-your-quarkus-app.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Sentry Error Tracker - A guardian of your Quarkus application'
 date: 2020-01-20
-tags: extension logging cloud error
+tags: tracing sentry
 author: adamevin
 ---
 

--- a/_posts/2020-01-20-sentry-the-guardian-of-your-quarkus-app.adoc
+++ b/_posts/2020-01-20-sentry-the-guardian-of-your-quarkus-app.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Sentry Error Tracker - A guardian of your Quarkus application'
 date: 2020-01-20
-tags: quarkus extension logging cloud error
+tags: extension logging cloud error
 author: adamevin
 ---
 

--- a/_posts/2020-01-21-march-of-ides.adoc
+++ b/_posts/2020-01-21-march-of-ides.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus support in IDE's
 date: 2020-01-21
-tags: development-tips ide vscode che eclipse intellij
+tags: development-tips ide    
 synopsis: An overview on currently available IDE integrations for Quarkus.
 author: maxandersen
 ---

--- a/_posts/2020-01-21-march-of-ides.adoc
+++ b/_posts/2020-01-21-march-of-ides.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus support in IDE's
 date: 2020-01-21
-tags: quarkus vscode che eclipse intellij
+tags: vscode che eclipse intellij
 synopsis: An overview on currently available IDE integrations for Quarkus.
 author: maxandersen
 ---

--- a/_posts/2020-01-21-march-of-ides.adoc
+++ b/_posts/2020-01-21-march-of-ides.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus support in IDE's
 date: 2020-01-21
-tags: vscode che eclipse intellij
+tags: development-tips ide vscode che eclipse intellij
 synopsis: An overview on currently available IDE integrations for Quarkus.
 author: maxandersen
 ---

--- a/_posts/2020-01-21-quarkus-eclipse-microprofile-3-2-compatible.adoc
+++ b/_posts/2020-01-21-quarkus-eclipse-microprofile-3-2-compatible.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus is Eclipse MicroProfile 3.2 compatible!
 date: 2020-01-21
-tags: microprofile
+tags: announcement microprofile
 author: kenfinnigan
 ---
 

--- a/_posts/2020-01-21-quarkus-eclipse-microprofile-3-2-compatible.adoc
+++ b/_posts/2020-01-21-quarkus-eclipse-microprofile-3-2-compatible.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus is Eclipse MicroProfile 3.2 compatible!
 date: 2020-01-21
-tags: quarkus microprofile
+tags: microprofile
 author: kenfinnigan
 ---
 

--- a/_posts/2020-01-23-quarkus-fault-tolerance-4-0.adoc
+++ b/_posts/2020-01-23-quarkus-fault-tolerance-4-0.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'New fault tolerance implementation in Quarkus'
 date: 2020-01-23
-tags: smallrye fault-tolerance
+tags: extension smallrye fault-tolerance
 author: michalszynkiewicz
 ---
 

--- a/_posts/2020-01-23-quarkus-fault-tolerance-4-0.adoc
+++ b/_posts/2020-01-23-quarkus-fault-tolerance-4-0.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'New fault tolerance implementation in Quarkus'
 date: 2020-01-23
-tags: quarkus smallrye fault-tolerance
+tags: smallrye fault-tolerance
 author: michalszynkiewicz
 ---
 

--- a/_posts/2020-01-24-quarkus-wins-devies-award.adoc
+++ b/_posts/2020-01-24-quarkus-wins-devies-award.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus wins DEVIES award
 date: 2020-01-24
-tags: awards
+tags: announcement awards
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/awards

--- a/_posts/2020-01-24-quarkus-wins-devies-award.adoc
+++ b/_posts/2020-01-24-quarkus-wins-devies-award.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Quarkus wins DEVIES award
 date: 2020-01-24
-tags: quarkus awards
+tags: awards
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/awards

--- a/_posts/2020-01-28-quarkus-1-2-0-final-released.adoc
+++ b/_posts/2020-01-28-quarkus-1-2-0-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.2.0.Final released - GraalVM 19.3.1 support, Metrics, Cache extension, and more'
 date: 2020-01-28
-tags: quarkus-release
+tags: release
 synopsis: GraalVM 19.3.1 support, Metrics, a brand new Cache extension, Vault Transit Secret engine, Quarkus 1.2.0.Final is here packed with new features.
 author: gsmet
 ---

--- a/_posts/2020-01-28-quarkus-1-2-0-final-released.adoc
+++ b/_posts/2020-01-28-quarkus-1-2-0-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.2.0.Final released - GraalVM 19.3.1 support, Metrics, Cache extension, and more'
 date: 2020-01-28
-tags: quarkus release
+tags: quarkus-release
 synopsis: GraalVM 19.3.1 support, Metrics, a brand new Cache extension, Vault Transit Secret engine, Quarkus 1.2.0.Final is here packed with new features.
 author: gsmet
 ---

--- a/_posts/2020-01-28-vscode-quarkus-1.3.0.adoc
+++ b/_posts/2020-01-28-vscode-quarkus-1.3.0.adoc
@@ -3,7 +3,7 @@ layout: post
 title: 'Introducing 10 new features in Quarkus Tools for Visual Studio Code 1.3.0'
 date: 2020-02-07
 author: dakwon
-tags: ide vscode
+tags: ide 
 ---
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.3.0
 :star: *

--- a/_posts/2020-01-28-vscode-quarkus-1.3.0.adoc
+++ b/_posts/2020-01-28-vscode-quarkus-1.3.0.adoc
@@ -3,6 +3,7 @@ layout: post
 title: 'Introducing 10 new features in Quarkus Tools for Visual Studio Code 1.3.0'
 date: 2020-02-07
 author: dakwon
+tags: ide vscode
 ---
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.3.0
 :star: *

--- a/_posts/2020-02-10-asiakastieto-chooses-quarkus-for-microservices.adoc
+++ b/_posts/2020-02-10-asiakastieto-chooses-quarkus-for-microservices.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Suomen Asiakastieto Oy chooses Quarkus for their microservices development
 date: 2020-02-10
-tags: quarkus user-story
+tags: user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/asiakastieto

--- a/_posts/2020-02-10-asiakastieto-chooses-quarkus-for-microservices.adoc
+++ b/_posts/2020-02-10-asiakastieto-chooses-quarkus-for-microservices.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Suomen Asiakastieto Oy chooses Quarkus for their microservices development
 date: 2020-02-10
-tags: quarkus user story
+tags: quarkus user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/asiakastieto

--- a/_posts/2020-02-17-aviatar-experiences-significant-savings.adoc
+++ b/_posts/2020-02-17-aviatar-experiences-significant-savings.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Lufthansa Technik AVIATAR experiences significant cloud resources savings by moving to Kubernetes-native Quarkus
 date: 2020-02-17
-tags: quarkus user-story
+tags: user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/lufthansatechnik

--- a/_posts/2020-02-17-aviatar-experiences-significant-savings.adoc
+++ b/_posts/2020-02-17-aviatar-experiences-significant-savings.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Lufthansa Technik AVIATAR experiences significant cloud resources savings by moving to Kubernetes-native Quarkus
 date: 2020-02-17
-tags: quarkus user story
+tags: quarkus user-story
 author: cesarsaavedra
 ---
 :imagesdir: /assets/images/posts/quarkus-user-stories/lufthansatechnik

--- a/_posts/2020-02-19-quarkus-1-2-1-final-released.adoc
+++ b/_posts/2020-02-19-quarkus-1-2-1-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.2.1.Final released - Bugfixes only'
 date: 2020-02-19
-tags: quarkus-release
+tags: release
 synopsis: 1.2.1.Final fixes several issues in Quarkus and the documentation.
 author: gsmet
 ---

--- a/_posts/2020-02-19-quarkus-1-2-1-final-released.adoc
+++ b/_posts/2020-02-19-quarkus-1-2-1-final-released.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus 1.2.1.Final released - Bugfixes only'
 date: 2020-02-19
-tags: quarkus release
+tags: quarkus-release
 synopsis: 1.2.1.Final fixes several issues in Quarkus and the documentation.
 author: gsmet
 ---


### PR DESCRIPTION
Here is the basic mechanics to create archive of tags.

uses jekyll-archives so can be used to archive anything but it of course slows down rendering of the site so for now just enabled for tags.

here is a screenshot of how it currently looks like:
![2020-02-21_15-53-55](https://user-images.githubusercontent.com/54129/75049672-83368b80-54c2-11ea-8e64-05fb162901d9.png)

gives you an idea, but need some ux TLC :)
