### PR TITLE
Fix typo in the article 'Quarkus 1.12.1.Final released - Bugfixes'

### DIFF
--- a/_posts/2021-03-03-quarkus-1-12-1-final-released.adoc
+++ b/_posts/2021-03-03-quarkus-1-12-1-final-released.adoc
@@ -9,7 +9,7 @@ author: gsmet
 
 1.12.1.Final is a maintenance release fixing bugs and improving the documentation.
 
-1.12.1.Final is a safe upgrade for everyone using Quarkus 1.11.
+1.12.1.Final is a safe upgrade for everyone using Quarkus 1.12.
 
 If you are not using 1.12 already, please refer to the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-1.12[1.12 migration guide].
 


### PR DESCRIPTION
In the article 'Quarkus 1.12.1.Final released - Bugfixes', 
It is stated that '1.12.1.Final is a safe upgrade for everyone using Quarkus 1.11.' but it seems it should be '1.12.1.Final is a safe upgrade for everyone using Quarkus 1.12.'