### PR TITLE
Docs Look and Feel updates

### DIFF
--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -9,7 +9,8 @@ layout: base
 {% endif %}
 {% assign guide_url = page.url | replace_regex: '^/version/[^/]+(/.*)', '\1' %}
 
-<div class="full-width-version-bg grey guidebar align-self">
+<div class="full-width-version-bg guidebar align-self">
+  
   <a class="guidebarcol returnlink" href="{{site.baseurl}}/{% if versioned_page %}version/{{docversion}}/guides/{% else %}guides/{% endif %}"> Back to Guides</a>
   <div class="guidebarcol version">
     <label id="guide-version-label" class="guide-dropdown-label">Select Guide Version</label>

--- a/_sass/includes/whitecards.scss
+++ b/_sass/includes/whitecards.scss
@@ -53,7 +53,7 @@ grid-column: span 3;
 .click-cards {
 
     h3 {
-      margin: 0;
+      margin: 3rem 0rem 1rem;
       padding-bottom: .5rem;
       &:not(:first-child) {
         margin-top: 3rem;

--- a/_sass/layouts/documentation.scss
+++ b/_sass/layouts/documentation.scss
@@ -107,7 +107,7 @@ Styles for the documentation index page
     height: calc(100% - 2rem);
     grid-column: span 4;
     min-height: 80px;
-    margin: 1rem 0;
+    margin: 1rem 3rem 1rem 0rem;
     position: relative;
 
     @media screen and (max-width: 1300px) {
@@ -116,6 +116,7 @@ Styles for the documentation index page
 
     @media screen and (max-width: 768px) {
       grid-column: span 12;
+      margin: 1rem 0rem 1rem 0rem;
     }
 
     @media screen and (max-width: 480px) {
@@ -123,12 +124,12 @@ Styles for the documentation index page
     }
 
     h4 {
-      margin: 0 0 0 100px;
+      margin: 0 0 0 90px;
       padding: 0;
     }
 
     .description {
-      margin: 1rem 0 0 100px;
+      margin: 1rem 0 0 90px;
       font-size: 1rem;
       line-height: 1.3rem;
 
@@ -138,7 +139,7 @@ Styles for the documentation index page
     }
 
     &.quarkiverse .origin {
-      padding-left: 100px;
+      padding-left: 120px;
       text-align: left;
       position: relative;
     }
@@ -150,7 +151,7 @@ Styles for the documentation index page
       height: 25px;
       width: 25px;
       position: absolute; 
-      left: 70px;
+      left: 90px;
     }
   }
 

--- a/_sass/layouts/guides.scss
+++ b/_sass/layouts/guides.scss
@@ -195,7 +195,7 @@ div.guides-configuration-reference {
   }
 }
 
-/*=============== Guides and Guide Versioning Controls (Gray Bar) =================== */
+/*=============== Guides and Guide Versioning Controls (Gray/Blue Bar) =================== */
 
 .guidebar {
   display: flex;
@@ -212,13 +212,13 @@ div.guides-configuration-reference {
 
     &.returnlink {
       position: relative;
-      padding-left: 1.2em;
+      padding-left: 1.3em;
     }
     &.returnlink:after {
-      content:"\f104";
-      font-size: 1rem;
+      content:"\f053";
+      font-size: 1.05rem;
       left: .4rem;
-      top: .6rem;
+      top: .7rem;
       font-family:"Font Awesome 5 Free";
       font-style:normal;
       font-weight:900;
@@ -266,7 +266,7 @@ div.guides-configuration-reference {
   
   .returnlink,
   .guide-dropdown-label {
-    color: $dark-blue-alt;
+    color: $white;
     line-height: normal;
     padding: .5rem;
     margin-right: .5rem;

--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -739,6 +739,7 @@ li {
 .full-width-version-bg {
   margin: 0 -13rem 2rem -13rem;
   padding: .75rem 13rem;
+  background-color: $quarkus-blue;
 
   @media screen and (max-width: 1170px) {
     margin: 0 -6rem 2rem -6rem;
@@ -747,17 +748,6 @@ li {
   @media screen and (max-width: 768px) {
     margin: 0 -2rem 1rem -2rem;
     padding: .75rem 2rem;
-  }
-
-  &.grey {
-    background-color: $grey-0 ;
-
-    h1, h2, h3, h4, h5, h6, p, span {
-      color: $dark-blue-alt;
-    }
-    a {
-      color: $link-light-bg;
-    }
   }
 
   .returnlink {
@@ -875,6 +865,9 @@ li {
     }
     a {
       color: $link-light-bg;
+    }
+   .guide-dropdown-label {
+    color: $dark-blue-alt;
     }
   }
 


### PR DESCRIPTION
1) Adjust spacing of the diataxis framework cards to make the content easier to read and help with visual alignment of elements.
2) change grey version and back bar at the top to blue to be consistent with the blue back bar on the blogs page
3) Adjust spacing on the old versions page to add space above the H3 titles so the categories are more consumable.