### PR TITLE
Updated the Quarkus repo URL (master -> main)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
+** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 Contributions are welcome, please submit pull requests for the `develop` branch.
 
 **Important:** the guides are maintained in the main Quarkus repository and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc.
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To write a blog:
 Please read [CONTRIBUTING.md](https://github.com/quarkusio/quarkusio.github.io/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 **Important:** the guides are maintained in the main Quarkus repository and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc.
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc.
 
 ## License
 

--- a/_guides/conditional-extension-dependencies.adoc
+++ b/_guides/conditional-extension-dependencies.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Conditional Extension Dependencies
 

--- a/_guides/deploying-to-heroku.adoc
+++ b/_guides/deploying-to-heroku.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying to Heroku
 include::./attributes.adoc[]

--- a/_posts/2020-08-20-codestarts-preview.adoc
+++ b/_posts/2020-08-20-codestarts-preview.adoc
@@ -106,11 +106,11 @@ If you have an extension and would like to provide a codestart for it:
 
 - Doc: https://github.com/quarkusio/quarkus/blob/master/independent-projects/tools/codestarts/codestarts.adoc
 
-- Example codestarts dir: https://github.com/quarkusio/quarkus/tree/master/devtools/platform-descriptor-json/src/main/resources/codestarts
+- Example codestarts dir: https://github.com/quarkusio/quarkus/tree/main/devtools/platform-descriptor-json/src/main/resources/codestarts
 
 Feel free to contact us via https://quarkusio.zulipchat.com/[Zulip] or the https://groups.google.com/forum/#!forum/quarkus-dev[Quarkus Development mailing list] for any question or suggestion.
 
-NOTE: Here are the Codestarts https://github.com/quarkusio/quarkus/tree/master/independent-projects/tools/codestarts[core code], and the https://github.com/quarkusio/quarkus/tree/master/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts[base codestarts] used to scaffold your Quarkus application.
+NOTE: Here are the Codestarts https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/codestarts[core code], and the https://github.com/quarkusio/quarkus/tree/main/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts[base codestarts] used to scaffold your Quarkus application.
 
 == The door is now open to an endless new playground
 

--- a/_posts/2020-12-08-resteasy-reactive.adoc
+++ b/_posts/2020-12-08-resteasy-reactive.adoc
@@ -7,7 +7,7 @@ synopsis: RESTEasy Reactive is ready to be tested
 author: geoand
 ---
 
-It gives the Quarkus and RESTEasy teams great pleasure to announce that RESTEasy Reactive integration in Quarkus has landed in the main Quarkus repo footnote:disclaimer[Currently the main RESTEasy Reactive component resides at https://github.com/quarkusio/quarkus/tree/master/independent-projects/resteasy-reactive
+It gives the Quarkus and RESTEasy teams great pleasure to announce that RESTEasy Reactive integration in Quarkus has landed in the main Quarkus repo footnote:disclaimer[Currently the main RESTEasy Reactive component resides at https://github.com/quarkusio/quarkus/tree/main/independent-projects/resteasy-reactive
 in the main Quarkus repository; the plan is however that once things settle, this code will move to https://github.com/resteasy/resteasy-reactive. This move should not affect users of the quarkus-resteasy-reactive extensions in any way, just a heads up if anyone reads this blog post in the future and can’t find it.] and will be part of the next Quarkus release 1.11.
 
 We are looking forward to everyone testing it and providing us as much feedback as possible.

--- a/_versions/1.11/guides/all-builditems.adoc
+++ b/_versions/1.11/guides/all-builditems.adoc
@@ -4,7 +4,7 @@ layout: guides-configuration-reference
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 include::./attributes.adoc[]
 

--- a/_versions/1.11/guides/all-config.adoc
+++ b/_versions/1.11/guides/all-config.adoc
@@ -4,7 +4,7 @@ layout: guides-configuration-reference
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - All configuration options
 

--- a/_versions/1.11/guides/amazon-dynamodb.adoc
+++ b/_versions/1.11/guides/amazon-dynamodb.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon DynamoDB Client
 :extension-status: preview

--- a/_versions/1.11/guides/amazon-iam.adoc
+++ b/_versions/1.11/guides/amazon-iam.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon IAM Client
 :extension-status: preview

--- a/_versions/1.11/guides/amazon-kms.adoc
+++ b/_versions/1.11/guides/amazon-kms.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon KMS Client
 :extension-status: preview

--- a/_versions/1.11/guides/amazon-lambda-http.adoc
+++ b/_versions/1.11/guides/amazon-lambda-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon Lambda with RESTEasy, Undertow, or Vert.x Web 
 :extension-status: preview

--- a/_versions/1.11/guides/amazon-lambda.adoc
+++ b/_versions/1.11/guides/amazon-lambda.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon Lambda
 :extension-status: preview

--- a/_versions/1.11/guides/amazon-s3.adoc
+++ b/_versions/1.11/guides/amazon-s3.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon S3 Client
 

--- a/_versions/1.11/guides/amazon-ses.adoc
+++ b/_versions/1.11/guides/amazon-ses.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SES Client
 :extension-status: preview

--- a/_versions/1.11/guides/amazon-sns.adoc
+++ b/_versions/1.11/guides/amazon-sns.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SNS Client
 :extension-status: preview

--- a/_versions/1.11/guides/amazon-sqs.adoc
+++ b/_versions/1.11/guides/amazon-sqs.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SQS Client
 :extension-status: preview

--- a/_versions/1.11/guides/amqp.adoc
+++ b/_versions/1.11/guides/amqp.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using AMQP with Reactive Messaging
 :extension-status: preview

--- a/_versions/1.11/guides/azure-functions-http.adoc
+++ b/_versions/1.11/guides/azure-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Azure Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
 :extension-status: preview

--- a/_versions/1.11/guides/blaze-persistence.adoc
+++ b/_versions/1.11/guides/blaze-persistence.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Blaze-Persistence
 

--- a/_versions/1.11/guides/building-my-first-extension.adoc
+++ b/_versions/1.11/guides/building-my-first-extension.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building my first extension
 

--- a/_versions/1.11/guides/building-native-image.adoc
+++ b/_versions/1.11/guides/building-native-image.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building a Native Executable
 

--- a/_versions/1.11/guides/building-substrate-howto.adoc
+++ b/_versions/1.11/guides/building-substrate-howto.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building a Custom SubstrateVM
 

--- a/_versions/1.11/guides/cache.adoc
+++ b/_versions/1.11/guides/cache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Application Data Caching
 :extension-status: preview

--- a/_versions/1.11/guides/camel.adoc
+++ b/_versions/1.11/guides/camel.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Apache Camel on Quarkus
 

--- a/_versions/1.11/guides/cassandra.adoc
+++ b/_versions/1.11/guides/cassandra.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the Cassandra Client
 

--- a/_versions/1.11/guides/cdi-integration.adoc
+++ b/_versions/1.11/guides/cdi-integration.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - CDI Integration Guide
 

--- a/_versions/1.11/guides/cdi-reference.adoc
+++ b/_versions/1.11/guides/cdi-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Contexts and Dependency Injection
 

--- a/_versions/1.11/guides/cdi.adoc
+++ b/_versions/1.11/guides/cdi.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Introduction to Contexts and Dependency Injection
 

--- a/_versions/1.11/guides/centralized-log-management.adoc
+++ b/_versions/1.11/guides/centralized-log-management.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Centralized log management (Graylog, Logstash, Fluentd)
 

--- a/_versions/1.11/guides/class-loading-reference.adoc
+++ b/_versions/1.11/guides/class-loading-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Class Loading Reference
 

--- a/_versions/1.11/guides/cli-tooling.adoc
+++ b/_versions/1.11/guides/cli-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Quarkus Command Line Interface (CLI)
 

--- a/_versions/1.11/guides/command-mode-reference.adoc
+++ b/_versions/1.11/guides/command-mode-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Command Mode Applications
 

--- a/_versions/1.11/guides/config-reference.adoc
+++ b/_versions/1.11/guides/config-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuration Reference Guide
 

--- a/_versions/1.11/guides/config.adoc
+++ b/_versions/1.11/guides/config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuring Your Application
 

--- a/_versions/1.11/guides/consul-config.adoc
+++ b/_versions/1.11/guides/consul-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reading properties from Consul
 

--- a/_versions/1.11/guides/container-image.adoc
+++ b/_versions/1.11/guides/container-image.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Container Images
 

--- a/_versions/1.11/guides/context-propagation.adoc
+++ b/_versions/1.11/guides/context-propagation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Context Propagation in Quarkus
 

--- a/_versions/1.11/guides/credentials-provider.adoc
+++ b/_versions/1.11/guides/credentials-provider.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using a Credentials Provider
 

--- a/_versions/1.11/guides/datasource.adoc
+++ b/_versions/1.11/guides/datasource.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Datasources
 

--- a/_versions/1.11/guides/deploying-to-azure-cloud.adoc
+++ b/_versions/1.11/guides/deploying-to-azure-cloud.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying to Microsoft Azure Cloud
 

--- a/_versions/1.11/guides/deploying-to-google-cloud.adoc
+++ b/_versions/1.11/guides/deploying-to-google-cloud.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying to Google Cloud Platform (GCP)
 

--- a/_versions/1.11/guides/deploying-to-kubernetes.adoc
+++ b/_versions/1.11/guides/deploying-to-kubernetes.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes extension
 

--- a/_versions/1.11/guides/deploying-to-openshift.adoc
+++ b/_versions/1.11/guides/deploying-to-openshift.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying on OpenShift
 

--- a/_versions/1.11/guides/dev-ui.adoc
+++ b/_versions/1.11/guides/dev-ui.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Dev UI
 

--- a/_versions/1.11/guides/elasticsearch.adoc
+++ b/_versions/1.11/guides/elasticsearch.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Connecting to an Elasticsearch cluster
 include::./attributes.adoc[]

--- a/_versions/1.11/guides/flyway.adoc
+++ b/_versions/1.11/guides/flyway.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Flyway
 

--- a/_versions/1.11/guides/funqy-amazon-lambda-http.adoc
+++ b/_versions/1.11/guides/funqy-amazon-lambda-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Amazon Lambda 
 :extension-status: preview

--- a/_versions/1.11/guides/funqy-amazon-lambda.adoc
+++ b/_versions/1.11/guides/funqy-amazon-lambda.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Amazon Lambda Binding
 :extension-status: preview

--- a/_versions/1.11/guides/funqy-azure-functions-http.adoc
+++ b/_versions/1.11/guides/funqy-azure-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Azure Functions
 :extension-status: preview

--- a/_versions/1.11/guides/funqy-gcp-functions-http.adoc
+++ b/_versions/1.11/guides/funqy-gcp-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Google Cloud Functions
 :extension-status: experimental

--- a/_versions/1.11/guides/funqy-gcp-functions.adoc
+++ b/_versions/1.11/guides/funqy-gcp-functions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Google Cloud Functions
 :extension-status: experimental

--- a/_versions/1.11/guides/funqy-http.adoc
+++ b/_versions/1.11/guides/funqy-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding (Standalone)
 

--- a/_versions/1.11/guides/funqy-knative-events.adoc
+++ b/_versions/1.11/guides/funqy-knative-events.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Knative Events Binding
 

--- a/_versions/1.11/guides/funqy.adoc
+++ b/_versions/1.11/guides/funqy.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy
 

--- a/_versions/1.11/guides/gcp-functions-http.adoc
+++ b/_versions/1.11/guides/gcp-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
 :extension-status: experimental

--- a/_versions/1.11/guides/gcp-functions.adoc
+++ b/_versions/1.11/guides/gcp-functions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless)
 :extension-status: experimental

--- a/_versions/1.11/guides/getting-started-reactive.adoc
+++ b/_versions/1.11/guides/getting-started-reactive.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Getting started with Reactive
 

--- a/_versions/1.11/guides/getting-started-testing.adoc
+++ b/_versions/1.11/guides/getting-started-testing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Testing Your Application
 

--- a/_versions/1.11/guides/getting-started.adoc
+++ b/_versions/1.11/guides/getting-started.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Creating Your First Application
 

--- a/_versions/1.11/guides/gradle-config.adoc
+++ b/_versions/1.11/guides/gradle-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Gradle Plugin Repositories
 

--- a/_versions/1.11/guides/gradle-tooling.adoc
+++ b/_versions/1.11/guides/gradle-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Gradle
 

--- a/_versions/1.11/guides/grpc-getting-started.adoc
+++ b/_versions/1.11/guides/grpc-getting-started.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started with gRPC
 

--- a/_versions/1.11/guides/grpc-service-consumption.adoc
+++ b/_versions/1.11/guides/grpc-service-consumption.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Consuming a gRPC Service
 

--- a/_versions/1.11/guides/grpc-service-implementation.adoc
+++ b/_versions/1.11/guides/grpc-service-implementation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Implementing a gRPC Service
 

--- a/_versions/1.11/guides/grpc.adoc
+++ b/_versions/1.11/guides/grpc.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus gRPC
 

--- a/_versions/1.11/guides/hibernate-orm-panache-kotlin.adoc
+++ b/_versions/1.11/guides/hibernate-orm-panache-kotlin.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified Hibernate ORM with Panache and Kotlin
 

--- a/_versions/1.11/guides/hibernate-orm-panache.adoc
+++ b/_versions/1.11/guides/hibernate-orm-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified Hibernate ORM with Panache
 

--- a/_versions/1.11/guides/hibernate-orm.adoc
+++ b/_versions/1.11/guides/hibernate-orm.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Hibernate ORM and JPA
 

--- a/_versions/1.11/guides/hibernate-search-orm-elasticsearch.adoc
+++ b/_versions/1.11/guides/hibernate-search-orm-elasticsearch.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Hibernate Search guide
 :hibernate-search-doc-prefix: https://docs.jboss.org/hibernate/search/6.0/reference/en-US/html_single/

--- a/_versions/1.11/guides/http-reference.adoc
+++ b/_versions/1.11/guides/http-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - HTTP Reference
 

--- a/_versions/1.11/guides/ide-tooling.adoc
+++ b/_versions/1.11/guides/ide-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Tools in your favorite IDE
 

--- a/_versions/1.11/guides/infinispan-client.adoc
+++ b/_versions/1.11/guides/infinispan-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Infinispan Client
 

--- a/_versions/1.11/guides/jgit.adoc
+++ b/_versions/1.11/guides/jgit.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - JGit
 

--- a/_versions/1.11/guides/jms.adoc
+++ b/_versions/1.11/guides/jms.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using JMS
 include::./attributes.adoc[]

--- a/_versions/1.11/guides/kafka-streams.adoc
+++ b/_versions/1.11/guides/kafka-streams.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Kafka Streams
 

--- a/_versions/1.11/guides/kafka.adoc
+++ b/_versions/1.11/guides/kafka.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Kafka with Reactive Messaging
 

--- a/_versions/1.11/guides/kogito.adoc
+++ b/_versions/1.11/guides/kogito.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Kogito to add business automation capabilities to an application
 

--- a/_versions/1.11/guides/kotlin.adoc
+++ b/_versions/1.11/guides/kotlin.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Kotlin
 

--- a/_versions/1.11/guides/kubernetes-client.adoc
+++ b/_versions/1.11/guides/kubernetes-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes Client
 

--- a/_versions/1.11/guides/kubernetes-config.adoc
+++ b/_versions/1.11/guides/kubernetes-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes Config
 

--- a/_versions/1.11/guides/lifecycle.adoc
+++ b/_versions/1.11/guides/lifecycle.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Application Initialization and Termination
 

--- a/_versions/1.11/guides/liquibase.adoc
+++ b/_versions/1.11/guides/liquibase.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Liquibase
 

--- a/_versions/1.11/guides/logging-sentry.adoc
+++ b/_versions/1.11/guides/logging-sentry.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Logging to Sentry
 

--- a/_versions/1.11/guides/logging.adoc
+++ b/_versions/1.11/guides/logging.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuring Logging
 

--- a/_versions/1.11/guides/mailer.adoc
+++ b/_versions/1.11/guides/mailer.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Sending emails
 

--- a/_versions/1.11/guides/maven-tooling.adoc
+++ b/_versions/1.11/guides/maven-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building applications with Maven
 

--- a/_versions/1.11/guides/micrometer.adoc
+++ b/_versions/1.11/guides/micrometer.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Micrometer Metrics
 

--- a/_versions/1.11/guides/microprofile-fault-tolerance.adoc
+++ b/_versions/1.11/guides/microprofile-fault-tolerance.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Fault Tolerance
 

--- a/_versions/1.11/guides/microprofile-graphql.adoc
+++ b/_versions/1.11/guides/microprofile-graphql.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - GraphQL
 

--- a/_versions/1.11/guides/microprofile-health.adoc
+++ b/_versions/1.11/guides/microprofile-health.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - MicroProfile Health
 

--- a/_versions/1.11/guides/microprofile-metrics.adoc
+++ b/_versions/1.11/guides/microprofile-metrics.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - MicroProfile Metrics
 

--- a/_versions/1.11/guides/mongodb-panache.adoc
+++ b/_versions/1.11/guides/mongodb-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified MongoDB with Panache
 

--- a/_versions/1.11/guides/mongodb.adoc
+++ b/_versions/1.11/guides/mongodb.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the MongoDB Client
 include::./attributes.adoc[]

--- a/_versions/1.11/guides/native-and-ssl.adoc
+++ b/_versions/1.11/guides/native-and-ssl.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using SSL With Native Executables
 

--- a/_versions/1.11/guides/neo4j.adoc
+++ b/_versions/1.11/guides/neo4j.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Neo4j
 :neo4j_version: 4.0.0

--- a/_versions/1.11/guides/openapi-swaggerui.adoc
+++ b/_versions/1.11/guides/openapi-swaggerui.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenAPI and Swagger UI
 

--- a/_versions/1.11/guides/opentracing.adoc
+++ b/_versions/1.11/guides/opentracing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenTracing
 

--- a/_versions/1.11/guides/optaplanner.adoc
+++ b/_versions/1.11/guides/optaplanner.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = OptaPlanner - Using AI to optimize a schedule with OptaPlanner
 

--- a/_versions/1.11/guides/performance-measure.adoc
+++ b/_versions/1.11/guides/performance-measure.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Measuring Performance
 

--- a/_versions/1.11/guides/picocli.adoc
+++ b/_versions/1.11/guides/picocli.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Command Mode with Picocli
 :extension-status: experimental

--- a/_versions/1.11/guides/platform.adoc
+++ b/_versions/1.11/guides/platform.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Platform
 

--- a/_versions/1.11/guides/quartz.adoc
+++ b/_versions/1.11/guides/quartz.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduling Periodic Tasks with Quartz
 

--- a/_versions/1.11/guides/qute-reference.adoc
+++ b/_versions/1.11/guides/qute-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Qute Reference Guide
 

--- a/_versions/1.11/guides/qute.adoc
+++ b/_versions/1.11/guides/qute.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Qute Templating Engine
 :extension-status: experimental

--- a/_versions/1.11/guides/reactive-event-bus.adoc
+++ b/_versions/1.11/guides/reactive-event-bus.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the event bus
 

--- a/_versions/1.11/guides/reactive-messaging-http.adoc
+++ b/_versions/1.11/guides/reactive-messaging-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HTTP and WebSockets with Reactive Messaging
 

--- a/_versions/1.11/guides/reactive-routes.adoc
+++ b/_versions/1.11/guides/reactive-routes.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Reactive Routes
 

--- a/_versions/1.11/guides/reactive-sql-clients.adoc
+++ b/_versions/1.11/guides/reactive-sql-clients.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reactive SQL Clients
 

--- a/_versions/1.11/guides/redis.adoc
+++ b/_versions/1.11/guides/redis.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the Redis Client
 :extension-status: preview

--- a/_versions/1.11/guides/rest-client-multipart.adoc
+++ b/_versions/1.11/guides/rest-client-multipart.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the REST Client with Multipart
 

--- a/_versions/1.11/guides/rest-client.adoc
+++ b/_versions/1.11/guides/rest-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the REST Client
 

--- a/_versions/1.11/guides/rest-data-panache.adoc
+++ b/_versions/1.11/guides/rest-data-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Generating JAX-RS resources with Panache
 

--- a/_versions/1.11/guides/rest-json.adoc
+++ b/_versions/1.11/guides/rest-json.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing JSON REST Services
 

--- a/_versions/1.11/guides/resteasy-reactive.adoc
+++ b/_versions/1.11/guides/resteasy-reactive.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing REST Services with RESTEasy Reactive
 

--- a/_versions/1.11/guides/scheduler-reference.adoc
+++ b/_versions/1.11/guides/scheduler-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduler Reference Guide
 

--- a/_versions/1.11/guides/scheduler.adoc
+++ b/_versions/1.11/guides/scheduler.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduling Periodic Tasks
 

--- a/_versions/1.11/guides/scripting.adoc
+++ b/_versions/1.11/guides/scripting.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scripting with Quarkus
 include::./attributes.adoc[]

--- a/_versions/1.11/guides/security-authorization.adoc
+++ b/_versions/1.11/guides/security-authorization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Authorization of Web Endpoints
 

--- a/_versions/1.11/guides/security-built-in-authentication.adoc
+++ b/_versions/1.11/guides/security-built-in-authentication.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Built-In Authentication Support
 

--- a/_versions/1.11/guides/security-customization.adoc
+++ b/_versions/1.11/guides/security-customization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Tips and Tricks
 

--- a/_versions/1.11/guides/security-jdbc.adoc
+++ b/_versions/1.11/guides/security-jdbc.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with JDBC
 

--- a/_versions/1.11/guides/security-jpa.adoc
+++ b/_versions/1.11/guides/security-jpa.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with JPA
 

--- a/_versions/1.11/guides/security-jwt.adoc
+++ b/_versions/1.11/guides/security-jwt.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using JWT RBAC
 

--- a/_versions/1.11/guides/security-keycloak-authorization.adoc
+++ b/_versions/1.11/guides/security-keycloak-authorization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect and Keycloak to Centralize Authorization
 

--- a/_versions/1.11/guides/security-ldap.adoc
+++ b/_versions/1.11/guides/security-ldap.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with an LDAP Realm
 

--- a/_versions/1.11/guides/security-oauth2.adoc
+++ b/_versions/1.11/guides/security-oauth2.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OAuth2 RBAC
 

--- a/_versions/1.11/guides/security-openid-connect-client.adoc
+++ b/_versions/1.11/guides/security-openid-connect-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect and OAuth2 Client and Filters to manage access tokens
 

--- a/_versions/1.11/guides/security-openid-connect-multitenancy.adoc
+++ b/_versions/1.11/guides/security-openid-connect-multitenancy.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect Multi-Tenancy
 

--- a/_versions/1.11/guides/security-openid-connect-web-authentication.adoc
+++ b/_versions/1.11/guides/security-openid-connect-web-authentication.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect to Protect Web Applications using Authorization Code Flow.
 

--- a/_versions/1.11/guides/security-openid-connect.adoc
+++ b/_versions/1.11/guides/security-openid-connect.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect to Protect Service Applications using Bearer Token Authorization
 

--- a/_versions/1.11/guides/security-properties.adoc
+++ b/_versions/1.11/guides/security-properties.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with .properties File
 

--- a/_versions/1.11/guides/security-testing.adoc
+++ b/_versions/1.11/guides/security-testing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Testing
 

--- a/_versions/1.11/guides/security.adoc
+++ b/_versions/1.11/guides/security.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Architecture and Guides
 

--- a/_versions/1.11/guides/software-transactional-memory.adoc
+++ b/_versions/1.11/guides/software-transactional-memory.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Software Transactional Memory in Quarkus
 

--- a/_versions/1.11/guides/spring-boot-properties.adoc
+++ b/_versions/1.11/guides/spring-boot-properties.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Accessing application properties with Spring Boot properties API
 

--- a/_versions/1.11/guides/spring-cache.adoc
+++ b/_versions/1.11/guides/spring-cache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Cache API
 

--- a/_versions/1.11/guides/spring-cloud-config-client.adoc
+++ b/_versions/1.11/guides/spring-cloud-config-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reading properties from Spring Cloud Config Server
 

--- a/_versions/1.11/guides/spring-data-jpa.adoc
+++ b/_versions/1.11/guides/spring-data-jpa.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Extension for Spring Data API
 
@@ -596,7 +596,7 @@ quarkus.hibernate-orm.implicit-naming-strategy=org.springframework.boot.orm.jpa.
 
 ==== More examples
 
-An extensive list of examples can be seen in the https://github.com/quarkusio/quarkus/tree/master/integration-tests/spring-data-jpa[integration tests] directory which is located inside the Quarkus source code.
+An extensive list of examples can be seen in the https://github.com/quarkusio/quarkus/tree/main/integration-tests/spring-data-jpa[integration tests] directory which is located inside the Quarkus source code.
 
 === What is currently unsupported
 

--- a/_versions/1.11/guides/spring-data-rest.adoc
+++ b/_versions/1.11/guides/spring-data-rest.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Extension for Spring Data REST
 

--- a/_versions/1.11/guides/spring-di.adoc
+++ b/_versions/1.11/guides/spring-di.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring DI API
 

--- a/_versions/1.11/guides/spring-scheduled.adoc
+++ b/_versions/1.11/guides/spring-scheduled.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Scheduling API
 

--- a/_versions/1.11/guides/spring-security.adoc
+++ b/_versions/1.11/guides/spring-security.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Security API
 

--- a/_versions/1.11/guides/spring-web.adoc
+++ b/_versions/1.11/guides/spring-web.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Web API
 

--- a/_versions/1.11/guides/tests-with-coverage.adoc
+++ b/_versions/1.11/guides/tests-with-coverage.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Measuring the coverage of your tests
 

--- a/_versions/1.11/guides/tika.adoc
+++ b/_versions/1.11/guides/tika.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Tika
 

--- a/_versions/1.11/guides/tooling.adoc
+++ b/_versions/1.11/guides/tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using our Tooling
 

--- a/_versions/1.11/guides/transaction.adoc
+++ b/_versions/1.11/guides/transaction.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Transactions in Quarkus
 

--- a/_versions/1.11/guides/validation.adoc
+++ b/_versions/1.11/guides/validation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Validation with Hibernate Validator
 

--- a/_versions/1.11/guides/vault-auth.adoc
+++ b/_versions/1.11/guides/vault-auth.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Working with HashiCorp Vault’s Authentication
 

--- a/_versions/1.11/guides/vault-datasource.adoc
+++ b/_versions/1.11/guides/vault-datasource.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault with Databases
 

--- a/_versions/1.11/guides/vault-transit.adoc
+++ b/_versions/1.11/guides/vault-transit.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault's Transit Secret Engine
 

--- a/_versions/1.11/guides/vault.adoc
+++ b/_versions/1.11/guides/vault.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault
 

--- a/_versions/1.11/guides/vertx.adoc
+++ b/_versions/1.11/guides/vertx.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Eclipse Vert.x
 

--- a/_versions/1.11/guides/websockets.adoc
+++ b/_versions/1.11/guides/websockets.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using WebSockets
 

--- a/_versions/1.11/guides/writing-extensions.adoc
+++ b/_versions/1.11/guides/writing-extensions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing Your Own Extension
 

--- a/_versions/1.11/guides/writing-native-applications-tips.adoc
+++ b/_versions/1.11/guides/writing-native-applications-tips.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Tips for writing native applications
 

--- a/_versions/1.7/guides/all-config.adoc
+++ b/_versions/1.7/guides/all-config.adoc
@@ -4,7 +4,7 @@ layout: guides-configuration-reference
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - All configuration options
 

--- a/_versions/1.7/guides/amazon-dynamodb.adoc
+++ b/_versions/1.7/guides/amazon-dynamodb.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon DynamoDB Client
 :extension-status: preview

--- a/_versions/1.7/guides/amazon-kms.adoc
+++ b/_versions/1.7/guides/amazon-kms.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon KMS Client
 :extension-status: preview

--- a/_versions/1.7/guides/amazon-lambda-http.adoc
+++ b/_versions/1.7/guides/amazon-lambda-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon Lambda with RESTEasy, Undertow, or Vert.x Web 
 :extension-status: preview

--- a/_versions/1.7/guides/amazon-lambda.adoc
+++ b/_versions/1.7/guides/amazon-lambda.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon Lambda
 :extension-status: preview

--- a/_versions/1.7/guides/amazon-s3.adoc
+++ b/_versions/1.7/guides/amazon-s3.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon S3 Client
 

--- a/_versions/1.7/guides/amazon-ses.adoc
+++ b/_versions/1.7/guides/amazon-ses.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SES Client
 :extension-status: preview

--- a/_versions/1.7/guides/amazon-sns.adoc
+++ b/_versions/1.7/guides/amazon-sns.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SNS Client
 :extension-status: preview

--- a/_versions/1.7/guides/amazon-sqs.adoc
+++ b/_versions/1.7/guides/amazon-sqs.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Amazon SQS Client
 :extension-status: preview

--- a/_versions/1.7/guides/amqp.adoc
+++ b/_versions/1.7/guides/amqp.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using AMQP with Reactive Messaging
 :extension-status: preview

--- a/_versions/1.7/guides/azure-functions-http.adoc
+++ b/_versions/1.7/guides/azure-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Azure Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
 :extension-status: preview

--- a/_versions/1.7/guides/blaze-persistence.adoc
+++ b/_versions/1.7/guides/blaze-persistence.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Blaze-Persistence
 

--- a/_versions/1.7/guides/building-my-first-extension.adoc
+++ b/_versions/1.7/guides/building-my-first-extension.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building my first extension
 

--- a/_versions/1.7/guides/building-native-image.adoc
+++ b/_versions/1.7/guides/building-native-image.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building a Native Executable
 

--- a/_versions/1.7/guides/building-substrate-howto.adoc
+++ b/_versions/1.7/guides/building-substrate-howto.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building a Custom SubstrateVM
 

--- a/_versions/1.7/guides/cache.adoc
+++ b/_versions/1.7/guides/cache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Application Data Caching
 :extension-status: preview

--- a/_versions/1.7/guides/camel.adoc
+++ b/_versions/1.7/guides/camel.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Apache Camel on Quarkus
 

--- a/_versions/1.7/guides/cassandra.adoc
+++ b/_versions/1.7/guides/cassandra.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the Cassandra Client
 

--- a/_versions/1.7/guides/cdi-reference.adoc
+++ b/_versions/1.7/guides/cdi-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Contexts and Dependency Injection
 

--- a/_versions/1.7/guides/cdi.adoc
+++ b/_versions/1.7/guides/cdi.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Introduction to Contexts and Dependency Injection
 

--- a/_versions/1.7/guides/centralized-log-management.adoc
+++ b/_versions/1.7/guides/centralized-log-management.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Centralized log management (Graylog, Logstash, Fluentd)
 

--- a/_versions/1.7/guides/class-loading-reference.adoc
+++ b/_versions/1.7/guides/class-loading-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Class Loading Reference
 

--- a/_versions/1.7/guides/cli-tooling.adoc
+++ b/_versions/1.7/guides/cli-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Quarkus Command Line Interface (CLI)
 

--- a/_versions/1.7/guides/command-mode-reference.adoc
+++ b/_versions/1.7/guides/command-mode-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Command Mode Applications
 

--- a/_versions/1.7/guides/config.adoc
+++ b/_versions/1.7/guides/config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuring Your Application
 

--- a/_versions/1.7/guides/consul-config.adoc
+++ b/_versions/1.7/guides/consul-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reading properties from Consul
 

--- a/_versions/1.7/guides/container-image.adoc
+++ b/_versions/1.7/guides/container-image.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Container Images
 

--- a/_versions/1.7/guides/context-propagation.adoc
+++ b/_versions/1.7/guides/context-propagation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Context Propagation in Quarkus
 

--- a/_versions/1.7/guides/credentials-provider.adoc
+++ b/_versions/1.7/guides/credentials-provider.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using a Credentials Provider
 

--- a/_versions/1.7/guides/datasource.adoc
+++ b/_versions/1.7/guides/datasource.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Datasources
 

--- a/_versions/1.7/guides/deploying-to-azure-cloud.adoc
+++ b/_versions/1.7/guides/deploying-to-azure-cloud.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying to Microsoft Azure Cloud
 

--- a/_versions/1.7/guides/deploying-to-kubernetes.adoc
+++ b/_versions/1.7/guides/deploying-to-kubernetes.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes extension
 

--- a/_versions/1.7/guides/deploying-to-openshift.adoc
+++ b/_versions/1.7/guides/deploying-to-openshift.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Deploying on OpenShift
 

--- a/_versions/1.7/guides/elasticsearch.adoc
+++ b/_versions/1.7/guides/elasticsearch.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Connecting to an Elasticsearch cluster
 include::./attributes.adoc[]

--- a/_versions/1.7/guides/flyway.adoc
+++ b/_versions/1.7/guides/flyway.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Flyway
 

--- a/_versions/1.7/guides/funqy-amazon-lambda-http.adoc
+++ b/_versions/1.7/guides/funqy-amazon-lambda-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Amazon Lambda 
 :extension-status: preview

--- a/_versions/1.7/guides/funqy-amazon-lambda.adoc
+++ b/_versions/1.7/guides/funqy-amazon-lambda.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Amazon Lambda Binding
 :extension-status: preview

--- a/_versions/1.7/guides/funqy-azure-functions-http.adoc
+++ b/_versions/1.7/guides/funqy-azure-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding with Azure Functions
 :extension-status: preview

--- a/_versions/1.7/guides/funqy-gcp-functions.adoc
+++ b/_versions/1.7/guides/funqy-gcp-functions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Google Cloud Functions
 :extension-status: experimental

--- a/_versions/1.7/guides/funqy-http.adoc
+++ b/_versions/1.7/guides/funqy-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy HTTP Binding (Standalone)
 

--- a/_versions/1.7/guides/funqy-knative-events.adoc
+++ b/_versions/1.7/guides/funqy-knative-events.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy Knative Events Binding
 

--- a/_versions/1.7/guides/funqy.adoc
+++ b/_versions/1.7/guides/funqy.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Funqy
 

--- a/_versions/1.7/guides/gcp-functions-http.adoc
+++ b/_versions/1.7/guides/gcp-functions-http.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web
 :extension-status: experimental

--- a/_versions/1.7/guides/gcp-functions.adoc
+++ b/_versions/1.7/guides/gcp-functions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Google Cloud Functions (Serverless)
 :extension-status: experimental

--- a/_versions/1.7/guides/getting-started-reactive.adoc
+++ b/_versions/1.7/guides/getting-started-reactive.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Getting started with Reactive
 

--- a/_versions/1.7/guides/getting-started-testing.adoc
+++ b/_versions/1.7/guides/getting-started-testing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Testing Your Application
 

--- a/_versions/1.7/guides/getting-started.adoc
+++ b/_versions/1.7/guides/getting-started.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Creating Your First Application
 

--- a/_versions/1.7/guides/gradle-config.adoc
+++ b/_versions/1.7/guides/gradle-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Gradle Plugin Repositories
 

--- a/_versions/1.7/guides/gradle-tooling.adoc
+++ b/_versions/1.7/guides/gradle-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Gradle
 

--- a/_versions/1.7/guides/grpc-getting-started.adoc
+++ b/_versions/1.7/guides/grpc-getting-started.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started with gRPC
 

--- a/_versions/1.7/guides/grpc-service-consumption.adoc
+++ b/_versions/1.7/guides/grpc-service-consumption.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Consuming a gRPC Service
 

--- a/_versions/1.7/guides/grpc-service-implementation.adoc
+++ b/_versions/1.7/guides/grpc-service-implementation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Implementing a gRPC Service
 

--- a/_versions/1.7/guides/grpc.adoc
+++ b/_versions/1.7/guides/grpc.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus gRPC
 

--- a/_versions/1.7/guides/hibernate-orm-panache-kotlin.adoc
+++ b/_versions/1.7/guides/hibernate-orm-panache-kotlin.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified Hibernate ORM with Panache and Kotlin
 

--- a/_versions/1.7/guides/hibernate-orm-panache.adoc
+++ b/_versions/1.7/guides/hibernate-orm-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified Hibernate ORM with Panache
 

--- a/_versions/1.7/guides/hibernate-orm.adoc
+++ b/_versions/1.7/guides/hibernate-orm.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Hibernate ORM and JPA
 

--- a/_versions/1.7/guides/hibernate-search-elasticsearch.adoc
+++ b/_versions/1.7/guides/hibernate-search-elasticsearch.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Hibernate Search guide
 :extension-status: preview

--- a/_versions/1.7/guides/http-reference.adoc
+++ b/_versions/1.7/guides/http-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - HTTP Reference
 

--- a/_versions/1.7/guides/infinispan-client.adoc
+++ b/_versions/1.7/guides/infinispan-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Infinispan Client
 

--- a/_versions/1.7/guides/infinispan-embedded.adoc
+++ b/_versions/1.7/guides/infinispan-embedded.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Infinispan Embedded
 :extension-status: preview

--- a/_versions/1.7/guides/jgit.adoc
+++ b/_versions/1.7/guides/jgit.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - JGit
 

--- a/_versions/1.7/guides/jms.adoc
+++ b/_versions/1.7/guides/jms.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using JMS
 include::./attributes.adoc[]

--- a/_versions/1.7/guides/kafka-streams.adoc
+++ b/_versions/1.7/guides/kafka-streams.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Kafka Streams
 

--- a/_versions/1.7/guides/kafka.adoc
+++ b/_versions/1.7/guides/kafka.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Kafka with Reactive Messaging
 

--- a/_versions/1.7/guides/kogito.adoc
+++ b/_versions/1.7/guides/kogito.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Kogito to add business automation capabilities to an application
 

--- a/_versions/1.7/guides/kotlin.adoc
+++ b/_versions/1.7/guides/kotlin.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Kotlin
 

--- a/_versions/1.7/guides/kubernetes-client.adoc
+++ b/_versions/1.7/guides/kubernetes-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes Client
 

--- a/_versions/1.7/guides/kubernetes-config.adoc
+++ b/_versions/1.7/guides/kubernetes-config.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes Config
 

--- a/_versions/1.7/guides/kubernetes.adoc
+++ b/_versions/1.7/guides/kubernetes.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Kubernetes extension
 

--- a/_versions/1.7/guides/lifecycle.adoc
+++ b/_versions/1.7/guides/lifecycle.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Application Initialization and Termination
 

--- a/_versions/1.7/guides/liquibase.adoc
+++ b/_versions/1.7/guides/liquibase.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Liquibase
 

--- a/_versions/1.7/guides/logging-sentry.adoc
+++ b/_versions/1.7/guides/logging-sentry.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Logging to Sentry
 

--- a/_versions/1.7/guides/logging.adoc
+++ b/_versions/1.7/guides/logging.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Configuring Logging
 

--- a/_versions/1.7/guides/mailer.adoc
+++ b/_versions/1.7/guides/mailer.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Sending emails
 

--- a/_versions/1.7/guides/maven-tooling.adoc
+++ b/_versions/1.7/guides/maven-tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Building applications with Maven
 

--- a/_versions/1.7/guides/microprofile-fault-tolerance.adoc
+++ b/_versions/1.7/guides/microprofile-fault-tolerance.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Fault Tolerance
 

--- a/_versions/1.7/guides/microprofile-graphql.adoc
+++ b/_versions/1.7/guides/microprofile-graphql.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - GraphQL
 

--- a/_versions/1.7/guides/microprofile-health.adoc
+++ b/_versions/1.7/guides/microprofile-health.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - MicroProfile Health
 

--- a/_versions/1.7/guides/microprofile-metrics.adoc
+++ b/_versions/1.7/guides/microprofile-metrics.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - MicroProfile Metrics
 

--- a/_versions/1.7/guides/mongodb-panache.adoc
+++ b/_versions/1.7/guides/mongodb-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Simplified MongoDB with Panache
 

--- a/_versions/1.7/guides/mongodb.adoc
+++ b/_versions/1.7/guides/mongodb.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the MongoDB Client
 include::./attributes.adoc[]

--- a/_versions/1.7/guides/native-and-ssl.adoc
+++ b/_versions/1.7/guides/native-and-ssl.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using SSL With Native Executables
 

--- a/_versions/1.7/guides/neo4j.adoc
+++ b/_versions/1.7/guides/neo4j.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Neo4j
 :neo4j_version: 4.0.0

--- a/_versions/1.7/guides/openapi-swaggerui.adoc
+++ b/_versions/1.7/guides/openapi-swaggerui.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenAPI and Swagger UI
 

--- a/_versions/1.7/guides/opentracing.adoc
+++ b/_versions/1.7/guides/opentracing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenTracing
 

--- a/_versions/1.7/guides/optaplanner.adoc
+++ b/_versions/1.7/guides/optaplanner.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = OptaPlanner - Using AI to optimize a schedule with OptaPlanner
 

--- a/_versions/1.7/guides/performance-measure.adoc
+++ b/_versions/1.7/guides/performance-measure.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Measuring Performance
 

--- a/_versions/1.7/guides/picocli.adoc
+++ b/_versions/1.7/guides/picocli.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Command Mode with Picocli
 :extension-status: experimental

--- a/_versions/1.7/guides/quartz.adoc
+++ b/_versions/1.7/guides/quartz.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduling Periodic Tasks with Quartz
 

--- a/_versions/1.7/guides/qute-reference.adoc
+++ b/_versions/1.7/guides/qute-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Qute Reference Guide
 

--- a/_versions/1.7/guides/qute.adoc
+++ b/_versions/1.7/guides/qute.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Qute Templating Engine
 :extension-status: experimental

--- a/_versions/1.7/guides/reactive-event-bus.adoc
+++ b/_versions/1.7/guides/reactive-event-bus.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the event bus
 

--- a/_versions/1.7/guides/reactive-messaging.adoc
+++ b/_versions/1.7/guides/reactive-messaging.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Asynchronous messages between beans
 

--- a/_versions/1.7/guides/reactive-routes.adoc
+++ b/_versions/1.7/guides/reactive-routes.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Reactive Routes
 

--- a/_versions/1.7/guides/reactive-sql-clients.adoc
+++ b/_versions/1.7/guides/reactive-sql-clients.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reactive SQL Clients
 

--- a/_versions/1.7/guides/redis.adoc
+++ b/_versions/1.7/guides/redis.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the Redis Client
 :extension-status: preview

--- a/_versions/1.7/guides/rest-client-multipart.adoc
+++ b/_versions/1.7/guides/rest-client-multipart.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the REST Client with Multipart
 

--- a/_versions/1.7/guides/rest-client.adoc
+++ b/_versions/1.7/guides/rest-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using the REST Client
 

--- a/_versions/1.7/guides/rest-data-panache.adoc
+++ b/_versions/1.7/guides/rest-data-panache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Generating JAX-RS resources with Panache
 

--- a/_versions/1.7/guides/rest-json.adoc
+++ b/_versions/1.7/guides/rest-json.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing JSON REST Services
 

--- a/_versions/1.7/guides/scheduler-reference.adoc
+++ b/_versions/1.7/guides/scheduler-reference.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduler Reference Guide
 

--- a/_versions/1.7/guides/scheduler.adoc
+++ b/_versions/1.7/guides/scheduler.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Scheduling Periodic Tasks
 

--- a/_versions/1.7/guides/security-authorization.adoc
+++ b/_versions/1.7/guides/security-authorization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Authorization of Web Endpoints
 

--- a/_versions/1.7/guides/security-built-in-authentication.adoc
+++ b/_versions/1.7/guides/security-built-in-authentication.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Built-In Authentication Support
 

--- a/_versions/1.7/guides/security-customization.adoc
+++ b/_versions/1.7/guides/security-customization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Tips and Tricks
 

--- a/_versions/1.7/guides/security-jdbc.adoc
+++ b/_versions/1.7/guides/security-jdbc.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with JDBC
 

--- a/_versions/1.7/guides/security-jpa.adoc
+++ b/_versions/1.7/guides/security-jpa.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with JPA
 

--- a/_versions/1.7/guides/security-jwt.adoc
+++ b/_versions/1.7/guides/security-jwt.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using JWT RBAC
 

--- a/_versions/1.7/guides/security-keycloak-authorization.adoc
+++ b/_versions/1.7/guides/security-keycloak-authorization.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect and Keycloak to Centralize Authorization
 

--- a/_versions/1.7/guides/security-ldap.adoc
+++ b/_versions/1.7/guides/security-ldap.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with an LDAP Realm
 

--- a/_versions/1.7/guides/security-oauth2.adoc
+++ b/_versions/1.7/guides/security-oauth2.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OAuth2 RBAC
 

--- a/_versions/1.7/guides/security-openid-connect-multitenancy.adoc
+++ b/_versions/1.7/guides/security-openid-connect-multitenancy.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect Multi-Tenancy
 

--- a/_versions/1.7/guides/security-openid-connect-web-authentication.adoc
+++ b/_versions/1.7/guides/security-openid-connect-web-authentication.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect to Protect Web Applications using Authorization Code Flow.
 

--- a/_versions/1.7/guides/security-openid-connect.adoc
+++ b/_versions/1.7/guides/security-openid-connect.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using OpenID Connect to Protect Service Applications using Bearer Token Authorization
 

--- a/_versions/1.7/guides/security-properties.adoc
+++ b/_versions/1.7/guides/security-properties.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Security with .properties File
 

--- a/_versions/1.7/guides/security-testing.adoc
+++ b/_versions/1.7/guides/security-testing.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Testing
 

--- a/_versions/1.7/guides/security.adoc
+++ b/_versions/1.7/guides/security.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Security Architecture and Guides
 

--- a/_versions/1.7/guides/sending-emails.adoc
+++ b/_versions/1.7/guides/sending-emails.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Sending emails
 

--- a/_versions/1.7/guides/software-transactional-memory.adoc
+++ b/_versions/1.7/guides/software-transactional-memory.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Software Transactional Memory in Quarkus
 

--- a/_versions/1.7/guides/spring-boot-properties.adoc
+++ b/_versions/1.7/guides/spring-boot-properties.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Accessing application properties with Spring Boot properties API
 

--- a/_versions/1.7/guides/spring-cache.adoc
+++ b/_versions/1.7/guides/spring-cache.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Cache API
 

--- a/_versions/1.7/guides/spring-cloud-config-client.adoc
+++ b/_versions/1.7/guides/spring-cloud-config-client.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Reading properties from Spring Cloud Config Server
 

--- a/_versions/1.7/guides/spring-data-jpa.adoc
+++ b/_versions/1.7/guides/spring-data-jpa.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Extension for Spring Data API
 
@@ -599,7 +599,7 @@ quarkus.hibernate-orm.implicit-naming-strategy=org.springframework.boot.orm.jpa.
 
 ==== More examples
 
-An extensive list of examples can be seen in the https://github.com/quarkusio/quarkus/tree/master/integration-tests/spring-data-jpa[integration tests] directory which is located inside the Quarkus source code.
+An extensive list of examples can be seen in the https://github.com/quarkusio/quarkus/tree/main/integration-tests/spring-data-jpa[integration tests] directory which is located inside the Quarkus source code.
 
 === What is currently unsupported
 

--- a/_versions/1.7/guides/spring-di.adoc
+++ b/_versions/1.7/guides/spring-di.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring DI API
 

--- a/_versions/1.7/guides/spring-scheduled.adoc
+++ b/_versions/1.7/guides/spring-scheduled.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Scheduling API
 

--- a/_versions/1.7/guides/spring-security.adoc
+++ b/_versions/1.7/guides/spring-security.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Security API
 

--- a/_versions/1.7/guides/spring-web.adoc
+++ b/_versions/1.7/guides/spring-web.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Quarkus Extension for Spring Web API
 

--- a/_versions/1.7/guides/tests-with-coverage.adoc
+++ b/_versions/1.7/guides/tests-with-coverage.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Measuring the coverage of your tests
 

--- a/_versions/1.7/guides/tika.adoc
+++ b/_versions/1.7/guides/tika.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Apache Tika
 

--- a/_versions/1.7/guides/tooling.adoc
+++ b/_versions/1.7/guides/tooling.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using our Tooling
 

--- a/_versions/1.7/guides/transaction.adoc
+++ b/_versions/1.7/guides/transaction.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Transactions in Quarkus
 

--- a/_versions/1.7/guides/validation.adoc
+++ b/_versions/1.7/guides/validation.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Validation with Hibernate Validator
 

--- a/_versions/1.7/guides/vault-auth.adoc
+++ b/_versions/1.7/guides/vault-auth.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Working with HashiCorp Vault’s Authentication
 

--- a/_versions/1.7/guides/vault-datasource.adoc
+++ b/_versions/1.7/guides/vault-datasource.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault with Databases
 

--- a/_versions/1.7/guides/vault-transit.adoc
+++ b/_versions/1.7/guides/vault-transit.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault's Transit Secret Engine
 

--- a/_versions/1.7/guides/vault.adoc
+++ b/_versions/1.7/guides/vault.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using HashiCorp Vault
 

--- a/_versions/1.7/guides/vertx.adoc
+++ b/_versions/1.7/guides/vertx.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using Eclipse Vert.x
 

--- a/_versions/1.7/guides/websockets.adoc
+++ b/_versions/1.7/guides/websockets.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Using WebSockets
 

--- a/_versions/1.7/guides/writing-extensions.adoc
+++ b/_versions/1.7/guides/writing-extensions.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Writing Your Own Extension
 

--- a/_versions/1.7/guides/writing-native-applications-tips.adoc
+++ b/_versions/1.7/guides/writing-native-applications-tips.adoc
@@ -1,7 +1,7 @@
 ////
 This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus - Tips for writing native applications
 

--- a/faq.adoc
+++ b/faq.adoc
@@ -44,7 +44,7 @@ Oh yeah! We had quite a few extensions written outside the Quarkus "initial" tea
 
 Quarkus is an open ecosystem and we hope to see all the extensions people need to write their apps. We are working as we speak to allow an extension to be published in separate repos and separate GAVs and thus published in Maven repos independently of Quarkus core. This will greatly simplify the publication process. Expect news soon.
 
-The one current restriction is that extensions should work in both OpenJDK and GraalVM native executables. That is the guarantee we give Quarkus users (a cross compilation for their app). We have a maturity model to improve an extension to be fully "Quarked" and benefit from Quarkus, all done in incremental steps. Just hop on our https://quarkus.io/community/#discussions[mailing list] to discuss your ideas and get help. And you can start reading our https://quarkus.io/guides/writing-extensions[Writing extensions guide] as well or more simply get inspiration from the https://github.com/quarkusio/quarkus/tree/master/extensions[existing ones].
+The one current restriction is that extensions should work in both OpenJDK and GraalVM native executables. That is the guarantee we give Quarkus users (a cross compilation for their app). We have a maturity model to improve an extension to be fully "Quarked" and benefit from Quarkus, all done in incremental steps. Just hop on our https://quarkus.io/community/#discussions[mailing list] to discuss your ideas and get help. And you can start reading our https://quarkus.io/guides/writing-extensions[Writing extensions guide] as well or more simply get inspiration from the https://github.com/quarkusio/quarkus/tree/main/extensions[existing ones].
 
 
 ## What is GraalVM?


### PR DESCRIPTION
It's mentioned in many places to use the https://github.com/quarkusio/quarkus/tree/master/docs/src/master/asciidoc URL for contributing guides. That URL has now changed to https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc.

This PR updates that URL in the docs, and in the headers of all the versioned guides. 

See https://source.redhat.com/aboutredhat/weareredhat/inclusion/diversity__inclusion_wiki/conscious_language_project_faq for the reasons why we are making these changes and for guidance. 