### PR TITLE
Fix Guides index

### DIFF
--- a/_layouts/guides-index.html
+++ b/_layouts/guides-index.html
@@ -82,7 +82,7 @@ layout: base
           <li class="card">
               <a href="{{ guide_url }}" {% if is_external_guide %}target="_blank"{% endif %}></a>
               <p class="title">{{ guide.title }}</p>
-              <div class="description">{{ guide.description }}</div>
+              <div class="description">{{ guide.description | markdownify }}</div>
               <div class="keywords">{{ guide.keywords }}</div>
               {% if guide.origin == 'quarkiverse-hub' %}
               <div class="origin">


### PR DESCRIPTION
The description can contain Markdown. It was properly handled before but
it looks like the new design broke it.
