### PR TITLE
Fix vert-x tag name

### DIFF
--- a/_posts/2020-11-24-mutiny-vertx.adoc
+++ b/_posts/2020-11-24-mutiny-vertx.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Mutiny and the Reactiverse
 date: 2020-11-24
-tags: reactive mutiny vert.x
+tags: reactive mutiny vert-x
 synopsis: Discover the Mutiny variant of the Vert.x API
 author: cescoffier
 ---


### PR DESCRIPTION
As mentioned in #821, `vert.x` tag was redirecting to a 404 page. 
This branch replaces the `.` by an `-`, tags with an `-` are working.

close #821 