### PR TITLE
Fix vert-x tag name

### DIFF
--- a/_posts/2020-11-24-mutiny-vertx.adoc
+++ b/_posts/2020-11-24-mutiny-vertx.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Mutiny and the Reactiverse
 date: 2020-11-24
-tags: reactive mutiny vert.x
+tags: reactive mutiny vertx
 synopsis: Discover the Mutiny variant of the Vert.x API
 author: cescoffier
 ---


### PR DESCRIPTION
As mentioned in #821, the `.` in `vert.x` tag does not seem to work. This branch removes it from the tagname. 

close #821 
