### PR TITLE
Quarkus Cassandra Extension released blog

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -230,3 +230,10 @@ cescoffier:
   job_title: ""
   twitter: "clementplop"
   bio: "Do reactive stuff @ Red Hat"  
+csplinter:
+  name: "Chris Splinter"
+  email: "chris.splinter@datastax.com"
+  emailhash: "4d33b3e2469c5208da6708ad96634e64"
+  job_title: "Product Manager"
+  twitter: ""
+  bio: "Product Manager, Open Source @ DataStax"

--- a/_posts/2020-07-08-quarkus-cassandra-extension-released.adoc
+++ b/_posts/2020-07-08-quarkus-cassandra-extension-released.adoc
@@ -1,0 +1,92 @@
+---
+layout: post
+title: 'A Shot of Quarkus with a Cassandra Chaser: Time for Faster Microservices'
+date: 2020-07-08
+tags: extension cassandra
+synopsis: With the new Quarkus extension for Apache Cassandra® released in Quarkus 1.6, all it takes is a few lines of code to connect to and access your data stored in Cassandra and you get all of the benefits of Quarkus (fast-startup, low resource utilization, reactive programming).
+author: csplinter
+---
+
+With the new https://quarkus.io/guides/cassandra[Quarkus extension for Apache Cassandra]® released in Quarkus 1.6, all it takes is a few lines of code to connect to and access your data stored in Cassandra and you get all of the benefits of Quarkus (fast-startup, low resource utilization, reactive programming). 
+
+To enable the extension, add `cassandra-quarkus-client` to your application. You can do this by including the following dependency or by selecting Cassandra client in the https://code.quarkus.io/[project generator].
+----
+# the version at time of writing is 1.0.0-alpha3
+<dependency>
+  <groupId>com.datastax.oss.quarkus</groupId>
+  <artifactId>cassandra-quarkus-client</artifactId>
+  <version>${cassandra-quarkus.version}</version>
+</dependency>
+----
+
+The most common database connection settings can be configured directly in an `application.properties` file on the classpath, see below for an example. All of the settings and features of the https://docs.datastax.com/en/developer/java-driver/latest[DataStax Java driver for Cassandra] are available to you and the https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/reference/[advanced driver settings] can be placed in an `application.conf` file on the classpath. 
+
+----
+# Connecting to DataStax Astra astra.datastax.com
+# if specified, contact-points and local-datacenter are not needed
+quarkus.cassandra.cloud.secure-connect-bundle=/path/to/secure-connect-bundle.zip
+
+# Connection details
+quarkus.cassandra.contact-points=127.0.0.1:9042
+quarkus.cassandra.local-datacenter=dc1
+quarkus.cassandra.keyspace=<your keyspace>
+
+# Authentication
+quarkus.cassandra.auth.username=<your username>
+quarkus.cassandra.auth.password=<your password>
+
+----
+
+Once the database connection is configured, simply inject the https://www.javadoc.io/static/com.datastax.oss.quarkus/cassandra-quarkus-client/1.0.0-alpha1/com/datastax/oss/quarkus/runtime/api/session/QuarkusCqlSession.html[`QuarkusCqlSession`] in your application to get started. For seamless integration with https://quarkus.io/guides/getting-started-reactive[reactive applications], there is an `executeReactive` method on the `QuarkusCqlSession` that exposes Mutiny-compatible reactive execution methods and direct retrieval of Mutiny types. 
+----
+@ApplicationScoped
+public class ProductService {
+  
+  @Inject
+  private QuarkusCqlSession session;
+
+  public Multi<Product> getAllProducts() {
+    Multi<ReactiveRow> products = session.executeReactive("SELECT * from products");
+    return products.on().item().apply(Product::new);
+  }
+}
+----
+
+Mutiny types are also available when using the Cassandra Java driver's https://docs.datastax.com/en/developer/java-driver/4.7/manual/mapper/[object mapper]. With the Quarkus Cassandra extension, you can easily define your mapped entities and DAOs and then inject your DAOs in your reactive services in just a few lines of code! 
+
+For example, suppose that you have a `Product` entity, a `ProductDao` and a `ProductMapper` with standard CRUD operations, you can expose your DAO as an injectable bean:
+----
+public class ProductDaoProducer {
+
+  private final ProductDao dao;
+
+  @Inject
+  public ProductDaoProducer(QuarkusCqlSession cqlSession) {
+    ProductMapper mapper = new ProductMapperBuilder(cqlSession).build();
+    this.dao = mapper.productDao();
+  }
+
+  @Produces @ApplicationScoped
+  public ProductDao produceProductDao() { return dao; }
+}
+----
+
+… then inject it in a `ProductService` component, as follows:
+----
+@ApplicationScoped
+public class ProductService {
+
+  @Inject
+  private ProductDao dao;
+
+  public Uni<Product> findProduct(String id) { return dao.findById(id); }
+
+  public Multi<Product> getAllProducts() { return dao.findAll(); }
+}
+----
+
+You can retrieve this example and many others in https://github.com/datastax/cassandra-quarkus/blob/master/documentation/src/main/asciidoc/cassandraclient.adoc[the quickstart guide], which includes how to use the Quarkus Cassandra extension in https://quarkus.io/guides/building-native-image[native mode]. For users that are looking to get up and running in minutes with Cassandra, try out the free-tier in https://astra.datastax.com/[DataStax Astra].
+
+We value your feedback so please don't hesitate to open feature requests and bug reports in the https://github.com/datastax/cassandra-quarkus[extensions GitHub repository], ask questions at https://community.datastax.com/[community.datastax.com], or join the https://cassandra.apache.org/community/[Cassandra] and https://quarkus.io/community/[Quarkus] communities.
+
+Happy subatomic coding!

