### PR TITLE
Fix typo in column name

### DIFF
--- a/_guides/cassandra.adoc
+++ b/_guides/cassandra.adoc
@@ -368,7 +368,7 @@ using Docker, run the following commands:
 [source,shell]
 ----
 docker exec -it local-cassandra-instance cqlsh -e "CREATE KEYSPACE IF NOT EXISTS k1 WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}"
-docker exec -it local-cassandra-instance cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(id text, name text, description text, PRIMARY KEY((id), name))"
+docker exec -it local-cassandra-instance cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(store_id text, name text, description text, PRIMARY KEY((store_id), name))"
 ----
 
 If you're running Cassandra locally you can execute the cqlsh commands directly:
@@ -376,7 +376,7 @@ If you're running Cassandra locally you can execute the cqlsh commands directly:
 [source,shell]
 ----
 cqlsh -e "CREATE KEYSPACE IF NOT EXISTS k1 WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}
-cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(id text, name text, description text, PRIMARY KEY((id), name))
+cqlsh -e "CREATE TABLE IF NOT EXISTS k1.fruit(store_id text, name text, description text, PRIMARY KEY((store_id), name))
 ----
 
 == Creating a frontend


### PR DESCRIPTION
The name of the column in the Cassandra example is not `id` but `store_id`.

The docs in the [original repo](https://github.com/datastax/cassandra-quarkus/tree/master/quickstart) are updated but this guide still has the typo.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
