### PR TITLE
Fix some newsletter linking

### DIFF
--- a/_posts/2021-12-16-quarkus-newsletter-15.adoc
+++ b/_posts/2021-12-16-quarkus-newsletter-15.adoc
@@ -11,7 +11,7 @@ bibquery: ["pub.urldate > '2021-11-11'", "pub.urldate <= '2021-12-16'"]
 
 The December Newsletter has been published! This month, you can find articles about; testing a Quarkus Kafka application, exploring Java 17 features with Quarkus, Quarkus bean discovery with Jandex indexing, automating Quarkus with Gitlab, boosting throughput with RESTEasy Reactive in Quarkus 2.2, and Azure resources operator with Quarkus.
 
-Check out https://quarkus.io/newsletter/14/[Newsletter #15]!
+Check out https://quarkus.io/newsletter/15/[Newsletter #15]!
 
 Want to get newsletters in your inbox? https://quarkus.io/newsletter[Sign up for the newsletter] using the on page form.
 

--- a/_posts/2022-01-13-quarkus-newsletter-16.adoc
+++ b/_posts/2022-01-13-quarkus-newsletter-16.adoc
@@ -11,7 +11,7 @@ bibquery: ["pub.urldate > '2021-12-17'", "pub.urldate <= '2022-01-13'"]
 
 The January Newsletter has been published! This month, you can find articles about the Java InfoQ Trend report for December 2021, how to use Quarkus with the service binding operator, how to run Qurkus applications on Kubernetes, and lessons learned migrating Spring Boot to Quarkus.
 
-Check out https://quarkus.io/newsletter/14/[Newsletter #16]!
+Check out https://quarkus.io/newsletter/16/[Newsletter #16]!
 
 Want to get newsletters in your inbox? https://quarkus.io/newsletter[Sign up for the newsletter] using the on page form.
 

--- a/newsletter/15/index.html
+++ b/newsletter/15/index.html
@@ -211,7 +211,7 @@
           <tr>
             <td style="width:550px;">
               
-        <a href="https://blog.jdriven.com/2021/10/integration-testing-in-quarkus/" target="_blank">
+        <a href="https://objectpartners.com/2021/11/16/testing-a-quarkus-kafka-application/" target="_blank">
           
       <img alt="Article 1 feature image" height="auto" src="./index_files/0x0n2.png" style="border:none;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" title="" width="550">
     

--- a/newsletter/16/index.html
+++ b/newsletter/16/index.html
@@ -126,7 +126,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0px 25px 0px 0px;padding-top:0px;padding-bottom:0px;word-break:break-word;">
                   
-      <div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;"><p class="text-build-content" style="text-align: right; margin: 10px 0; margin-top: 10px; margin-bottom: 10px;" data-testid="1ITlr05D-"><a class="link-build-content" style="color:inherit;; text-decoration: none;" target="_blank" href="https://quarkus.io/newsletter/15"><span style="color:#4695EB;font-family:Open Sans;font-size:13px;line-height:22px;"><b>View online version</b></span></a></p></div>
+      <div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;"><p class="text-build-content" style="text-align: right; margin: 10px 0; margin-top: 10px; margin-bottom: 10px;" data-testid="1ITlr05D-"><a class="link-build-content" style="color:inherit;; text-decoration: none;" target="_blank" href="https://quarkus.io/newsletter/16"><span style="color:#4695EB;font-family:Open Sans;font-size:13px;line-height:22px;"><b>View online version</b></span></a></p></div>
     
                 </td>
               </tr>


### PR DESCRIPTION
The posts for newsletters 15 and 16 link to newsletter 14. Newsletter 15's title image links to the wrong article.