### PR TITLE
Add a 'security' keyword to all security guides

### DIFF
--- a/_data/guides-latest.yaml
+++ b/_data/guides-latest.yaml
@@ -105,9 +105,6 @@ categories:
       - title: Using the Reactive REST Client
         url: /guides/rest-client-reactive
         description: This guide explains how to use the RESTEasy Reactive REST Client.
-      - title: Using JWT RBAC
-        url: /guides/security-jwt
-        description: This guide explains how your application can utilize SmallRye JWT to provide secured access to the JAX-RS endpoints.
       - title: Using WebSockets
         url: /guides/websockets
         description: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications. Because it’s the canonical web socket application, we are going to create a simple chat application.
@@ -265,62 +262,75 @@ categories:
       - title: Security Overview
         url: /guides/security
         description: This guide is the entry point for everything security in Quarkus.
+        keywords: security
       - title: Using Security with .properties File
         url: /guides/security-properties
         description: This guide demonstrates how your Quarkus application can use a .properties file to store your user identities.
+        keywords: security
       - title: Using Security with JPA
         url: /guides/security-jpa
         description: This guide demonstrates how your Quarkus application can use a database to store your user identities with Hibernate ORM.
+        keywords: security
       - title: Using Security with JDBC
         url: /guides/security-jdbc
         description: This guide demonstrates how your Quarkus application can use a database to store your user identities.
+        keywords: security
       - title: Using Security with LDAP
         url: /guides/security-ldap
         description: This guide demonstrates how your Quarkus application can use a LDAP directory to store your user identities.
+        keywords: security
       - title: Using OpenID Connect (OIDC) to Protect Service Applications
         url: /guides/security-openid-connect
         description: This guide demonstrates how your Quarkus application can use Keycloak to protect your JAX-RS applications using bearer token authorization, where these tokens are issued by a Keycloak server.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) to Protect Web Applications
         url: /guides/security-openid-connect-web-authentication
         description: This guide demonstrates how to use the OpenID Connect Extension to protect your web application based on the Authorization Code Flow using Quarkus.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) Multi-Tenancy
         url: /guides/security-openid-connect-multitenancy
         description: This guide demonstrates how your OpenID Connect application can support multi-tenancy so that you can serve multiple tenants from a single application.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) and Keycloak to Centralize Authorizations
         url: /guides/security-keycloak-authorization
         description: This guide demonstrates how your Quarkus application can authorize access to protected resources using Keycloak Authorization Services.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) and OAuth2 Client and Filters
         url: /guides/security-openid-connect-client
         description: This guide explains how to use OpenID Connect and OAuth2 Client and Filters to acquire, refresh and propagate access tokens.
-        keywords: sso
+        keywords: sso,security
       - title: OpenID Connect (OIDC) Dev Services
         url: /guides/security-openid-connect-dev-services
         description: Start Keycloak or other providers automatically in dev and test modes.
+        keywords: security
       - title: Using JWT RBAC
         url: /guides/security-jwt
         description: This guide explains how your application can utilize SmallRye JWT to provide secured access to the JAX-RS endpoints.
+        keywords: security
       - title: Using OAuth2 RBAC
         url: /guides/security-oauth2
         description: This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the JAX-RS endpoints.
+        keywords: security
       - title: Using Vault
         url: /guides/vault
         description: This guide explains how you can use HashiCorp Vault to securely store your credentials in Quarkus.
+        keywords: security
       - title: Using Vault Transit Secret Engine
         url: /guides/vault-transit
         description: This guide explains how you can use HashiCorp Vault for "encryption as a service".
+        keywords: security
       - title: Using HashiCorp Vault with Databases
         url: /guides/vault-datasource
         description: Keep confidential your database credentials by storing them in Vault.
+        keywords: security
       - title: Working with HashiCorp Vault’s Authentication
         url: /guides/vault-auth
         description: This guide explains the various methods supported by Quarkus to authenticate to your Vault.
+        keywords: security
       - title: Credentials Provider
         url: /guides/credentials-provider
         description: This guides explains how to use the Vault credentials provider or implement your own custom one.
+        keywords: security
   - category: Business Automation
     cat-id: business-automation
     guides:

--- a/_data/guides-main.yaml
+++ b/_data/guides-main.yaml
@@ -105,9 +105,6 @@ categories:
       - title: Using the Reactive REST Client
         url: /guides/rest-client-reactive
         description: This guide explains how to use the RESTEasy Reactive REST Client.
-      - title: Using JWT RBAC
-        url: /guides/security-jwt
-        description: This guide explains how your application can utilize SmallRye JWT to provide secured access to the JAX-RS endpoints.
       - title: Using WebSockets
         url: /guides/websockets
         description: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications. Because it’s the canonical web socket application, we are going to create a simple chat application.
@@ -265,62 +262,75 @@ categories:
       - title: Security Overview
         url: /guides/security
         description: This guide is the entry point for everything security in Quarkus.
+        keywords: security
       - title: Using Security with .properties File
         url: /guides/security-properties
         description: This guide demonstrates how your Quarkus application can use a .properties file to store your user identities.
+        keywords: security
       - title: Using Security with JPA
         url: /guides/security-jpa
         description: This guide demonstrates how your Quarkus application can use a database to store your user identities with Hibernate ORM.
+        keywords: security
       - title: Using Security with JDBC
         url: /guides/security-jdbc
         description: This guide demonstrates how your Quarkus application can use a database to store your user identities.
+        keywords: security
       - title: Using Security with LDAP
         url: /guides/security-ldap
         description: This guide demonstrates how your Quarkus application can use a LDAP directory to store your user identities.
+        keywords: security
       - title: Using OpenID Connect (OIDC) to Protect Service Applications
         url: /guides/security-openid-connect
         description: This guide demonstrates how your Quarkus application can use Keycloak to protect your JAX-RS applications using bearer token authorization, where these tokens are issued by a Keycloak server.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) to Protect Web Applications
         url: /guides/security-openid-connect-web-authentication
         description: This guide demonstrates how to use the OpenID Connect Extension to protect your web application based on the Authorization Code Flow using Quarkus.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) Multi-Tenancy
         url: /guides/security-openid-connect-multitenancy
         description: This guide demonstrates how your OpenID Connect application can support multi-tenancy so that you can serve multiple tenants from a single application.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) and Keycloak to Centralize Authorizations
         url: /guides/security-keycloak-authorization
         description: This guide demonstrates how your Quarkus application can authorize access to protected resources using Keycloak Authorization Services.
-        keywords: sso
+        keywords: sso,security
       - title: Using OpenID Connect (OIDC) and OAuth2 Client and Filters
         url: /guides/security-openid-connect-client
         description: This guide explains how to use OpenID Connect and OAuth2 Client and Filters to acquire, refresh and propagate access tokens.
-        keywords: sso
+        keywords: sso,security
       - title: OpenID Connect (OIDC) Dev Services
         url: /guides/security-openid-connect-dev-services
         description: Start Keycloak or other providers automatically in dev and test modes.
+        keywords: security
       - title: Using JWT RBAC
         url: /guides/security-jwt
         description: This guide explains how your application can utilize SmallRye JWT to provide secured access to the JAX-RS endpoints.
+        keywords: security
       - title: Using OAuth2 RBAC
         url: /guides/security-oauth2
         description: This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the JAX-RS endpoints.
+        keywords: security
       - title: Using Vault
         url: /guides/vault
         description: This guide explains how you can use HashiCorp Vault to securely store your credentials in Quarkus.
+        keywords: security
       - title: Using Vault Transit Secret Engine
         url: /guides/vault-transit
         description: This guide explains how you can use HashiCorp Vault for "encryption as a service".
+        keywords: security
       - title: Using HashiCorp Vault with Databases
         url: /guides/vault-datasource
         description: Keep confidential your database credentials by storing them in Vault.
+        keywords: security
       - title: Working with HashiCorp Vault’s Authentication
         url: /guides/vault-auth
         description: This guide explains the various methods supported by Quarkus to authenticate to your Vault.
+        keywords: security
       - title: Credentials Provider
         url: /guides/credentials-provider
         description: This guides explains how to use the Vault credentials provider or implement your own custom one.
+        keywords: security
   - category: Business Automation
     cat-id: business-automation
     guides:


### PR DESCRIPTION
Add a security keyword to all security guides, and remove listing for the JWT guide from the web category

(related to quarkusio/quarkus#20622)

Signed-off-by: Nathan Erwin <nathan.d.erwin@gmail.com>