### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To write a blog:
   - `extension` used for blogs related to a specific extension.
   - `user-story` used for stories from users/companies adopting Quarkus.
   - `development-tips` used for blogs with tips to develop using Quarkus or Quarkus itself. 
-  - add a tech specific, like `kafka`, if your post has a signficant mention/relevance to that technology.
+  - add a tech specific, like `kafka`, if your post has a significant mention/relevance to that technology.
 - it's in asciidoc format, there is an example as shown with [2019-06-05-quarkus-and-web-ui-development-mode.adoc](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc)
 - send a pull request against the develop branch and voilà
 

--- a/_config.yml
+++ b/_config.yml
@@ -112,7 +112,7 @@ pagination:
   # Optional, defines the field that the posts should be sorted on (omit to default to 'date')
   sort_field: 'date'
 
-  # Optional, sorts the posts in reverse order (omit to default decending or sort_reverse: true)
+  # Optional, sorts the posts in reverse order (omit to default descending or sort_reverse: true)
   sort_reverse: true
 
   # Optional, the default category to use, omit or just leave this as 'posts' to get a backwards-compatible behavior (all posts)

--- a/_generated-config/config/quarkus-s2i-s2i-config.adoc
+++ b/_generated-config/config/quarkus-s2i-s2i-config.adoc
@@ -48,7 +48,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-s2i-s2i-config_quarkus.s2i.jar-
 
 [.description]
 --
-The directory where the jar is added during the assemble phase. This is dependant on the s2i image and should be supplied if a non default image is used.
+The directory where the jar is added during the assemble phase. This is dependent on the s2i image and should be supplied if a non default image is used.
 --|string 
 |`/deployments/`
 
@@ -66,7 +66,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-s2i-s2i-config_quarkus.s2i.nati
 
 [.description]
 --
-The directory where the native binary is added during the assemble phase. This is dependant on the s2i image and should be supplied if a non-default image is used.
+The directory where the native binary is added during the assemble phase. This is dependent on the s2i image and should be supplied if a non-default image is used.
 --|string 
 |`/home/quarkus/`
 

--- a/_guides/amazon-lambda.adoc
+++ b/_guides/amazon-lambda.adoc
@@ -489,7 +489,7 @@ This is explicitly set in `manage.sh` `cmd_create()`. Whilst the native image po
 == Using HTTPS or SSL/TLS
 
 If your code makes HTTPS calls, such as to a micro-service (or AWS service), you will need to add configuration to the native image,
-as GraalVM will only include the dependencies when explictly declared.  Quarkus, by default enables this functionality on extensions that implicitly require it.
+as GraalVM will only include the dependencies when explicitly declared.  Quarkus, by default enables this functionality on extensions that implicitly require it.
 For further information, please consult the link:native-and-ssl[Quarkus SSL guide]
 
 Open src/main/resources/application.properties and add the following line to enable SSL in your native image.

--- a/_guides/building-my-first-extension.adoc
+++ b/_guides/building-my-first-extension.adoc
@@ -61,7 +61,7 @@ Usually, Java frameworks do their bootstrapping during the runtime before actual
 * Having a peak of resource consumption at bootstrap: in a constrained environment, you will need to size the needed resources based on your technical bootstrap needs rather than your actual business needs.
 
 Quarkus' philosophy is to prevent as much as possible slow and memory intensive dynamic code execution by shifting left these actions and eventually do them during the build time.
-A Quarkus extension is a Java piece of code acting as an adapter layer for your favorite libary or technology.
+A Quarkus extension is a Java piece of code acting as an adapter layer for your favorite library or technology.
 
 == Description of a Quarkus extension
 
@@ -793,7 +793,7 @@ That's why there is the Quarkus Platform.
 
 *Quarkus Platform*
 
-Quarkus proposes a `quarkus-universe-bom` which is a certified list of extensions placed under the Quarkus Platform label. From an application developper, the objectives of the platform are:
+Quarkus proposes a `quarkus-universe-bom` which is a certified list of extensions placed under the Quarkus Platform label. From an application developer, the objectives of the platform are:
 
 * To guarantee a supportability of the extension (bugfix, security issues, dependency upgrades)
 * To ease the extension discovery through the Quarkus CLI or https://code.quarkus.io/

