### PR TITLE
change base layout to make page titles more legible in tabbed settings

### DIFF
--- a/_guides/topic/publications.adoc
+++ b/_guides/topic/publications.adoc
@@ -3,7 +3,7 @@ layout: publications
 permalink: /publications/
 ---
 include::../attributes.adoc[]
-= {project-name} - Publications
+= Publications
 
 Below is a list of articles, blogs, podcast and other tidbits published online around {project-name}.
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,13 +9,13 @@
   {% endif %}
 {% endif %}
 {% if page.title %}
-  {% assign page.title page_title_starts_with_quarkus = page.title | startswith: 'Quarkus -' %}
+  {% assign page.title page_title_ends_with_quarkus = page.title | endswith: '- Quarkus' %}
 {% else %}
-  {% assign page.title page_title_starts_with_quarkus = false %}
+  {% assign page.title page_title_ends_with_quarkus = false %}
 {% endif %}
 
 <head>
-  <title>{% unless page_title_starts_with_quarkus %}Quarkus - {% endunless %}{{ page.title }}{{ page_title_version_suffix }}</title>
+  <title>{% unless page_title_ends_with_quarkus %}{% endunless %}{{ page.title }}{{ page_title_version_suffix }} - Quarkus</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="Content-Security-Policy" content="default-src https://dpm.demdex.net; script-src 'self' 'unsafe-eval' 'sha256-ANpuoVzuSex6VhqpYgsG25OHWVA1I+F6aGU04LoI+5s=' 'sha256-ipy9P/3rZZW06mTLAR0EnXvxSNcnfSDPLDuh3kzbB1w=' js.bizographics.com https://www.redhat.com https://static.redhat.com assets.adobedtm.com jsonip.com https://ajax.googleapis.com https://www.googletagmanager.com https://www.google-analytics.com https://use.fontawesome.com https://app.mailjet.com http://www.youtube.com http://www.googleadservices.com https://googleads.g.doubleclick.net https://dpm.demdex.net https://giscus.app; style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com; img-src 'self' *; media-src 'self'; frame-src https://www.googletagmanager.com https://www.youtube.com https://embed.restream.io https://app.mailjet.com https://giscus.app; base-uri 'none'; object-src 'none'; form-action 'none'; font-src 'self' https://use.fontawesome.com https://fonts.gstatic.com;" />

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,13 +9,15 @@
   {% endif %}
 {% endif %}
 {% if page.title %}
-  {% assign page.title page_title_ends_with_quarkus = page.title | endswith: '- Quarkus' %}
+  {% assign page_title_starts_with_quarkus = page.title | startswith: 'Quarkus -' %}
+  {% assign page_title_ends_with_quarkus = page.title | endswith: '- Quarkus' %}
 {% else %}
-  {% assign page.title page_title_ends_with_quarkus = false %}
+  {% assign page_title_starts_with_quarkus = false %}
+  {% assign page_title_ends_with_quarkus = false %}
 {% endif %}
 
 <head>
-  <title>{% unless page_title_ends_with_quarkus %}{% endunless %}{{ page.title }}{{ page_title_version_suffix }} - Quarkus</title>
+  <title>{{ page.title }}{{ page_title_version_suffix }}{% unless page_title_starts_with_quarkus or page_title_ends_with_quarkus %} - Quarkus{% endunless %}</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="Content-Security-Policy" content="default-src https://dpm.demdex.net; script-src 'self' 'unsafe-eval' 'sha256-ANpuoVzuSex6VhqpYgsG25OHWVA1I+F6aGU04LoI+5s=' 'sha256-ipy9P/3rZZW06mTLAR0EnXvxSNcnfSDPLDuh3kzbB1w=' js.bizographics.com https://www.redhat.com https://static.redhat.com assets.adobedtm.com jsonip.com https://ajax.googleapis.com https://www.googletagmanager.com https://www.google-analytics.com https://use.fontawesome.com https://app.mailjet.com http://www.youtube.com http://www.googleadservices.com https://googleads.g.doubleclick.net https://dpm.demdex.net https://giscus.app; style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com; img-src 'self' *; media-src 'self'; frame-src https://www.googletagmanager.com https://www.youtube.com https://embed.restream.io https://app.mailjet.com https://giscus.app; base-uri 'none'; object-src 'none'; form-action 'none'; font-src 'self' https://use.fontawesome.com https://fonts.gstatic.com;" />

--- a/_plugins/startswith.rb
+++ b/_plugins/startswith.rb
@@ -1,9 +1,0 @@
-module Jekyll
-   module StringFilter
-    def startswith(text, query)
-      return text.start_with? query
-    end
-  end
-end
-  
-Liquid::Template.register_filter(Jekyll::StringFilter)

--- a/_plugins/strings.rb
+++ b/_plugins/strings.rb
@@ -1,0 +1,13 @@
+module Jekyll
+   module StringsFilter
+    def startswith(text, query)
+      return text.start_with? query
+    end
+
+    def endswith(text, query)
+      return text.end_with? query
+    end
+  end
+end
+  
+Liquid::Template.register_filter(Jekyll::StringsFilter)

--- a/_posts/2022-06-29-nativejdb-debugger-for-native-images.adoc
+++ b/_posts/2022-06-29-nativejdb-debugger-for-native-images.adoc
@@ -14,8 +14,7 @@ image::nativejdb.png[alt=NativeJDB]
 == Co-authored by: *Ansu Varghese, Research Software Engineer, IBM*
 
 
-==== In collaboration with:
-
+**In collaboration with:**
 
 _Max Andersen, Dimitris Andreadis, Andrew Dinn, Stuart Douglas, Jason Greene, David Grove, David Lloyd, Thomas Qvarnstrom, Foivos Zakkak, Galder Zamarreno (IBM Research and Red Hat)_
 

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
 ---
 layout: index
-title: Supersonic Subatomic Java
+title: Quarkus - Supersonic Subatomic Java
 ---

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
 ---
 layout: index
-title: Quarkus - Supersonic Subatomic Java
+title: Supersonic Subatomic Java
 ---

--- a/support.md
+++ b/support.md
@@ -1,5 +1,5 @@
 ---
 layout: support
-title: Support When You Need It.
+title: Support When You Need It
 permalink: /support/
 ---


### PR DESCRIPTION
Changed base file and modified a few other files so the page title reads "<page title> - Quarkus" instead of "Quarkus - <page title>". This allows the user to see the more of the title with browsers are stacked in tabs.

As documented it this issue:
https://github.com/quarkusio/quarkus/issues/24326