### PR TITLE
Add some keywords for the CDI-related guides

### DIFF
--- a/_data/guides.yaml
+++ b/_data/guides.yaml
@@ -32,10 +32,11 @@ categories:
       - title: Introduction to CDI
         url: /guides/cdi
         description: Quarkus DI solution is based on the [Contexts and Dependency Injection for Java 2.0](https://docs.jboss.org/cdi/spec/2.0/cdi-spec) specification. This guide explains the basics of CDI.
-        keywords: qualifier event interceptor observer
+        keywords: qualifier event interceptor observer arc
       - title: CDI Reference
         url: /guides/cdi-reference
         description: Go more in depth into the Quarkus implementation of CDI.
+        keywords: arc
       - title: Testing Your Application
         url: /guides/getting-started-testing
         description: |

--- a/_data/guides.yaml
+++ b/_data/guides.yaml
@@ -28,9 +28,11 @@ categories:
       - title: Application Initialization and Termination
         url: /guides/lifecycle
         description: You often need to execute custom actions when the application starts and clean up everything when the application stops. This guide explains how to be notified when an application stops or starts.
+        keywords: lifecycle event
       - title: Introduction to CDI
         url: /guides/cdi
         description: Quarkus DI solution is based on the [Contexts and Dependency Injection for Java 2.0](https://docs.jboss.org/cdi/spec/2.0/cdi-spec) specification. This guide explains the basics of CDI.
+        keywords: qualifier event interceptor observer
       - title: CDI Reference
         url: /guides/cdi-reference
         description: Go more in depth into the Quarkus implementation of CDI.


### PR DESCRIPTION
/cc @mkouba @gastaldi @geoand I added this feature recently. I added some keywords for the SSO-related guides and in this PR I add some for CDI (I was looking for things in the CDI doc).

If you think of others, be my guest. They are not visible but are included in the search engine.

Obviously, we don't want too many either as we don't want all the guides to pop up when looking for something but some others might be useful.

It's not pressing but I thought it could be useful to make you aware of it.