### PR TITLE
Bump actions and updated set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - uses: n1hility/cancel-previous-runs@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -12,7 +12,7 @@ jobs:
         id: deploy
         run: npx surge teardown https://quarkus-io-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,13 +20,13 @@ jobs:
     - name: Store PR id as variable
       id: pr
       run: |
-        echo "::set-output name=id::$(<pr-id.txt)"
+        echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT 
         rm -f pr-id.txt
     - name: Publishing to surge for preview
       id: deploy
       run: npx surge ./ --domain https://quarkus-io-pr-${{  steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
     - name: Update PR status comment on success
-      uses: actions-cool/maintain-one-comment@v1.2.1
+      uses: actions-cool/maintain-one-comment@v3.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         body: |
@@ -37,7 +37,7 @@ jobs:
         number: ${{ steps.pr.outputs.id }}
     - name: Update PR status comment on failure
       if: ${{ failure() }}
-      uses: actions-cool/maintain-one-comment@v1.2.1
+      uses: actions-cool/maintain-one-comment@v3.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         body: |

--- a/.github/workflows/sync-main-doc.yml
+++ b/.github/workflows/sync-main-doc.yml
@@ -8,11 +8,11 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: develop
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: quarkusio/quarkus
           path: .quarkus-main-repository
@@ -25,11 +25,11 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           # refresh cache every month to avoid unlimited growth


### PR DESCRIPTION
- Bumped actions
- Updated set-output as instructed in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
