### PR TITLE
Cross-link to release documentation

### DIFF
--- a/_posts/2020-12-03-quarkiverse.adoc
+++ b/_posts/2020-12-03-quarkiverse.adoc
@@ -25,6 +25,7 @@ Automated and secured publishing of your Maven releases to Maven Central::
 Registering and publishing artifacts to Maven central can become a daunting task. In Quarkiverse that is automated by GitHub Actions, requiring no manual interaction with any command line tools.
 Releasing an artifact is as simple as opening a pull-request changing the https://github.com/quarkiverse/quarkiverse-template/blob/main/.github/project.yml[`.github/project.yml`] file in the extension's repository.
 Once the pull-request is merged, a GitHub action is triggered invoking `mvn release:prepare release:perform` and the extension is deployed to Maven central.
+The Quarkiverse wiki has https://github.com/quarkiverse/quarkiverse/wiki/Release[more details and troubleshooting tips].
 
 image::/assets/images/posts/quarkiverse/quarkiverse-release.png[align="center"]
 


### PR DESCRIPTION
I had a hard time finding https://github.com/quarkiverse/quarkiverse/wiki/Release by google search. I'm hoping if we link to it, it will be a bit more-indexed by google, and also easier to navigate to from the pages google does find. 
