### PR TITLE
rework the vertical spacing on UL and OL in guides.

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -938,3 +938,19 @@ li {
       }
     }
   }
+
+/// guides page styling overrides
+
+.guides {
+
+  ul,ol {
+
+    li {
+    margin-bottom: .35rem !important;
+
+      p {
+      margin-bottom: 0 !important;
+     }
+    }
+  }
+}


### PR DESCRIPTION
Discussed with Erin about the vertical spacing issues (too much) on the Guides pages with the unordered and ordered lists. This PR will tighten up the spacing.