### PR TITLE
remove publications and awards page and add redirects

### DIFF
--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -16,10 +16,6 @@ links:
         url: /events
       - page: Newsletter
         url: /newsletter
-      - page: Publications
-        url: /publications
-      - page: Awards
-        url: /awards
       - page: Security&nbsp;policy
         url: /security
 

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -40,8 +40,6 @@
           <li><a href="{{site.baseurl}}/insights" class="{% if page.url contains '/insights/' %}active{% endif %}">PODCAST</a></li>
           <li><a href="{{site.baseurl}}/events" class="{% if page.url contains '/events/' %}active{% endif %}">EVENTS</a></li>
           <li><a href="{{site.baseurl}}/newsletter" class="{% if page.url contains '/newsletter/' %}active{% endif %}">NEWSLETTER</a></li>
-          <li><a href="{{site.baseurl}}/publications" class="{% if page.url contains '/publications/' %}active{% endif %}">PUBLICATIONS</a></li>
-          <li><a href="{{site.baseurl}}/awards" class="{% if page.url contains '/awards/' %}active{% endif %}">AWARDS</a></li>
           </ul>
       </li>
       <li>

--- a/_redirects/awards.md
+++ b/_redirects/awards.md
@@ -1,0 +1,5 @@
+---
+permalink: /awards/
+newUrl: /blog/tag/awards/
+external: true
+---

--- a/_redirects/publications.md
+++ b/_redirects/publications.md
@@ -1,0 +1,5 @@
+---
+permalink: /publications/
+newUrl: /newsletter/
+external: true
+---

--- a/awards.md
+++ b/awards.md
@@ -1,6 +1,0 @@
----
-layout: awards
-title: Awards and Recognition
-subtitle: Quarkus has been honored to receive multiple awards and recognition. We feel these are an affirmation of the great work being done by our dedicated community. We’ve started a trophy case to share the kudos with everyone.
-permalink: /awards/
----

--- a/publications.md
+++ b/publications.md
@@ -1,6 +1,0 @@
----
-layout: publications
-title: Publications
-subtitle: Articles, blogs, podcast and other tidbits published online around Quarkus.
-permalink: /publications/
----


### PR DESCRIPTION
I reviewed the web traffic logs and the awards page and publications page get minimal traffic. The publications page function was made obsolete (and it's content went static) once we started using mailjet to push our newsletter. I've put in a redirect to have /publications redirect to /newsletter. Additionally, the awards page is rather static (no new awards this year) and its announcement function is better served on the blog with an "awards" tag. I put in a redirect of /awards to the blog/tag/awards page.

Additionally, I removed both the Publications and Awards links from the flyout navigation and footer navigation to clean up both of them. 

I haven't removed the source pages/data/layouts/css if we ever want to bring those pages back