### PR TITLE
Fixed link to WELD docs

### DIFF
--- a/_guides/cdi.adoc
+++ b/_guides/cdi.adoc
@@ -399,7 +399,7 @@ class Logger {
 <2> Fire the event synchronously.
 <3> This method is notified when a `TaskCompleted` event is fired.
 
-TIP: For more info about events/observers visit https://docs.jboss.org/weld/reference/latest/en-US/html/events.html[Weld docs, window="_blank"].
+TIP: For more info about events/observers visit https://docs.jboss.org/weld/reference/latest/en-US/html/#events[Weld docs, window="_blank"].
 
 == Conclusion
 


### PR DESCRIPTION
The correct url is https://docs.jboss.org/weld/reference/latest/en-US/html/#events

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
