### PR TITLE
Set outfilesuffix to an empty string

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,7 @@ asciidoctor:
     source-highlighter: highlightjs
     sectanchors: ''
     icons: font
+    outfilesuffix: ''
 
 # Pages permalink
 defaults:


### PR DESCRIPTION
This allows to reference the adoc files and have the links properly
built without the .html suffix.