### PR TITLE
Fix typo in about.html that led to 404

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -16,7 +16,7 @@
     <div class="width-3-12 width-12-12-m">
       <img src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg">
       <h3>Kubernetes-native</h3>
-      <p>Quarkus was built from the ground up for Kubernetes making it easy to deploy applications without having to understand all of the complexities of the platform. Quarkus allows developers to automatically generate Kubernetes resources including building and deploying container images without having to manually create YAML files. <br><a href="/Kubernetes-native/">Learn more about Kubernetes-native</a></p>
+      <p>Quarkus was built from the ground up for Kubernetes making it easy to deploy applications without having to understand all of the complexities of the platform. Quarkus allows developers to automatically generate Kubernetes resources including building and deploying container images without having to manually create YAML files. <br><a href="/kubernetes-native/">Learn more about Kubernetes-native</a></p>
     </div>
     <div class="width-3-12 width-12-12-m">
       <img src="{{site.baseurl}}/assets/images/about/icon-standards.svg">


### PR DESCRIPTION
Changes link from `/Kubernetes-native/` to `/kubernetes-native/`