### PR TITLE
Replace old attributes

### DIFF
--- a/_layouts/quarkus2.html
+++ b/_layouts/quarkus2.html
@@ -84,13 +84,13 @@ layout: vision
     <h3>Quarkus Insights Episode #55: The Quarkus 2.0 Launch</h3>
   </div>
   <div class="width-12-12 video-container">
-    <iframe src="https://www.youtube.com/embed/WyeaF2pk8Ec" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/WyeaF2pk8Ec" frameborder="0" allow="autoplay; encrypted-media; fullscreen"></iframe>
   </div>
   <div class="width-12-12">
     <h3>Continous Testing in Quarkus 2.0</h3>
   </div>
   <div class="width-12-12 video-container">
-    <iframe src="https://www.youtube.com/embed/rUyiTzbezjw" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/rUyiTzbezjw" frameborder="0" allow="autoplay; encrypted-media; fullscreen"></iframe>
   </div>
 </div>
 


### PR DESCRIPTION
`allowfullscreen` attribute also breaks [ja.quarkus.io](https://github.com/quarkusio/ja.quarkus.io) build because it cannot be parsed by po4a parser. 
It would be appreciated if it is replaced with `allow="fullscreen"`