### PR TITLE
Add Google Cloud services guides

### DIFF
--- a/_data/guides-latest.yaml
+++ b/_data/guides-latest.yaml
@@ -128,7 +128,7 @@ categories:
         description: This guide demonstrates how your Quarkus application can utilize the SmallRye Fault Tolerance specification through the SmallRye Fault Tolerance extension.
       - title: Using Reactive Routes
         url: /guides/reactive-routes
-        description: This guide demonstrates how to use reactive routes.  
+        description: This guide demonstrates how to use reactive routes.
       - title: Implementing GraphQL Services
         url: /guides/smallrye-graphql
         description: This guide explains how to leverage SmallRye GraphQL to implement GraphQL services.
@@ -173,7 +173,7 @@ categories:
         description: This guide covers how to use Hibernate Validator/Bean Validation in your REST services.
       - title: Cache your application data
         url: /guides/cache
-        description: This guide explains how to cache expensive method calls of your CDI beans using simple annotations. 
+        description: This guide explains how to cache expensive method calls of your CDI beans using simple annotations.
       - title: Schema Migration with Flyway
         url: /guides/flyway
         description: This guide covers how to use the Flyway extension to manage your schema migrations.
@@ -183,6 +183,9 @@ categories:
       - title: Reactive SQL Clients
         url: /guides/reactive-sql-clients
         description: This guide covers how to use the Reactive SQL Clients in Quarkus.
+      - title: Using Hibernate Reactive
+        url: /guides/hibernate-reactive
+        description: Reactive API for Hibernate ORM
       - title: Simplified Hibernate Reactive with Panache
         url: /guides/hibernate-reactive-panache
         description: Simplified reactive ORM layer based on Hibernate Reactive.
@@ -206,7 +209,7 @@ categories:
         description: This guide covers the usage of MongoDB using active records and repositories in a Kotlin project.
       - title: Redis Client
         url: /guides/redis
-        description: This guide covers how to use a Redis datastore in Quarkus. 
+        description: This guide covers how to use a Redis datastore in Quarkus.
       - title: Redis Dev Services
         url: /guides/redis-dev-services
         description: Start Redis automatically in dev and test modes.
@@ -224,6 +227,26 @@ categories:
       - title: Amazon S3
         url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud BigQuery
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/bigquery.html
+        description: This guide covers how to use GCP BigQuery in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Bigtable
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/bigtable.html
+        description: This guide covers how to use GCP Bigtable in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Firestore
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/firestore.html
+        description: This guide covers how to use GCP Firestore in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Spanner
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/spanner.html
+        description: This guide covers how to use GCP Spanner in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Storage
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/storage.html
+        description: This guide covers how to use GCP Storage in Quarkus.
         origin: quarkiverse-hub
       - title: Using Software Transactional Memory
         url: /guides/software-transactional-memory
@@ -278,11 +301,14 @@ categories:
         description: This guide demonstrates how your Quarkus application can utilize the Apache Kafka Streams API to implement stream processing applications based on Apache Kafka.
       - title: Using the event bus
         url: /guides/reactive-event-bus
-        description: This guide explains how different beans can interact using the event bus.  
+        description: This guide explains how different beans can interact using the event bus.
       - title: Using JMS
         url: /guides/jms
         description: This guide demonstrates how your Quarkus application can use JMS messaging with AMQP 1.0 using Apache Qpid JMS, or using Apache ActiveMQ Artemis JMS.
-        
+      - title: Google Cloud PubSub
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/pubsub.html
+        description: This guide covers how to use GCP PubSub in Quarkus.
+        origin: quarkiverse-hub
   - category: Security
     cat-id: security
     guides:
@@ -524,6 +550,10 @@ categories:
         url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ssm.html
         description: This guide covers how to use the AWS Systems Manager in Quarkus.
         origin: quarkiverse-hub
+      - title: Access Google Cloud services
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/index.html
+        description: This guide covers how to use multiple GCP services.
+        origin: quarkiverse-hub
   - category: Observability
     cat-id: observability
     guides:
@@ -547,9 +577,9 @@ categories:
         description: This guide demonstrates how your Quarkus application can utilize the SmallRye Fault Tolerance extension.
       - title: Using Sentry to Monitor your Logs
         url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-logging-sentry/dev/index.html
-        description: This guide explains how to use Sentry to monitor your application and be notified when exceptions occur. 
+        description: This guide explains how to use Sentry to monitor your application and be notified when exceptions occur.
         origin: quarkiverse-hub
-      - title: Centralized Log Management 
+      - title: Centralized Log Management
         url: /guides/centralized-log-management
         description: This guide explains how to centralize your logs with Logstash or Fluentd using the Graylog Extended Log Format (GELF).
   - category: Serialization
@@ -662,7 +692,7 @@ categories:
         description: This reference guide explains in more details the configuration and usage of the Quarkus Mailer.
       - title: Templating with Qute
         url: /guides/qute
-        description: Learn more about how you can use templating in your applications with the Qute template engine. 
+        description: Learn more about how you can use templating in your applications with the Qute template engine.
       - title: Qute Reference Guide
         url: /guides/qute-reference
         description: Learn everything you need to know about the Qute template engine.
@@ -687,6 +717,10 @@ categories:
       - title: Measuring Performance
         url: /guides/performance-measure
         description: This guide explains how to best measure the footprint of a Quarkus application.
+      - title: Consume Configuration from Google Cloud Secret Manager
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/secretmanager.html
+        description: This guide covers how to use GCP Secret Manager in Quarkus to consume configuration properties directly or via your `application.properties`.
+        origin: quarkiverse-hub
   - category: Alternative Languages
     cat-id: alternative-languages
     guides:

--- a/_data/guides-main.yaml
+++ b/_data/guides-main.yaml
@@ -228,6 +228,26 @@ categories:
         url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
+      - title: Google Cloud BigQuery
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/bigquery.html
+        description: This guide covers how to use GCP BigQuery in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Bigtable
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/bigtable.html
+        description: This guide covers how to use GCP Bigtable in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Firestore
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/firestore.html
+        description: This guide covers how to use GCP Firestore in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Spanner
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/spanner.html
+        description: This guide covers how to use GCP Spanner in Quarkus.
+        origin: quarkiverse-hub
+      - title: Google Cloud Storage
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/storage.html
+        description: This guide covers how to use GCP Storage in Quarkus.
+        origin: quarkiverse-hub
       - title: Using Software Transactional Memory
         url: /guides/software-transactional-memory
         description: This guides covers the usage of Software Transactional Memory (STM).
@@ -285,7 +305,10 @@ categories:
       - title: Using JMS
         url: /guides/jms
         description: This guide demonstrates how your Quarkus application can use JMS messaging with AMQP 1.0 using Apache Qpid JMS, or using Apache ActiveMQ Artemis JMS.
-        
+      - title: Google Cloud PubSub
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/pubsub.html
+        description: This guide covers how to use GCP PubSub in Quarkus.
+        origin: quarkiverse-hub
   - category: Security
     cat-id: security
     guides:
@@ -527,6 +550,10 @@ categories:
         url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ssm.html
         description: This guide covers how to use the AWS Systems Manager in Quarkus.
         origin: quarkiverse-hub
+      - title: Access Google Cloud services
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/index.html
+        description: This guide covers how to use multiple GCP services.
+        origin: quarkiverse-hub
   - category: Observability
     cat-id: observability
     guides:
@@ -690,6 +717,10 @@ categories:
       - title: Measuring Performance
         url: /guides/performance-measure
         description: This guide explains how to best measure the footprint of a Quarkus application.
+      - title: Consume Configuration from Google Cloud Secret Manager
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/secretmanager.html
+        description: This guide covers how to use GCP Secret Manager in Quarkus to consume configuration properties directly or via your `application.properties`.
+        origin: quarkiverse-hub
   - category: Alternative Languages
     cat-id: alternative-languages
     guides:


### PR DESCRIPTION
@gsmet

I added a single entry to the Cloud section to avoid having too many guides on it. AWS services was added with one entry per service, maybe I should do the same ?

I added the secret manager guide under the miscelaneous section (as was done for Consul), I'm not sure it's the best place but there is no Configuration section and the core one is already packed with a lot of guide.
