### PR TITLE
update examples of supported version in security.adoc

### DIFF
--- a/security.adoc
+++ b/security.adoc
@@ -37,9 +37,9 @@ Due to the sensitive nature of security bugs, the disclosure process is more con
 The community will fix security bugs for the latest major.minor version published at https://quarkus.io/get-started/.
 
 *Version &nbsp;&nbsp;&nbsp;&nbsp; Supported* +
-latest 1.x &nbsp;&nbsp; ✅ +
-older 1.x &nbsp;&nbsp; ❌ +
-< 1.0 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ❌
+latest 2.x &nbsp;&nbsp; ✅ +
+older 2.x &nbsp;&nbsp; ❌ +
+< 2.0 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ❌
 
 
 We may fix the vulnerability to older versions depending on the severity of the issue and the age of the release, but we are only committing to the latest version released.


### PR DESCRIPTION
This seems to be outdated, since no more 1.x releases were provided after 2.x was released