### PR TITLE
edited content on WT and abstracts page to remove references to shirts

### DIFF
--- a/_includes/worldtour-2022.html
+++ b/_includes/worldtour-2022.html
@@ -9,7 +9,7 @@
       <p>We are taking requests…if you had a tour stop before, we can create a new experience to give your JUG a fresh deeper look at Quarkus. No Freebird or Stairway to Heaven. ;)
       </p>
       <p>Are we visiting a JUG near you? Then look out for their announcements or if not, get them to reach out to us and we’ll see if we can squeeze them in!</p>
-      <p>And yeah, we still have cool concert shirts and swag.</p>
+      <p>And yeah, we still have cool swag.</p>
       <p>Keep rocking the Java world!</p>
     </div>
     <div class="width-6-12 width-12-12-m">

--- a/_includes/worldtour-abstracts-2022.html
+++ b/_includes/worldtour-abstracts-2022.html
@@ -14,7 +14,7 @@
       <p>For the last 25 years, Java has performed for organizations across the world but you've never seen anything like this. We'll cover all the classics like "Start Me Up" and "Living' on a VM" and some new jams like "Stairway to Native" and "Sweet JPA of Mine" and more.</p>
       <p>In this session the Quarkus Team will give you a unique, hands-on experience:  An introduction to Quarkus, a follow-along hands-on demo or two and then a Q&A with some of the band, umm, developers involved.</p>
       <p>So join us as we explore how Quarkus helps Java developers everywhere to be more productive, create modern masterpieces and, well,  have more fun:  90 odd minutes of technical discussion, some live coding and a Q&A - it’s going to be a  blast.</p>
-      <p>Oh and did we mention swag? Maybe even a Tour T-Shirt?</p>
+      <p>Oh and did we mention some cool swag?</p>
       <p>Time to rock the Java world 2022 style…</p>
       </div>
       <div class="width-2-12 width-12-12-m"></div>
@@ -25,7 +25,7 @@
       <p>Quarkus is the rising star for Kube Native Java as it re-imagines the Java stack to give you the performance characteristics and developer experience you need to create modern, high performing applications. Quarkus helps you use your existing skills and code in new ways and greatly reduces the technical burden when moving to a Kubernetes-centric environment.</p>
       <p>Join us as we explore how Quarkus helps Java developers everywhere to be more productive, create modern masterpieces and, have a little bit more fun.</p>
       <p>It’s going to be a blast.  90 odd minutes of technical discussion, some live coding and a Q&A.</p>
-      <p>Oh and did we mention swag? Maybe even a Tour T-Shirt?</p>
+      <p>Oh and did we mention some cool swag?</p>
       <p>Time to rock the Java world 2022 style…</p>
     </div>
 


### PR DESCRIPTION
We are uncertain if we'll be restocking "QWT 2022" shirts so we're removing references to shirts.