### PR TITLE
add a border to all code blocks, even those without hightlightjs

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -301,11 +301,12 @@ pre {
  padding: 0;
 }
 
-pre.highlight {
+pre.highlight, .literalblock pre, .listingblock > .content > pre {
  border: 1px solid $quarkus-blue;
  padding: 1rem;
  line-height: 1.2em;
  overflow-x: auto;
+ color: #EFEFEF;
 }
 
 pre > code,


### PR DESCRIPTION
The code blocks that don't receive highlightjs miss a border and don't use standard white font color like for example shell script.

Example: https://quarkus.io/guides/vault-datasource

AsciiDoc (note the missing `[source]`): 
```
----
mvn quarkus:add-extension -Dextensions="io.quarkus:quarkus-hibernate-orm,io.quarkus:quarkus-jdbc-postgresql"
----
```

Rendered in browser before change: 

![image](https://user-images.githubusercontent.com/3957921/85884930-b9bf4280-b7e3-11ea-99b0-b275d587db3b.png)

Rendered in browser after change:

![image](https://user-images.githubusercontent.com/3957921/85885000-df4c4c00-b7e3-11ea-92d5-883d38e2a74f.png)


