### PR TITLE
Update building-native-image.adoc

### DIFF
--- a/_guides/building-native-image.adoc
+++ b/_guides/building-native-image.adoc
@@ -342,7 +342,7 @@ you can only test via HTTP calls. Your test code does not actually run natively,
 that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
 
 If you share your test class between JVM and native executions like we advise above, you can mark certain tests
-with the `@DisabledOnNativeImage` annotation in order to only run them on the JVM.
+with the `@DisabledOnIntegrationTest` annotation in order to only run them on the JVM.
 
 
 === Testing an existing native executable


### PR DESCRIPTION
changed @DisabledOnNativeImage to @DisabledOnIntegrationTest as the former is deprecated since 2.9

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
