### PR TITLE
update language selector for usability and official site designation.

### DIFF
--- a/_data/language.yaml
+++ b/_data/language.yaml
@@ -1,1 +1,0 @@
-headline: "The English version of Quarkus.io is the official project site. Translated sites are community supported on a best-effort basis."

--- a/_data/language.yaml
+++ b/_data/language.yaml
@@ -1,0 +1,1 @@
+headline: "The English version of Quarkus.io is the official project site. Translated sites are community supported on a best-effort basis."

--- a/_data/languages.yaml
+++ b/_data/languages.yaml
@@ -1,2 +1,2 @@
 language:
-  - headline: "The English version of Quarkus.io is the official project site. Translated sites are community supported on a best-effort basis."
+  - headline: 'The <a href="https://quarkus.io">English version of quarkus.io</a> is the official project site. Translated sites are community supported on a best-effort basis.'

--- a/_data/languages.yaml
+++ b/_data/languages.yaml
@@ -1,0 +1,2 @@
+language:
+  - headline: "The English version of Quarkus.io is the official project site. Translated sites are community supported on a best-effort basis."

--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -60,7 +60,7 @@ links:
     subfolderitems:
       - page: English
         url: https://quarkus.io/
-      - page: Japanese
+      - page: 日本語
         url: https://ja.quarkus.io/
 
 more_links:

--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -62,6 +62,9 @@ links:
         url: https://quarkus.io/
       - page: 日本語
         url: https://ja.quarkus.io/
+      - page: 简体中文
+        url: https://cn.quarkus.io/
+        
 
 more_links:
 

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -50,8 +50,8 @@
       <li class="dropdown">
         <span href="{{site.baseurl}}/language/"><div class="fas fa-globe langicon"></div><i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
-          <li><a href="https://quarkus.io/" >ENGLISH</a></li>
-          <li><a href="https://ja.quarkus.io/">JAPANESE</a></li>
+          <li><a href="https://quarkus.io/" >OFFICIAL (ENGLISH)</a></li>
+          <li><a href="https://ja.quarkus.io/">日本語 - JAPANESE</a></li>
           </ul>
       </li>
     </ul>

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -52,6 +52,7 @@
         <ul class="submenu">
           <li><a href="https://quarkus.io/" >OFFICIAL (ENGLISH)</a></li>
           <li><a href="https://ja.quarkus.io/">日本語 - JAPANESE</a></li>
+          <li><a href="https://cn.quarkus.io/">简体中文 - CHINESE</a></li>
           </ul>
       </li>
     </ul>

--- a/_includes/homepage-language.html
+++ b/_includes/homepage-language.html
@@ -1,0 +1,5 @@
+{% for item in site.data.languages.language %}
+<div class="grid-wrapper communitysite">
+  <div class="grid__item width-12-12">{{ item.headline }}</div>
+</div>
+{% endfor %}

--- a/_includes/homepage-language.html
+++ b/_includes/homepage-language.html
@@ -1,5 +1,7 @@
+{%if site.cname!="quarkus.io" %}
 {% for item in site.data.languages.language %}
 <div class="grid-wrapper communitysite">
-  <div class="grid__item width-12-12">{{ item.headline }}</div>
+  <div class="grid__item width-12-12">cname: "{{ site.cname }}" {{ item.headline }}</div>
 </div>
 {% endfor %}
+{% endif %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -2,6 +2,7 @@
 layout: base
 ---
 <div class="quarkus-homepage">
+  {% include homepage-language.html %}
   {% include homepage-hero-band-ssjprime.html %}
   {% include homepage-features-icon-band.html %}
   {% include homepage-performance-band.html %}

--- a/_plugins/cname.rb
+++ b/_plugins/cname.rb
@@ -1,0 +1,12 @@
+# loads CNAME into cname config variable
+module Jekyll
+	class LimitedEnvironmentVariables < Generator
+		def generate(site)
+			if(File.exist?('CNAME')) 
+				site.config['cname'] = File.read("CNAME").strip
+			else
+				site.config['cname'] = ""
+			end
+		end
+	end
+end

--- a/_sass/includes/homepage-languageband.scss
+++ b/_sass/includes/homepage-languageband.scss
@@ -1,0 +1,6 @@
+.communitysite {
+  background-color: $dark-blue-1;
+  text-align: center;
+  margin: 0 -13rem;
+  padding: .5rem 13rem;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -60,4 +60,5 @@ $baseurl: "{{ site.baseurl }}";
 @import "includes/copycode";
 @import "includes/asciidoc-tabs";
 @import "includes/tooltip";
+@import "includes/homepage-languageband.scss";
 


### PR DESCRIPTION
Changes to the language pulldown

1) for better usability, changed "Japanese" to be legible in Japanese characters in header and footer.
2) In primary navigation, changed "English" to "Official (English)" to help the indicate to the user the English version of the site is the main project site.
3) Added thin banner on home page between the Navigation and the hero. This banner uses a yml (languages.yaml) file to store the content for easier translation. The content reads; "The English version of Quarkus.io is the official project site. Translated sites are community supported on a best-effort basis."  We want to use this disclaimer so the users understand that the content of translations may lag behind the English site. One thought would be to make that banner not visible for the English site but visible and translated for any non-english site. 

Thoughts on making the banner only visible on the translated sites?