### PR TITLE
fix main nav language color icon error

### DIFF
--- a/_sass/includes/header-navigation.scss
+++ b/_sass/includes/header-navigation.scss
@@ -102,6 +102,7 @@ div.nav-wrapper {
 
     .dropdown .langicon {
       padding-right: .3rem;
+      color: $white;
     }
 
     .dropdown:hover {


### PR DESCRIPTION
This fixes a css error on the globe icon in the navigation. It looses its white color on any page besides the homepage. This PR fixes that problem.