### PR TITLE
Make it easy to copy environment variables in config tables - add button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,7 @@ asciidoctor:
     sectanchors: ''
     icons: font
     outfilesuffix: ''
+    add-copy-button-to-env-var: true
 
 # Pages permalink
 defaults:

--- a/_guides/javascript/config.js
+++ b/_guides/javascript/config.js
@@ -295,6 +295,10 @@ function makeCollapsibleHandler(descDiv, td, row,
         if( (target.localName == 'a' || getAncestor(target, "a"))) {
             return;
         }
+        // don't collapse if the target is button with attribute "do-not-collapse"
+        if( (target.localName == 'button' && target.hasAttribute("do-not-collapse"))) {
+            return;
+        }
 
         var isCollapsed = descDiv.classList.contains('description-collapsed');
         if( isCollapsed ) {

--- a/_plugins/asciidoctor-extension.rb
+++ b/_plugins/asciidoctor-extension.rb
@@ -38,3 +38,16 @@ Extensions.register do
     end
   end
 end
+
+env_var_id=0
+Extensions.register do
+  inline_macro do
+    named :env_var_with_copy_button
+    resolve_attributes false
+    process do |parent, target, attrs|
+      copy_btn = %(<code id="env-var-#{env_var_id}">#{target}</code><button class="btn-copy fa fa-clipboard inline-btn-copy" data-clipboard-action="copy" data-clipboard-target="#env-var-#{env_var_id}" title="Copy to clipboard" do-not-collapse="true"></button>)
+      env_var_id += 1
+      create_inline_pass parent, %(#{copy_btn})
+    end
+  end
+end

--- a/_sass/includes/copycode.css
+++ b/_sass/includes/copycode.css
@@ -1,7 +1,6 @@
 /* modification for button copy */
 
 .btn-copy {
-  float: right;
   font-family: FontAwesome;
   padding: 0rem;
   line-height: .5rem;
@@ -12,4 +11,13 @@
 }
 .btn-copy:hover {
   color: $quarkus-blue !important;
+}
+.btn-copy[float-right] {
+  float: right;
+}
+
+/* Avoid different line-heights when the button is used */
+.inline-btn-copy {
+  margin-top: 0;
+  margin-bottom: 0;
 }

--- a/assets/javascript/copy.js
+++ b/assets/javascript/copy.js
@@ -9,6 +9,7 @@ codes.forEach((code) => {
   btn.setAttribute("data-clipboard-action", "copy");
   btn.setAttribute("data-clipboard-target", "#code" + countID);
   btn.setAttribute("title", "Copy to clipboard")
+  btn.setAttribute("float-right", "true");
   
   let div = document.createElement('div');
   div.appendChild(btn);


### PR DESCRIPTION
Configuration tables contain environment variables that are hard to copy as when you click on them, the property description collapse and the env variable is gone. @famod suggested we should do something about that here https://github.com/quarkusio/quarkus/pull/26408#issuecomment-1198304829

This PR adds a copy button right behind each such environment variable and also prevents collapsing.

![image](https://user-images.githubusercontent.com/43821672/184210338-49b5db14-974d-4e15-bffa-6f2ba9f46f4f.png)
