### PR TITLE
Fix newsletter #5 typo

### DIFF
--- a/_data/publications.yaml
+++ b/_data/publications.yaml
@@ -901,7 +901,7 @@
   author: "Loic Mathieu"
   url: "https://www.loicmathieu.fr/wordpress/en/informatique/quarkus-et-testcontainers/"
   urldate: "2020-02-24"
-  notes: "Loic walks through how to use TestContainers with Quarkus."
+  note: "Loic walks through how to use TestContainers with Quarkus."
 
 - id: QuarkusANewAgeofModernJavaFrameworksisHere4Comprehension-2020-02-23
   type: article 


### PR DESCRIPTION
An HTML line break is being displayed in the newsletter but the note content is missing.

See https://quarkus.io/blog/quarkus-newsletter-5/