### PR TITLE
Fix broken link to Reactive Messaging guides

### DIFF
--- a/_data/guides-2-7.yaml
+++ b/_data/guides-2-7.yaml
@@ -297,10 +297,12 @@ categories:
         url: /guides/rabbitmq-dev-services
         description: Start RabbitMQ automatically in dev and test modes.
       - title: Using HTTP with Reactive Messaging
-        url: /guides/reactive-messaging-http
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-reactive-messaging-http/dev/reactive-messaging-http.html
+        origin: quarkiverse-hub
         description: This guide demonstrates how your Quarkus application can utilize SmallRye Reactive Messaging to consume and produce HTTP messages.
       - title: Using WebSockets with Reactive Messaging
-        url: /guides/reactive-messaging-websocket
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-reactive-messaging-http/dev/reactive-messaging-websocket.html
+        origin: quarkiverse-hub
         description: This guide demonstrates how your Quarkus application can utilize SmallRye Reactive Messaging to consume and produce messages via WebSockets.
       - title: Using Apache Kafka Streams
         url: /guides/kafka-streams

--- a/_data/guides-latest.yaml
+++ b/_data/guides-latest.yaml
@@ -309,10 +309,12 @@ categories:
         url: /guides/rabbitmq-dev-services
         description: Start RabbitMQ automatically in dev and test modes.
       - title: Using HTTP with Reactive Messaging
-        url: /guides/reactive-messaging-http
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-reactive-messaging-http/dev/reactive-messaging-http.html
+        origin: quarkiverse-hub
         description: This guide demonstrates how your Quarkus application can utilize SmallRye Reactive Messaging to consume and produce HTTP messages.
       - title: Using WebSockets with Reactive Messaging
-        url: /guides/reactive-messaging-websocket
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-reactive-messaging-http/dev/reactive-messaging-websocket.html
+        origin: quarkiverse-hub
         description: This guide demonstrates how your Quarkus application can utilize SmallRye Reactive Messaging to consume and produce messages via WebSockets.
       - title: Using Apache Kafka Streams
         url: /guides/kafka-streams

--- a/_data/guides-main.yaml
+++ b/_data/guides-main.yaml
@@ -309,10 +309,12 @@ categories:
         url: /guides/rabbitmq-dev-services
         description: Start RabbitMQ automatically in dev and test modes.
       - title: Using HTTP with Reactive Messaging
-        url: /guides/reactive-messaging-http
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-reactive-messaging-http/dev/reactive-messaging-http.html
+        origin: quarkiverse-hub
         description: This guide demonstrates how your Quarkus application can utilize SmallRye Reactive Messaging to consume and produce HTTP messages.
       - title: Using WebSockets with Reactive Messaging
-        url: /guides/reactive-messaging-websocket
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-reactive-messaging-http/dev/reactive-messaging-websocket.html
+        origin: quarkiverse-hub
         description: This guide demonstrates how your Quarkus application can utilize SmallRye Reactive Messaging to consume and produce messages via WebSockets.
       - title: Using Apache Kafka Streams
         url: /guides/kafka-streams


### PR DESCRIPTION
Fixed broken links to the `Using HTTP with Reactive Messaging` and `Using WebSockets with Reactive Messaging` guides