### PR TITLE
The 'buildNative' task has been deprecated in favor of 'build -Dquarkus.package.type=native'

### DIFF
--- a/_includes/homepage-developer_joy-band.html
+++ b/_includes/homepage-developer_joy-band.html
@@ -21,7 +21,7 @@
 
   # Or
 
-$ ./gradlew buildNative</code></pre>
+$ gradle build -Dquarkus.package.type=native</code></pre>
           </div>
         </div>
         <a href="/vision/developer-joy">Learn more</a>


### PR DESCRIPTION
I also substituted the wrapper since the `mvn` command example above is not using it 