### PR TITLE
Replace Restream player with YouTube's

### DIFF
--- a/_includes/insights-band.html
+++ b/_includes/insights-band.html
@@ -6,7 +6,7 @@
     </div>
     <div class="width-12-12 width-12-12-m">
       <div class="iframe-container">
-      <iframe src="https://embed.restream.io/player/index.html?token=6b40eef71ed45dd4ece244b0f0ef3436" width="960" height="576" frameborder="0" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/playlist?list=PLsM3ZE5tGAVatO65JIxgskQh-OKoqM4F2" width="960" height="576" frameborder="0" allowfullscreen></iframe>
     </div>
     </div>
     <div class="width-12-12 width-12-12-m">


### PR DESCRIPTION
Fixes #945