### PR TITLE
Added redirects for revamped security guides

### DIFF
--- a/_redirects/guides/security-getting-started.md
+++ b/_redirects/guides/security-getting-started.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-getting-started/index.html
+newUrl: /guides/security-basic-authentication-concept
+---

--- a/_redirects/guides/security.md
+++ b/_redirects/guides/security.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security/index.html
+newUrl: /guides/security-overview-concept
+---


### PR DESCRIPTION
Relates to the restructuring work of the following guides into the new Quarkus diataxis templates:

`security.adoc` -> `security-overview-concept.adoc`
and
`security-getting-started.adoc` -> `security-basic-authentication-concept.adoc`

See quarkusio/quarkus repo [PR: #29418](https://github.com/quarkusio/quarkus/pull/29418/files#)