### PR TITLE
have language link menu point to exact page

### DIFF
--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -50,10 +50,10 @@
       <li class="dropdown">
         <span href="{{site.baseurl}}/language/"><div class="fas fa-globe langicon"></div><i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
-          <li><a href="https://quarkus.io/" >OFFICIAL (ENGLISH)</a></li>
-          <li><a href="https://es.quarkus.io/">ESPAÑOL</a></li>
-          <li><a href="https://cn.quarkus.io/">简体中文</a></li>
-          <li><a href="https://ja.quarkus.io/">日本語</a></li>
+          <li><a href="https://quarkus.io{{ page.url }}" >OFFICIAL (ENGLISH)</a></li>
+          <li><a href="https://es.quarkus.io{{ page.url }}">ESPAÑOL</a></li>
+          <li><a href="https://cn.quarkus.io{{ page.url }}">简体中文</a></li>
+          <li><a href="https://ja.quarkus.io{{ page.url }}">日本語</a></li>
           </ul>
       </li>
     </ul>


### PR DESCRIPTION
currently globe menu links to root of every language page.

this PR makes it so if you are on i.e. quarkus.io/blog the chinese link will point to cn.quarkus.io/blog making it so you don't have to navigate to the specific page again.