### PR TITLE
Fix/update quickstart links after branch renamed to main

### DIFF
--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -27,6 +27,6 @@
 :quarkus-mailing-list-index: https://groups.google.com/d/forum/quarkus-dev
 :quickstarts-base-url: https://github.com/quarkusio/quarkus-quickstarts
 :quickstarts-clone-url: https://github.com/quarkusio/quarkus-quickstarts.git
-:quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/master.zip
-:quickstarts-blob-url: https://github.com/quarkusio/quarkus-quickstarts/blob/master
-:quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/master
+:quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/main.zip
+:quickstarts-blob-url: https://github.com/quarkusio/quarkus-quickstarts/blob/main
+:quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/main

--- a/_versions/1.11/guides/attributes.adoc
+++ b/_versions/1.11/guides/attributes.adoc
@@ -27,6 +27,6 @@
 :quarkus-mailing-list-index: https://groups.google.com/d/forum/quarkus-dev
 :quickstarts-base-url: https://github.com/quarkusio/quarkus-quickstarts
 :quickstarts-clone-url: https://github.com/quarkusio/quarkus-quickstarts.git
-:quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/master.zip
-:quickstarts-blob-url: https://github.com/quarkusio/quarkus-quickstarts/blob/master
-:quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/master
+:quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/main.zip
+:quickstarts-blob-url: https://github.com/quarkusio/quarkus-quickstarts/blob/main
+:quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/main

--- a/_versions/1.7/guides/attributes.adoc
+++ b/_versions/1.7/guides/attributes.adoc
@@ -27,6 +27,6 @@
 :quarkus-mailing-list-index: https://groups.google.com/d/forum/quarkus-dev
 :quickstarts-base-url: https://github.com/quarkusio/quarkus-quickstarts
 :quickstarts-clone-url: https://github.com/quarkusio/quarkus-quickstarts.git
-:quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/master.zip
-:quickstarts-blob-url: https://github.com/quarkusio/quarkus-quickstarts/blob/master
-:quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/master
+:quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/main.zip
+:quickstarts-blob-url: https://github.com/quarkusio/quarkus-quickstarts/blob/main
+:quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/main


### PR DESCRIPTION
The links to the quickstart archives are currently all broken on the site after the repository branch was renamed. This updates the site to use the new branch name for the links and resolve the breakage.

Some of the other links just get redirected, with a banner displayed on the page about the rename, I have updated their attributes too though.