### PR TITLE
Fix warning during build

### DIFF
--- a/_posts/2020-08-18-quarkus-hackathon-finalist-announcement.adoc
+++ b/_posts/2020-08-18-quarkus-hackathon-finalist-announcement.adoc
@@ -8,7 +8,7 @@ author: jbeck
 ---
 :imagesdir: /assets/images/posts/announcements
 
-= Quarkus Hackathon Finalists
+== Quarkus Hackathon Finalists
 
 [.customer-logo]
 image::homepage_herocallout_finalists.png[]
@@ -22,33 +22,33 @@ The Quarkus community is excited to announce the finalists for the https://quark
 
 ==== The "Best Overall" and individual sub-category winners will be announced on Friday, August 21st @ 10 AM - 12 PM EDT via the https://www.youtube.com/watch?v=j24uuhA3Wc8[*Quarkus YouTube Live*] channel.
 
-==== The finalist selection committee had a hard time narrowing the list down but here they are (in no particular order):
+===== The finalist selection committee had a hard time narrowing the list down but here they are (in no particular order):
 
-== *Best Overall*
+=== *Best Overall*
 [width="75%",cols="4",grid="none"]
 |=======
 |https://devpost.com/software/appname-ybfhks[*TidePool*] |https://devpost.com/software/mikro-minyma[*PopulationHealth IoT*] |https://devpost.com/software/slurpanize[*Slurpanize*] |https://devpost.com/software/weblith-io[*Weblith*]
 |=======
 
-== *Best Serverless*
+=== *Best Serverless*
 [width="75%"]
 |=======
 |https://devpost.com/software/brightact-app-againt-domestic-violence[*BrightAct Social Innovation*] |https://devpost.com/software/test-dy4jlx[*Quarkus Classify*]
 |=======
 
-== *Best Kubernetes-native*
+=== *Best Kubernetes-native*
 [width="75%"]
 |=======
 |https://devpost.com/software/slurpanize[*Slurpanize*] |https://devpost.com/software/appname-ybfhks[*TidePool*]
 |=======
 
-== *Best IoT*
+=== *Best IoT*
 [width="75%"]
 |=======
 |https://devpost.com/software/mikro-minyma[*PopulationHealth IoT*] |https://devpost.com/software/test-your-trivia[*Test Your Trivia*]
 |=======
 
-== *Best Modernized*
+=== *Best Modernized*
 [width="75%"]
 |=======
 |https://devpost.com/software/weblith-io[*Weblith*] |https://devpost.com/software/quarkus-spring-data-jpa-integration-no-api-no-panache[*Quarkus Spring Data JPA*]


### PR DESCRIPTION
This commit fixes the following warning during the build:

```
asciidoctor: WARNING: 2020-08-18-quarkus-hackathon-finalist-announcement.adoc: line 10: section title out of sequence: expected level 1, got level 2
```