--- a/_guides/kafka-streams.adoc
+++ b/_guides/kafka-streams.adoc
@@ -582,7 +582,7 @@ kafkacat -b kafka:9092 -C -o beginning -q -t temperatures-aggregated
 ----
 
 You should see new values arrive as the producer continues to emit temperature measurements,
-each value on the outbound topic showing the mininum, maxium and average temperature values of the represented weather station.
+each value on the outbound topic showing the minimum, maximum and average temperature values of the represented weather station.
 
 == Interactive Queries
 

--- a/_guides/maven-tooling.adoc
+++ b/_guides/maven-tooling.adoc
@@ -464,7 +464,7 @@ Quarkus Maven plugin supports the generation of Uber-Jars by specifying a `quark
 The original jar will still be present in the `target` directory but it will be renamed to contain the `.original` suffix.
 
 When building an Uber-Jar you can specify entries that you want to exclude from the generated jar by using the `quarkus.package.ignored-entries` configuration
-option, this takes a comma seperated list of entries to ignore.
+option, this takes a comma separated list of entries to ignore.
 
 Uber-Jar creation by default excludes link:https://docs.oracle.com/javase/tutorial/deployment/jar/intro.html[signature files] that might be present in the dependencies of the application.
 

--- a/_guides/microprofile-fault-tolerance.adoc
+++ b/_guides/microprofile-fault-tolerance.adoc
@@ -391,7 +391,7 @@ public class CoffeeRepositoryService {
 }
 ----
 
-And inject the code bellow into the `CoffeeResource` endpoint:
+And inject the code below into the `CoffeeResource` endpoint:
 
 [source,java]
 ----

--- a/_guides/neo4j.adoc
+++ b/_guides/neo4j.adoc
@@ -18,7 +18,7 @@ Cypher is used to for both querying the graph and creating or updating nodes and
 As a declarative language it used to tell the database what to do and not how to do it.
 
 NOTE: Learn more about Cypher in the https://neo4j.com/docs/cypher-manual/current/[Neo4j Cypher manual].
-      Cypher is not only availabe in Neo4j, but for example coming to https://github.com/opencypher/morpheus[Apache Spark].
+      Cypher is not only available in Neo4j, but for example coming to https://github.com/opencypher/morpheus[Apache Spark].
       A spec called http://www.opencypher.org[OpenCypher] is available, too.
 
 Clients communicate over the so called Bolt protocol with the database.

--- a/_guides/qute-reference.adoc
+++ b/_guides/qute-reference.adoc
@@ -184,7 +184,7 @@ A typical example is the for/each loop - during iteration the content of the sec
 [TIP]
 ====
 Data passed to the template instance are always accessible using the `data` namespace. 
-This could be useful to access data for which the key is overriden:  
+This could be useful to access data for which the key is overridden:  
 
 [source,html]
 ----
@@ -542,8 +542,8 @@ These sections can be used to include another template and possibly override som
 </body>
 </html>
 ----
-<1> `insert` sections are used to specify parts that could be overriden by a template that includes the given template.
-<2> An `insert` section may define the default content that is rendered if not overriden.
+<1> `insert` sections are used to specify parts that could be overridden by a template that includes the given template.
+<2> An `insert` section may define the default content that is rendered if not overridden.
 
 .Template "detail"
 [source,html]
@@ -558,7 +558,7 @@ These sections can be used to include another template and possibly override som
 {/include}
 ----
 <1> `include` section is used to specify the extended template.
-<2> Nested blocks are used to specify the parts that should be overriden.
+<2> Nested blocks are used to specify the parts that should be overridden.
 
 NOTE: Section blocks can also define an optional end tag - `{/title}`.
 

--- a/_guides/reactive-sql-clients.adoc
+++ b/_guides/reactive-sql-clients.adoc
@@ -503,10 +503,10 @@ public static Uni<Void> insertTwoFruits(PgPool client, Fruit fruit1, Fruit fruit
 }
 ----
 
-In this example, the two insertions are not dependant on each other and are executed concurrently (but in the same transaction).
+In this example, the two insertions are not dependent on each other and are executed concurrently (but in the same transaction).
 This transaction is committed on success and rolled back on failure.
 
-You can also create dependant actions as follows:
+You can also create dependent actions as follows:
 
 [source, java]
 ----

--- a/_guides/security-jdbc.adoc
+++ b/_guides/security-jdbc.adoc
@@ -204,7 +204,7 @@ quarkus.security.jdbc.principal-query.attribute-mappings.0.index=2 <3>
 quarkus.security.jdbc.principal-query.attribute-mappings.0.to=groups
 ----
 
-The `elytron-security-jdbc` extension requires at least one principal query to autenticate the user and its identity.
+The `elytron-security-jdbc` extension requires at least one principal query to authenticate the user and its identity.
 
 <1> We define a parameterized SQL statement (with exactly 1 parameter) which should return the user's password plus any additional information you want to load.
 <2> We  configure the password mapper with the position of the password field in the `SELECT` fields and other information like salt, hash encoding, etc.

--- a/_guides/security-jwt.adoc
+++ b/_guides/security-jwt.adoc
@@ -316,7 +316,7 @@ nQIDAQAB
 
 === Generating a JWT
 
-Often one obtains a JWT from an identity manager like https://www.keycloak.org/[Keycloak], but for this quickstart we will generate our own using the JWT generation API provided by `smallrye-jwt` (see <<generate-jwt-tokens, Generate JWT tokens with SmallRye JWT>> for more infomation) and the TokenUtils class shown in the following listing. Take this source and place it into `security-jwt-quickstart/src/test/java/org/acme/security/jwt/TokenUtils.java`.
+Often one obtains a JWT from an identity manager like https://www.keycloak.org/[Keycloak], but for this quickstart we will generate our own using the JWT generation API provided by `smallrye-jwt` (see <<generate-jwt-tokens, Generate JWT tokens with SmallRye JWT>> for more information) and the TokenUtils class shown in the following listing. Take this source and place it into `security-jwt-quickstart/src/test/java/org/acme/security/jwt/TokenUtils.java`.
 
 
 .JWT utility class

--- a/_guides/security-oauth2.adoc
+++ b/_guides/security-oauth2.adoc
@@ -12,7 +12,7 @@ include::./attributes.adoc[]
 This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the JAX-RS endpoints.
 
 OAuth2 is an authorization framework that enables applications to obtain access to an HTTP resource on behalf of a user. 
-It can be used to implement an application authentication mechanism based on tokens by delegating to an external server (the authentication server) the user authentification and providing a token for the authentication context.
+It can be used to implement an application authentication mechanism based on tokens by delegating to an external server (the authentication server) the user authentication and providing a token for the authentication context.
 
 If your OAuth2 Authentication server provides JWT tokens, you should use link:security-jwt[MicroProfile JWT RBAC] instead, this extension aims to be used with opaque tokens and validate the token by calling an introspection endpoint.
 

--- a/_guides/security-openid-connect.adoc
+++ b/_guides/security-openid-connect.adoc
@@ -254,7 +254,7 @@ Then run it:
 java -jar ./target/security-openid-connect-quickstart-runner.jar
 ----
 
-=== Runing in Native Mode
+=== Running in Native Mode
 
 This same demo can be compiled into native code: no modifications required.
 


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 1 typo in `README.md`
- 1 typo in `_config.yml`
- 2 typos in `_generated-config/config/quarkus-s2i-s2i-config.adoc`
- 1 typo in `_guides/amazon-lambda.adoc`
- 2 typos in `_guides/building-my-first-extension.adoc`
- 1 typo in `_guides/kafka-streams.adoc`
- 1 typo in `_guides/maven-tooling.adoc`
- 1 typo in `_guides/microprofile-fault-tolerance.adoc`
- 1 typo in `_guides/neo4j.adoc`
- 4 typos in `_guides/qute-reference.adoc`
- 2 typos in `_guides/reactive-sql-clients.adoc`
- 1 typo in `_guides/security-jdbc.adoc`
- 1 typo in `_guides/security-jwt.adoc`
- 1 typo in `_guides/security-oauth2.adoc`
- 1 typo in `_guides/security-openid-connect.adoc`



Best! :robot: