### PR TITLE
Add missing local attribute

### DIFF
--- a/_guides/_attributes-local.adoc
+++ b/_guides/_attributes-local.adoc
@@ -1,5 +1,6 @@
 // tag::xref-attributes[]
 :doc-examples: ./_examples
+:doc-guides: .
 :generated-dir: ../_generated-doc/latest
 :code-examples: {generated-dir}/examples
 :imagesdir: /guides/images

--- a/_versions/2.13/guides/_attributes-local.adoc
+++ b/_versions/2.13/guides/_attributes-local.adoc
@@ -1,5 +1,6 @@
 // tag::xref-attributes[]
 :doc-examples: ./_examples
+:doc-guides: .
 :generated-dir: ../../../_generated-doc/2.13
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images

--- a/_versions/main/guides/_attributes-local.adoc
+++ b/_versions/main/guides/_attributes-local.adoc
@@ -1,5 +1,6 @@
 // tag::xref-attributes[]
 :doc-examples: ./_examples
+:doc-guides: .
 :generated-dir: ../../../_generated-doc/main
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images


### PR DESCRIPTION
Cross-reference between docs in various locations (examples/templates/base docs) need an additional local attribute.
