### PR TITLE
Fix relative path to properly display version select list

### DIFF
--- a/_data/guides-1-11.yaml
+++ b/_data/guides-1-11.yaml
@@ -525,16 +525,16 @@ categories:
     cat-id: writing-extensions
     guides:
       - title: Building My First Extension
-        url: building-my-first-extension
+        url: /guides/building-my-first-extension
         description: Learn step by step how to build a simple extension.
       - title: CDI Integration
-        url: cdi-integration
+        url: /guides/cdi-integration
         description: Learn how to integrate your extension with Quarkus' CDI container.
       - title: Contributing to Dev UI
-        url: dev-ui
+        url: /guides/dev-ui
         description: Learn how to get your extension contribute features to the Dev UI.
       - title: All BuildItems
-        url: all-builditems
+        url: /guides/all-builditems
         description: Explore all the BuildItems you can consume/produce in your extensions.
       - title: Writing Your Own Extension
         url: /guides/writing-extensions

--- a/_data/guides-1-7.yaml
+++ b/_data/guides-1-7.yaml
@@ -427,7 +427,7 @@ categories:
     cat-id: writing-extensions
     guides:
       - title: Building My First Extension
-        url: building-my-first-extension
+        url: /guides/building-my-first-extension
         description: Learn step by step how to build a simple extension.
       - title: Writing Your Own Extension
         url: /guides/writing-extensions

--- a/_data/guides-latest.yaml
+++ b/_data/guides-latest.yaml
@@ -528,16 +528,16 @@ categories:
     cat-id: writing-extensions
     guides:
       - title: Building My First Extension
-        url: building-my-first-extension
+        url: /guides/building-my-first-extension
         description: Learn step by step how to build a simple extension.
       - title: CDI Integration
-        url: cdi-integration
+        url: /guides/cdi-integration
         description: Learn how to integrate your extension with Quarkus' CDI container.
       - title: Contributing to Dev UI
-        url: dev-ui
+        url: /guides/dev-ui
         description: Learn how to get your extension contribute features to the Dev UI.
       - title: All BuildItems
-        url: all-builditems
+        url: /guides/all-builditems
         description: Explore all the BuildItems you can consume/produce in your extensions.
       - title: Writing Your Own Extension
         url: /guides/writing-extensions

--- a/_data/guides-main.yaml
+++ b/_data/guides-main.yaml
@@ -537,16 +537,16 @@ categories:
     cat-id: writing-extensions
     guides:
       - title: Building My First Extension
-        url: building-my-first-extension
+        url: /guides/building-my-first-extension
         description: Learn step by step how to build a simple extension.
       - title: CDI Integration
-        url: cdi-integration
+        url: /guides/cdi-integration
         description: Learn how to integrate your extension with Quarkus' CDI container.
       - title: Contributing to Dev UI
-        url: dev-ui
+        url: /guides/dev-ui
         description: Learn how to get your extension contribute features to the Dev UI.
       - title: All BuildItems
-        url: all-builditems
+        url: /guides/all-builditems
         description: Explore all the BuildItems you can consume/produce in your extensions.
       - title: Writing Your Own Extension
         url: /guides/writing-extensions


### PR DESCRIPTION
some guides versions list is broken.

e.g. https://quarkus.io/guides/building-my-first-extension versions list is broken.