### PR TITLE
Word Corrected forward slash to backward slash

### DIFF
--- a/_guides/getting-started.adoc
+++ b/_guides/getting-started.adoc
@@ -41,7 +41,7 @@ To complete this guide, you need:
 ====
 If you have multiple JDK's installed it is not certain Maven will pick up the expected java
 and you could end up with unexpected results.
-You can verify which JDK Maven uses by running `mvn --version`. 
+You can verify which JDK Maven uses by running `mvn --version`.
 ====
 
 
@@ -87,7 +87,7 @@ cd getting-started
 
 For Windows users
 
-- If using cmd , (don't use forward slash `\`)
+- If using cmd , (don't use backward slash `\`)
 
 [source,shell,subs=attributes+]
 ----


### PR DESCRIPTION
Corrected, Wrongly named backward slash (\\) as Forward slash(\/)...