### PR TITLE
Round 2 of tag archive page/navigation

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -14,7 +14,9 @@ layout: base
     {% for post in paginator.posts %}
       {% assign author = site.data.authors[post.author] %}
       <div class="blog-list-item grid-wrapper">
-        <div class="post-date grid__item width-12-12">{{ post.date | date: '%B %d, %Y' }}</div>
+        <div class="post-date grid__item width-12-12">{{ post.date | date: '%B %d, %Y' }} 
+          {% for tag in post.tags %}<a href="{{site.baseurl}}/blog/tag/{{tag}}">#{{ tag}}</a> {% endfor %}
+        </div>
         <div class="post-title grid__item width-12-12">
           <a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a>
         </div>
@@ -47,5 +49,11 @@ layout: base
       {% endif %}
   </div>
   
-  <div class="grid__item width-2-12"></div>
+  <div class="grid__item width-2-12">
+    {% for stats in site.tags %}
+     {% assign tag = stats | first %}
+     {% assign posts = stats | last %}
+     <a href="{{site.baseurl}}/blog/tag/{{tag}}">{{ tag }}</a></br>
+    {% endfor %}
+  </div>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,10 @@ layout: base
 
 <div class="post-page grid-wrapper">
   <div class="grid__item width-10-12 width-12-12-m doc-content">
-    <div class="post-date">{{ page.date | date: '%B %d, %Y' }}</div>
+    <p> < <a href="{{site.baseurl}}/blog">Back to all posts</a></p>
+    <div class="post-date">{{ page.date | date: '%B %d, %Y' }}
+      {% for tag in page.tags %}<a href="{{site.baseurl}}/blog/tag/{{tag}}">#{{ tag}}</a> {% endfor %}
+    </div>
     <h1>{{ page.title }}</h1>
     <div class="grid-wrapper">
       <div class="grid__item width-8-12 width-12-12-m byline-wrapper">

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -2,12 +2,33 @@
 layout: base
 ---
 
-<h1>Posts with {{ page.type }} '{{ page.title }}'</h1>
+<div class="grid-wrapper">
+  <div class="grid__item width-10-12">
+    <h1 class="title text-caps">Tagged posts: '{{ page.title }}'</h1>
+  </div>
+  <div class="grid__item width-2-12 align-self-center">
+    <a href="{{site.baseurl}}/feed.xml"><i class="fas fa-rss-square"></i></a>
+  </div>
+
+<div class="grid__item width-10-12 width-12-12-m">
 <ul class="posts">
   {% for post in page.posts %}
     <li>
       <span class="post-date">{{ post.date | date: '%B %d, %Y' }}</span>
-      <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+      <div>
+        <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+      </div>
     </li>
   {% endfor %}
 </ul>
+</div>
+
+<div class="grid__item width-2-12">
+  {% for stats in site.tags %}
+   {% assign tag = stats | first %}
+   {% assign posts = stats | last %}
+   <a href="{{site.baseurl}}/blog/tag/{{tag}}">{{ tag }}</a></br>
+  {% endfor %}
+</div>
+</div>
+

--- a/_posts/2020-01-14-quarkus-newsletter-5.adoc
+++ b/_posts/2020-01-14-quarkus-newsletter-5.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus Newsletter #5'
 date: 2020-02-26
-tags: quarkus newsletter
+tags: newsletter
 synopsis: Latest online content in and around Quarkus.
 author: maxandersen
 bibquery: ["pub.urldate >= '2020-01-15'", "pub.urldate <= '2020-02-26'"]

--- a/blog.md
+++ b/blog.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "Quarkus - Blog"
+title: "Blog"
 permalink: /blog/
 pagination: 
   enabled: true

--- a/community.md
+++ b/community.md
@@ -1,5 +1,5 @@
 ---
 layout: community
-title: Quarkus - Community
+title: Community
 permalink: /community/
 ---

--- a/extensions.md
+++ b/extensions.md
@@ -1,5 +1,5 @@
 ---
 layout: extensions
-title: Quarkus - Extensions
+title: Extensions
 permalink: /extensions/
 ---


### PR DESCRIPTION
Based on @insectengine proposal (with a few cleanups based on how current format/layout is)

![2020-03-09_22-06-43](https://user-images.githubusercontent.com/54129/76257591-44d6f580-6252-11ea-959f-32ed4fab2904.png)

![2020-03-09_22-07-00](https://user-images.githubusercontent.com/54129/76257619-51f3e480-6252-11ea-8a99-faac8d75ce3e.png)

![2020-03-09_22-07-26](https://user-images.githubusercontent.com/54129/76257699-7b147500-6252-11ea-99b3-3dbc0788b72d.png)

