### PR TITLE
fix: getting started commands with jbang

### DIFF
--- a/_includes/get-started-code-steps.html
+++ b/_includes/get-started-code-steps.html
@@ -6,26 +6,29 @@
     </div>
     <div class="width-10-12 width-12-12-m">
       <h3>Install via Command Line Interface</h3>
-      <p>Open your favorite CLI and paste this script to install the Quarkus CLI.</p>
+      <p>Open your favorite terminal and use JBang to install the Quarkus CLI. You do not need to have Java installed first.</p>
       <h4>For Linux, macOS, and Windows (using WSL or bash compatible shell like Cygwin or MinGW)</h4>
           <div class= "highlighter-rouge">
             <div class="highlight">
-              <pre class="highlight"><code>curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force quarkus@quarkusio</code></pre>
+              <pre class="highlight"><code>curl -Ls https://sh.jbang.dev | bash -s - trust add https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/
+curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force quarkus@quarkusio</code></pre>
             </div>
           </div>
       <h4>For Windows using Powershell</h4>
           <div class= "highlighter-rouge">
             <div class="highlight">
-              <pre class="highlight"><code>iex "& { $(iwr https://ps.jbang.dev) } app install --fresh --force quarkus@quarkusio"</code></pre>
+              <pre class="highlight"><code>iex "& { $(iwr https://ps.jbang.dev) } trust add https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/"
+iex "& { $(iwr https://ps.jbang.dev) } app install --fresh --force quarkus@quarkusio"</code></pre>
             </div>
           </div>
-      <p>If it's your first time to install, you'll need to restart your shell.</p>
-      <h4>Or install via SDKMAN!</h4>
+      <p>If it's your first time to install, you'll need ot restart your shell.</p>
+      <h4>Or, you can also install the CLI with SDKMAN!</h4>
           <div class= "highlighter-rouge">
             <div class="highlight">
               <pre class="highlight"><code>sdk install quarkus</code></pre>
             </div>
           </div>
+      <h4>For more options, such as Homebrew or Chocolatey, see <a href="/guides/cli-tooling">the Quarkus CLI guide</a>.</h4>
     </div>
     <div class="width-2-12 width-12-12-m">
       <h2 class="step">Step <span class="step-no">2</span></h2>


### PR DESCRIPTION
Fixing this based on https://github.com/quarkusio/quarkus/issues/22723

To test this ensure you do not have ~/.jbang/trusted-sources.json in you file system or at least no trust of maven central.

The issue here is that if you are BRAND NEW user you don't have
trusted the location quarkusio jbang catalog fetches its jars from.
i.e. you have no `~/.jbang/trusted-sources.json`

Thus if you run this command first:
`curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force quarkus@quarkusio`

jbang will ask you to trust BUT curl via pipe result in no tty being available, i.e. user
can not say/answer yes; thus until jbang 0.86 we delayed that question until
you actually try and run the installed script - but as seen in #22723
that confuses people too.

So in jbang 0.87 I made it so `jbang app install` will ask you for trust,
but it does not fix the first install as here you still don't have a tty to ask user.

Thus this PR adds explicit call for trust. Then it works for initial user too.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
