### PR TITLE
remove double l10n banner on frontpage

### DIFF
--- a/_includes/homepage-language.html
+++ b/_includes/homepage-language.html
@@ -1,7 +1,0 @@
-{%if site.cname!="quarkus.io" %}
-{% for item in site.data.languages.language %}
-<div class="grid-wrapper communitysite">
-  <div class="grid__item width-12-12">{{ item.headline }}</div>
-</div>
-{% endfor %}
-{% endif %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -2,7 +2,6 @@
 layout: base
 ---
 <div class="quarkus-homepage">
-  {% include homepage-language.html %}
   {% include homepage-hero-band-ssjprime.html %}
   {% include homepage-features-icon-band.html %}
   {% include homepage-userstory-callout.html %}


### PR DESCRIPTION
without this cn.quarkus.io and ja.quarkus.io has a double mention of localized vs official site.

only the top level one should be visible/included.
