### PR TITLE
Update JMS guide link text and description

### DIFF
--- a/_data/guides.yaml
+++ b/_data/guides.yaml
@@ -141,9 +141,9 @@ categories:
       - title: Asynchronous Message Passing
         url: /guides/reactive-messaging
         description: This guide explains how different beans can interact using asynchronous messages.  
-      - title: Using JMS with Artemis
+      - title: Using JMS
         url: /guides/jms
-        description: This guide demonstrates how your Quarkus application can use Artemis JMS messaging.
+        description: This guide demonstrates how your Quarkus application can use JMS messaging with AMQP 1.0 using Apache Qpid JMS, or using Apache ActiveMQ Artemis JMS.
         
   - category: Security
     cat-id: security


### PR DESCRIPTION
https://github.com/quarkusio/quarkus-platform/pull/28 adds the Qpid JMS client extension to the platform for 1.3.0 and https://github.com/quarkusio/quarkus/pull/7538 updates the JMS guide to use it and Artemis JMS.
 
When the site is updated for 1.3.0 the link+details on https://quarkus.io/guides/ will need tweaked accordingly, which this PR aims to address.

Presumably it sits open until then, I just wanted to have it ready for when the time comes.