### PR TITLE
Add links to alternate localized versions used by SEO crawlers

### DIFF
--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -57,14 +57,19 @@ links:
 
   - title: Languages
     width: 1
+    id: languages # we need id in case "Languages" get localized; please note the languages are also used for alternate links
     subfolderitems:
       - page: English
+        code: en
         url: https://quarkus.io/
       - page: Español
+        code: es
         url: https://es.quarkus.io/
       - page: 简体中文
+        code: zh # ISO 639-1 language code for Chinese
         url: https://cn.quarkus.io/
       - page: 日本語
+        code: ja
         url: https://ja.quarkus.io/
 
 more_links:

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -48,6 +48,15 @@
   <link rel="alternate" type="application/rss+xml"  href="/feed.xml" title="{{ site.title }}">
   <script src="/assets/javascript/goan.js" type="text/javascript"></script>
   <script src="/assets/javascript/hl.js" type="text/javascript"></script>
+  {% comment %}
+    Tell Google all the language variants of a page, including itself. Existence of the localized variant is not checked.
+  {% endcomment %}
+  {% assign path = page.url | remove_first: "/" %}
+  {% assign languages = site.data.projectfooter.links | where: "id", "languages" | first %}
+  {% for language in languages.subfolderitems %}
+  <link rel="alternate" hreflang="{{ language.code }}" href="{{ language.url | append: path }}" />
+  {% endfor %}
+  <link rel="alternate" hreflang="x-default" href="https://quarkus.io/" />
 </head>
 
 <body class="{% if page.url == '/' %}homepage{% else %}{{page.layout}}{% endif %}">


### PR DESCRIPTION
closes: #1456

Adds links to each localization so SEO crawlers can identify the alternate URLs. Links are static (not added to DOM dynamically based on current state) as I'm not sure DOM manipulation in `<head>` would be taken into account (f.e. if we were to check "is page there" and based on result either add the link or not; Google crawler runs JavaScript, but there is no reference to re-rendering).

Possible pitfall of this solution is that we also generate links for the pages that are not localized yet (does not exist). While this could be avoided by analysis of other site projects (`en` would analyse `es`, `ja`, `zh` and so on), it would necessarily take some time. I have following reasons to think it's okay to include links that might lead to `NOT FOUND`:
- https://developers.google.com/search/docs/advanced/crawling/http-network-errors#http-status-codes says `Any content Googlebot received from URLs that return a 4xx status code is ignored.`. Ignored != punished.
- If Google were to keep the database of the links it won't visit again because he got 404, it would risk that status has changed (the information could be obsolete in a minutes). Also just keeping such a database instead of doing f.e. HEAD requests seems ineffective.
- We avoid sync problems, https://developers.google.com/search/docs/advanced/crawling/localized-versions#html says `If two pages don't both point to each other, the tags will be ignored.`, so we need circular reference and only adding links when other 3 exists calls for sync hell.
- This way the information is never obsolete - if f.e. Japanse site added a new guide, we are already pointing at it and don't have to wait for next sync (or github bot action, whatever).