--- a/_posts/2020-07-09-quarkus-cassandra-extension-released.adoc
+++ b/_posts/2020-07-09-quarkus-cassandra-extension-released.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'A Shot of Quarkus with a Cassandra Chaser: Time for Faster Microservices'
-date: 2020-07-08
+date: 2020-07-09
 tags: extension cassandra
 synopsis: With the new Quarkus extension for Apache Cassandra® released in Quarkus 1.6, all it takes is a few lines of code to connect to and access your data stored in Cassandra and you get all of the benefits of Quarkus (fast-startup, low resource utilization, reactive programming).
 author: csplinter
@@ -10,6 +10,8 @@ author: csplinter
 With the new https://quarkus.io/guides/cassandra[Quarkus extension for Apache Cassandra]® released in Quarkus 1.6, all it takes is a few lines of code to connect to and access your data stored in Cassandra and you get all of the benefits of Quarkus (fast-startup, low resource utilization, reactive programming). 
 
 To enable the extension, add `cassandra-quarkus-client` to your application. You can do this by including the following dependency or by selecting Cassandra client in the https://code.quarkus.io/[project generator].
+
+[source,xml]
 ----
 # the version at time of writing is 1.0.0-alpha3
 <dependency>
@@ -21,6 +23,7 @@ To enable the extension, add `cassandra-quarkus-client` to your application. You
 
 The most common database connection settings can be configured directly in an `application.properties` file on the classpath, see below for an example. All of the settings and features of the https://docs.datastax.com/en/developer/java-driver/latest[DataStax Java driver for Cassandra] are available to you and the https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/reference/[advanced driver settings] can be placed in an `application.conf` file on the classpath. 
 
+[source,properties]
 ----
 # Connecting to DataStax Astra astra.datastax.com
 # if specified, contact-points and local-datacenter are not needed
@@ -34,10 +37,11 @@ quarkus.cassandra.keyspace=<your keyspace>
 # Authentication
 quarkus.cassandra.auth.username=<your username>
 quarkus.cassandra.auth.password=<your password>
-
 ----
 
 Once the database connection is configured, simply inject the https://www.javadoc.io/static/com.datastax.oss.quarkus/cassandra-quarkus-client/1.0.0-alpha1/com/datastax/oss/quarkus/runtime/api/session/QuarkusCqlSession.html[`QuarkusCqlSession`] in your application to get started. For seamless integration with https://quarkus.io/guides/getting-started-reactive[reactive applications], there is an `executeReactive` method on the `QuarkusCqlSession` that exposes Mutiny-compatible reactive execution methods and direct retrieval of Mutiny types. 
+
+[source,java]
 ----
 @ApplicationScoped
 public class ProductService {
@@ -55,6 +59,8 @@ public class ProductService {
 Mutiny types are also available when using the Cassandra Java driver's https://docs.datastax.com/en/developer/java-driver/4.7/manual/mapper/[object mapper]. With the Quarkus Cassandra extension, you can easily define your mapped entities and DAOs and then inject your DAOs in your reactive services in just a few lines of code! 
 
 For example, suppose that you have a `Product` entity, a `ProductDao` and a `ProductMapper` with standard CRUD operations, you can expose your DAO as an injectable bean:
+
+[source,java]
 ----
 public class ProductDaoProducer {
 
@@ -72,6 +78,8 @@ public class ProductDaoProducer {
 ----
 
 … then inject it in a `ProductService` component, as follows:
+
+[source,java]
 ----
 @ApplicationScoped
 public class ProductService {


### PR DESCRIPTION
Blog post for the Quarkus Cassandra Extension

Guide: https://quarkus.io/guides/cassandra
Source: https://github.com/datastax/cassandra-quarkus
