### PR TITLE
provide faster serving for blog posts/website updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ These instructions will get you a copy of the Quarkus.io website up and running 
 
 6. Build the site and make it available on a local server
   
-        bundle exec jekyll serve
+        ./serve.sh
+
+   Or if you want it faster and okey to not have guides included use the following:
+
+        ./serve-noguides.sh
+
 
 7. Now browse to http://localhost:4000
 

--- a/_noguides_config.yml
+++ b/_noguides_config.yml
@@ -1,0 +1,3 @@
+exclude:
+  - _guides
+  - _versions

--- a/serve-noguides.sh
+++ b/serve-noguides.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo WARNING: Serving site with no guides. It is fast though!
+bundle exec jekyll serve --config _config.yml,_noguides_config.yml $*
+

--- a/serve.sh
+++ b/serve.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-bundle exec jekyll serve
+bundle exec jekyll serve $*
+


### PR DESCRIPTION
this adds a separate config that does nothing but just exclude guides/version and then provide command to use it.

difference on my machine is 5 seconds instead of 60+ seconds for full render.


