### PR TITLE
Add metrics path in the Micrometer Prometheus OCP post

### DIFF
--- a/_posts/2021-03-15-micrometer-prometheus-openshift.adoc
+++ b/_posts/2021-03-15-micrometer-prometheus-openshift.adoc
@@ -183,11 +183,16 @@ spec:
   endpoints:
   - interval: 30s
     targetPort: 8080
+    path: /q/metrics
     scheme: http
   selector:
     matchLabels:
       app-with-metrics: 'quarkus-app'
 ----
+
+The path `/q/metrics` is the default metrics endpoint in Quarkus. 
+
+We could configure the `/metrics` endpoint Prometheus expects in `application.properties` instead of adding the path attribute above using the following property: `quarkus.micrometer.export.prometheus.path=/metrics`.
 
 And apply it:
 


### PR DESCRIPTION
Adding the metrics path to the `ServiceMonitor` object is mandatory from Quarkus 2.x as the old paths (`/metrics`) are not longer redirected to the right path `/q/metrics`.

This change is related to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0#prometheus-servicemonitor.
