### PR TITLE
Updated the quarkus-tree-url variables (master -> main)

### DIFF
--- a/_guides/attributes.adoc
+++ b/_guides/attributes.adoc
@@ -20,7 +20,7 @@
 :quarkus-base-url: https://github.com/quarkusio/quarkus
 :quarkus-clone-url: https://github.com/quarkusio/quarkus.git
 :quarkus-archive-url: https://github.com/quarkusio/quarkus/archive/master.zip
-:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/master
+:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/main
 :quarkus-issues-url: https://github.com/quarkusio/quarkus/issues
 :quarkus-images-url: https://github.com/quarkusio/quarkus-images/tree
 :quarkus-chat-url: https://quarkusio.zulipchat.com

--- a/_versions/1.11/guides/attributes.adoc
+++ b/_versions/1.11/guides/attributes.adoc
@@ -19,7 +19,7 @@
 :quarkus-base-url: https://github.com/quarkusio/quarkus
 :quarkus-clone-url: https://github.com/quarkusio/quarkus.git
 :quarkus-archive-url: https://github.com/quarkusio/quarkus/archive/master.zip
-:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/master
+:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/main
 :quarkus-issues-url: https://github.com/quarkusio/quarkus/issues
 :quarkus-images-url: https://github.com/quarkusio/quarkus-images/tree
 :quarkus-chat-url: https://quarkusio.zulipchat.com

--- a/_versions/1.7/guides/attributes.adoc
+++ b/_versions/1.7/guides/attributes.adoc
@@ -19,7 +19,7 @@
 :quarkus-base-url: https://github.com/quarkusio/quarkus
 :quarkus-clone-url: https://github.com/quarkusio/quarkus.git
 :quarkus-archive-url: https://github.com/quarkusio/quarkus/archive/master.zip
-:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/master
+:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/main
 :quarkus-issues-url: https://github.com/quarkusio/quarkus/issues
 :quarkus-images-url: https://github.com/quarkusio/quarkus-images/tree
 :quarkus-chat-url: https://quarkusio.zulipchat.com

--- a/_versions/main/guides/attributes.adoc
+++ b/_versions/main/guides/attributes.adoc
@@ -20,7 +20,7 @@
 :quarkus-base-url: https://github.com/quarkusio/quarkus
 :quarkus-clone-url: https://github.com/quarkusio/quarkus.git
 :quarkus-archive-url: https://github.com/quarkusio/quarkus/archive/master.zip
-:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/master
+:quarkus-tree-url: https://github.com/quarkusio/quarkus/tree/main
 :quarkus-issues-url: https://github.com/quarkusio/quarkus/issues
 :quarkus-images-url: https://github.com/quarkusio/quarkus-images/tree
 :quarkus-chat-url: https://quarkusio.zulipchat.com


### PR DESCRIPTION
Updating the `quarkus-tree-url` variable to point to the updated Quarkus repo URL, that has renamed the `master` branch to `main`.

I've not checked every usage of the `quarkus-tree-url` variable, but I don't see any situations in which the rename would break. 

See https://source.redhat.com/aboutredhat/weareredhat/inclusion/diversity__inclusion_wiki/conscious_language_project_faq for the reasons why we are making these changes and for guidance.