### PR TITLE
fix timezone for correct date

### DIFF
--- a/_posts/2022-11-28-quarkus-support-for-aws-lambda-snapstart.adoc
+++ b/_posts/2022-11-28-quarkus-support-for-aws-lambda-snapstart.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Quarkus support for AWS Lambda SnapStart"
-date:   2022-11-28 00:00 +0100
+date:   2022-11-28
 author: sshaaf
 tags: announcement
 synopsis: Amazon Web Services (AWS)  announced the SnapStart feature for AWS Lambda. SnapStart reduces startup latency for Java-based functions running on AWS Lambda, and Quarkus supports it from day one!


### PR DESCRIPTION
fixing the date, since it was showing up at a day before due to timezone. re: AWS Snapstart blog post