### PR TITLE
Update qute-reference.adoc

### DIFF
--- a/_guides/qute-reference.adoc
+++ b/_guides/qute-reference.adoc
@@ -1253,7 +1253,7 @@ import io.quarkus.qute.i18n.Localized;
 import io.quarkus.qute.i18n.Message;
 
 @Localized("de") <1>
-public interface GermanAppMessages {
+public interface GermanAppMessages extends AppMessages {
 
     @Override
     @Message("Hallo {name}!") <2>


### PR DESCRIPTION
Missing `extends` for the Localized Message Bundle 

I missed some documentation for the localization, had to dig in the unit tests for this but not sure where to put it: 
```
templateInstance
                    .setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag(locale)
```

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
