### PR TITLE
Move Content Security Policy to config file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -177,3 +177,17 @@ jekyll-archives:
   permalinks:
     tag: '/blog/tag/:name/'
   
+
+############################################################
+
+# Add header file to move Content Security Protection
+
+webrick:
+  headers:
+      Content-Security-Policy:
+        default-src  https://dpm.demdex.net;
+        script-src 'self' 'unsafe-eval' 'sha256-ANpuoVzuSex6VhqpYgsG25OHWVA1I+F6aGU04LoI+5s=' 'sha256-ipy9P/3rZZW06mTLAR0EnXvxSNcnfSDPLDuh3kzbB1w=' js.bizographics.com https://www.redhat.com https://static.redhat.com assets.adobedtm.com jsonip.com https://ajax.googleapis.com https://www.googletagmanager.com https://www.google-analytics.com https://use.fontawesome.com https://app.mailjet.com http://www.youtube.com http://www.googleadservices.com https://googleads.g.doubleclick.net https://dpm.demdex.net; 
+        style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com; 
+        img-src 'self' *;
+        media-src 'self';
+        frame-src https://www.googletagmanager.com https://www.youtube.com https://embed.restream.io https://app.mailjet.com; base-uri 'none'; object-src 'none'; form-action 'none'; font-src 'self' https://use.fontawesome.com https://fonts.gstatic.com;

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -18,8 +18,6 @@
   <title>{% unless page_title_starts_with_quarkus %}Quarkus - {% endunless %}{{ page.title }}{{ page_title_version_suffix }}</title>
   <script id="adobe_dtm" src="https://www.redhat.com/dtm.js" type="text/javascript"></script>
   <script src="{{ '/assets/javascript/highlight.pack.js' | relative_url }}" type="text/javascript"></script>
-  <META HTTP-EQUIV='Content-Security-Policy' CONTENT="default-src 'none'; script-src 'self' 'unsafe-eval' 'sha256-ANpuoVzuSex6VhqpYgsG25OHWVA1I+F6aGU04LoI+5s=' 'sha256-ipy9P/3rZZW06mTLAR0EnXvxSNcnfSDPLDuh3kzbB1w=' js.bizographics.com https://www.redhat.com assets.adobedtm.com jsonip.com https://ajax.googleapis.com https://www.googletagmanager.com https://www.google-analytics.com https://use.fontawesome.com; style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com; img-src 'self' *; media-src 'self' ; frame-src https://www.googletagmanager.com https://www.youtube.com https://embed.restream.io https://app.mailjet.com; frame-ancestors 'none'; base-uri 'none'; object-src 'none'; form-action 'none'; font-src 'self' https://use.fontawesome.com https://fonts.gstatic.com;">
-  <META HTTP-EQUIV='X-Frame-Options' CONTENT="DENY">
   <META HTTP-EQUIV='X-XSS-Protection' CONTENT="1; mode=block">
   <META HTTP-EQUIV='X-Content-Type-Options' CONTENT="nosniff">
   <meta charset="utf-8">


### PR DESCRIPTION
We are getting console errors because of our current configuration of the CSP. Some attributes can't be set in the meta data so I moved it all to the config file. This fixed all of the errors I've seen on my browsers.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
