### PR TITLE
clarify microprofile is not for any kind of http

### DIFF
--- a/_guides/topic/continuum.adoc
+++ b/_guides/topic/continuum.adoc
@@ -75,7 +75,7 @@ Finally, methods requiring a transaction are simply annotated with `@Transaction
 
 Let's now imagine you need to access another HTTP endpoint.
 You can use a HTTP client directly, this is nothing more than repeating boilerplate code.
-Quarkus provides a way to call HTTP endpoint easily using the MicroProfile Rest Client API.
+Quarkus provides a way to call HTTP endpoints that return Rest based results easily using the MicroProfile Rest Client API.
 
 First declare your service as follows:
 


### PR DESCRIPTION
got this page shared as argument for quarkus docs stating microprofile rest client could be used for raw http access. 

here is my attempt on clarifying it

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
