### PR TITLE
fix: add author to feeed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -23,6 +23,14 @@ layout: null
             <guid>
                 {{ post.url | prepend: site.url }}
             </guid>
+            {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
+            {% assign post_author = site.data.authors[post_author] | default: post_author %}
+            {% if post_author %}
+                <author>
+                    <name>{{ post_author.name | default: "" | xml_escape }}</name>
+                    {% if post_author.twitter %}<uri>https://twitter.com/{{ post_author.twitter | xml_escape }}</uri>{% endif %}
+            </author>
+            {% endif %}
         </item>
         {% endfor %}
     </channel>


### PR DESCRIPTION
Wanted to be able to fetch from /feed.xml posts and have author tag to filter/sort by.

this just adds standard author tags to the feed.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **