### PR TITLE
fix rest client reactive exception handling guide

### DIFF
--- a/_guides/rest-client-reactive.adoc
+++ b/_guides/rest-client-reactive.adoc
@@ -649,9 +649,10 @@ A simple example of implementing such a `ResponseExceptionMapper` for the `Exten
 
 [source, java]
 ----
-public interface MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
+public class MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
 
-    RuntimeException toThrowable(Response response) {
+    @Override
+    public RuntimeException toThrowable(Response response) {
         if (response.getStatus() == 500) {
             throw new RuntimeException("The remote service responded with HTTP 500");
         }

--- a/_versions/2.7/guides/rest-client-reactive.adoc
+++ b/_versions/2.7/guides/rest-client-reactive.adoc
@@ -656,9 +656,10 @@ A simple example of implementing such a `ResponseExceptionMapper` for the `Exten
 
 [source, java]
 ----
-public interface MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
+public class MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
 
-    RuntimeException toThrowable(Response response) {
+    @Override
+    public RuntimeException toThrowable(Response response) {
         if (response.getStatus() == 500) {
             throw new RuntimeException("The remote service responded with HTTP 500");
         }

--- a/_versions/main/guides/rest-client-reactive.adoc
+++ b/_versions/main/guides/rest-client-reactive.adoc
@@ -649,9 +649,10 @@ A simple example of implementing such a `ResponseExceptionMapper` for the `Exten
 
 [source, java]
 ----
-public interface MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
+public class MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
 
-    RuntimeException toThrowable(Response response) {
+    @Override
+    public RuntimeException toThrowable(Response response) {
         if (response.getStatus() == 500) {
             throw new RuntimeException("The remote service responded with HTTP 500");
         }


### PR DESCRIPTION
I believe that:
- The implementation of `ResponseExceptionMapper` should be done by a `class` and not an `interface`.
- The method toThrowable should be public, or I receive this error: `Cannot reduce the visibility of the inherited method from ResponseExceptionMapper<RuntimeException>`

## Current version

```java
public interface MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {

    RuntimeException toThrowable(Response response) {
        if (response.getStatus() == 500) {
            throw new RuntimeException("The remote service responded with HTTP 500");
        }
        return null;
    }
}
```

## Proposed version

```java
public class MyResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {

    @Override
    public RuntimeException toThrowable(Response response) {
        if (response.getStatus() == 500) {
            throw new RuntimeException("The remote service responded with HTTP 500");
        }
        return null;
    }
}
```