### PR TITLE
Create 2021-02-25-migrating-existing-apps-to-quarkus-with-mta.adoc

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -281,3 +281,10 @@ jcarvaja:
   emailhash: "c36dc2ca5ea73cbbd6cf8eae3c54d0e1"
   twitter: "jcarvajalh"
   job_title: "Senior Quality Engineer"
+mperezco:
+  name: "Miguel Pérez Colino"
+  email: "miguel@redhat.com"
+  emailhash: "a6802d839bfb6c3f03e4de1eb4a55589"
+  job_title: "Product Manager @ Red Hat"
+  twitter: "mmmmmmpc"
+  bio: "Miguel is an experienced IT enthusiast with a clear orientation towards open source software & open standards. He has an extensive background in IT, from operations to architecture of large deployments; from identifying and prototyping solutions to defining IT strategies. He has delivered large projects, including NATO interoperable command and control systems in defence, and digital transformation in the finance sector. As part of the Cloud Platforms Business Unit, in Red Hat, he works to build the tools and define methodologies to ease modernization and migration for customers, enabling open source adoption"  

--- a/_posts/2021-02-25-migrating-existing-apps-to-quarkus-with-mta..adoc
+++ b/_posts/2021-02-25-migrating-existing-apps-to-quarkus-with-mta..adoc
@@ -1,0 +1,31 @@
+---
+layout: post
+title: Migrating existing applications to Quarkus with Migration Toolkit for Applications
+date: 2021-02-25
+tags: mta
+synopsis: Migrating existing Java applications, like Spring Boot ones, to Quarkus by using the Migration Toolkit for Applications
+author: mperezco
+---
+
+== The evolution of Java
+
+Java is a language that never ceases to impress me. From its conception, to the first Java Virtual Machines with the premise of “write once run anywhere”, to Tomcat or to the Enterprise Edition standards (whether J2EE, or Java EE) it’s an ever evolving language.
+With the advent of containerization and the possibility of effectively managing microservices, running components that could be loaded in a "reactive" manner and the need for boot speed and efficiency, Quarkus is revealing itself as the choice for Cloud Native Java programmers.
+
+== Working with brownfield applications
+
+But, after so many years and lines of code written, how can we move those Java workloads to this set of new paradigms? The Red Hat Modernization and Migration Solutions team is here to help by providing the http://red.ht/mta[Migration Toolkit for Applications] (MTA), a tool that simplifies, and reduces the effort required to take this step. As a matter of fact, just like Java, MTA is not a new tool but one that has been evolving over time.
+
+It all started by helping developers update their code to run in a new https://developers.redhat.com/products/eap/[JBoss EAP] version, a "piece of cake". That’s why the tool started by being called "JBoss Cake" back in 2012. It kept evolving to be able to be used to modernize Java code and move it from WebLogic or WebSphere to JBoss EAP or https://developers.redhat.com/products/webserver/[JBoss Web Server] (the Red Hat Supported build of Tomcat), when it became the Red Hat Application Migration Toolkit. It kept being improved by developers and consultants, bringing their experience by working in the first line with production code, who wrote more and better rules, increasing the number of covered cases.
+
+== MTA 5.1.2 and beyond
+
+In the latest evolution, the tool started being called by its current name, Migration Toolkit for Applications, or MTA. With the release 5.0.0, it started seeding the first rules to help migrate applications from the Spring Boot framework to Quarkus. That happened, among other things due to the feedback that developer teams working with modern Java patterns, and deploying on Kubernetes, were interested in. It happened that these teams were using Spring Boot but quickly became interested in Quarkus as a way to improve speed, required resources, and productivity. With version 5.1.1, MTA broke the 120 rules barrier to ease this transformation path. Now, closing the circle, MTA in the coming release 5.1.3 of MTA (expected by mid March 2021) will include rules to upgrade code written for Quarkus 1.11, so it can efficiently be moved to 1.12. A piece of cake! 
+
+== Related resources
+
+Do you want to know more? Here you are, some MTA related resources:
+
+* http://red.ht/mta[MTA web page] (with downloads and demo videos)
+* https://developers.redhat.com/blog/2020/12/08/spring-boot-to-quarkus-migrations-and-more-in-red-hats-migration-toolkit-for-applications-5-1-0/[Spring Boot to Quarkus migrations with MTA] (in developers.redhat.com)
+* https://youtu.be/coeVxLaXy5M[Migrating Spring Boot "Pet-Clinic" (REST version) to Quarkus] (http://konveyor.io[konveyor.io] meetup recording)

--- a/_posts/2021-02-25-migrating-existing-apps-to-quarkus-with-mta.adoc
+++ b/_posts/2021-02-25-migrating-existing-apps-to-quarkus-with-mta.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Migrating existing applications to Quarkus with Migration Toolkit for Applications
-date: 2021-02-25
+date: 2021-03-29
 tags: mta
 synopsis: Migrating existing Java applications, like Spring Boot ones, to Quarkus by using the Migration Toolkit for Applications
 author: mperezco


### PR DESCRIPTION
Create new blog post for Quarkus.io on the topic Migrating existing applications to Quarkus with Migration Toolkit for Applications

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
