### PR TITLE
Fix vert.x tag name

### DIFF
--- a/_posts/2021-01-12-magic-control.adoc
+++ b/_posts/2021-01-12-magic-control.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Bored with magic tricks?
 date: 2021-01-12
-tags: vertx
+tags: vert.x
 synopsis: How to control the amount of magic from Quarkus
 author: cescoffier
 ---


### PR DESCRIPTION
Sorry for the confusion I may have introduced about the `vert.x` tag name last week. Thanks to #824 the `vert.x` tag works.
 
This branch set the tag to `vert.x` in the last article. This avoid to have both `vert.x` and `vertx` in the tag list. 