### PR TITLE
fix broken links to Discussions

### DIFF
--- a/_includes/feedback-community-band.html
+++ b/_includes/feedback-community-band.html
@@ -4,7 +4,7 @@
       <h3>Feedback and Help</h3>
       <p>For usage questions, we recommend to:</p>
       <ul>
-        <li>Use the <a href="https://github.com/quarkusio/discussions">Discussions</a> section on our Github project. </li>
+        <li>Use the <a href="https://github.com/quarkusio/quarkus/discussions">Discussions</a> section on our Github project. </li>
         <li>Ask on <a href="https://stackoverflow.com/questions/tagged/quarkus">Stack Overflow with the <code>quarkus</code> tag</a></li>
       </ul>
       <p>For questions related to the development of Quarkus:</p>

--- a/_includes/support-help-band.html
+++ b/_includes/support-help-band.html
@@ -15,7 +15,7 @@
   <div class="width-3-12 width-12-12-m help-block">
     <img src="{{site.baseurl}}/assets/images/support/icon-discussion.svg">
     <h4>Discussions and Collaboration</h4>
-    <p>Check out our <a href="https://github.com/quarkusio/discussions">Github Discussions</a> collaboration area to interact with other Quarkus users and developers.</p>
+    <p>Check out our <a href="https://github.com/quarkusio/quarkus/discussions">Github Discussions</a> collaboration area to interact with other Quarkus users and developers.</p>
   </div>
   <div class="width-3-12 width-12-12-m help-block">
     <img src="{{site.baseurl}}/assets/images/support/icon-development.svg">


### PR DESCRIPTION
Fix broken links to Discussions on the [homepage](http://quarkus.io/) and the [support](http://quarkus.io/support/) pages.