### PR TITLE
Fix changelog link for 2.2.3

### DIFF
--- a/_posts/2021-09-16-quarkus-2-2-3-final-released.adoc
+++ b/_posts/2021-09-16-quarkus-2-2-3-final-released.adoc
@@ -15,7 +15,7 @@ If you are not using 2.2 already, please refer to the https://github.com/quarkus
 
 == Full changelog
 
-You can get https://github.com/quarkusio/quarkus/releases/tag/2.2.2.Final[the full changelog of 2.2.2.Final on GitHub].
+You can get https://github.com/quarkusio/quarkus/releases/tag/2.2.3.Final[the full changelog of 2.2.3.Final on GitHub].
 
 == Come Join Us
 


### PR DESCRIPTION
This fixes the changelog link in the blog post. It was still pointing to 2.2.2.Final