### PR TITLE
Fixed path for xattr command

### DIFF
--- a/_guides/building-native-image.adoc
+++ b/_guides/building-native-image.adoc
@@ -119,7 +119,7 @@ Use the following command to recursively delete the `com.apple.quarantine` exten
 
 [source,shell]
 -----
-xattr -r -d com.apple.quarantine $HOME/Development/graalvm/
+xattr -r -d com.apple.quarantine $GRAALVM_HOME
 -----
 ====
 


### PR DESCRIPTION
The Mac workaround assumes GraalVM is installed in `$HOME/Development/graalvm/`/ Fixed to use the $GRAALVM_HOME variable.