### PR TITLE
Add SmallRye JWT Build guide to Security guides

### DIFF
--- a/_data/guides-main.yaml
+++ b/_data/guides-main.yaml
@@ -303,11 +303,11 @@ categories:
         keywords: security
       - title: Using OpenID Connect (OIDC) to Protect Service Applications
         url: /guides/security-openid-connect
-        description: This guide demonstrates how your Quarkus application can use Keycloak to protect your JAX-RS applications using bearer token authorization, where these tokens are issued by a Keycloak server.
-        keywords: sso,security
+        description: This guide demonstrates how to use the OpenID Connect extension to protect your Quarkus JAX-RS service application using Bearer Token Authorization where the tokens are issued by OpenId Connect Providers such as Keycloak.
+        keywords: sso,jwt,security
       - title: Using OpenID Connect (OIDC) to Protect Web Applications
         url: /guides/security-openid-connect-web-authentication
-        description: This guide demonstrates how to use the OpenID Connect Extension to protect your web application based on the Authorization Code Flow using Quarkus.
+        description: This guide demonstrates how to use the OpenID Connect extension to protect your Quarkus JAX-RS web application using the Authorization Code Flow and OpenId Connect Providers such as Keycloak.
         keywords: sso,security
       - title: Using OpenID Connect (OIDC) Multi-Tenancy
         url: /guides/security-openid-connect-multitenancy
@@ -327,8 +327,12 @@ categories:
         keywords: security
       - title: Using JWT RBAC
         url: /guides/security-jwt
-        description: This guide explains how your application can utilize SmallRye JWT to provide secured access to the JAX-RS endpoints.
+        description: This guide explains how your application can utilize SmallRye JWT to verify JWT tokens and provide secured access to the JAX-RS endpoints.
         keywords: security
+      - title: Build, Sign and Encrypt JSON Web Tokens (JWT)
+        url: /guides/security-jwt-build
+        description: This guide explains how your application can build, sign and/or encrypt JWT tokens with a fluent and configurable SmallRye JWT Build API.
+        keywords: jwt,security
       - title: Using OAuth2 RBAC
         url: /guides/security-oauth2
         description: This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the JAX-RS endpoints.


### PR DESCRIPTION
This PR is a follow up to https://github.com/quarkusio/quarkus/pull/21130 which moved the smallrye-jwt-build related docs to its own dedicated guide - so this guide is also referenced from the security category here.

I've also updated a little bit OIDC and OIDC web-app guide descriptions to align them with the introductions in the respective guides