### PR TITLE
Correct vertical alignment of navbar on mobile

### DIFF
--- a/_sass/core/includes/header-navigation.scss
+++ b/_sass/core/includes/header-navigation.scss
@@ -19,7 +19,7 @@ $nav-height: 70px;
   display: inline;
 }
 
-// Navigation 
+// Navigation
 nav {
   float: right;
   padding-top: 1rem;
@@ -115,8 +115,7 @@ nav ul.nav-list {
     z-index: 1;
   }
   .logo-wrapper {
-    display: block;
-    margin: 0 auto;
+    display: flex;
     padding-top: 0;
   }
   nav {

--- a/_sass/includes/header-navigation.scss
+++ b/_sass/includes/header-navigation.scss
@@ -19,11 +19,14 @@ div.nav-wrapper {
 .main-nav {
   position: relative;
   width: 100%;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
 
   .container {
-    padding-top: 1rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
   }
 
   a, a i,
@@ -58,21 +61,23 @@ div.nav-wrapper {
   }
 
   .logo-wrapper {
-    display: inline-block;
-    padding-top: 0; 
+    display: flex;
+    align-items: center;
+    padding-top: 0;
     width: 13rem;
     height: 40px;
     padding: 0 10px;
     z-index: 0;
     @media screen and (max-width: 768px) {
       width: 8rem;
-      margin-top: .5rem;
     }
 
     @include position;
 
     a, span {
       color: #2A5D6C !important;
+      display: flex;
+      align-items: center;
     }
   }
 
@@ -121,15 +126,14 @@ div.nav-wrapper {
   }
 
   .nav-toggle {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     font-size: 1.7em;
     line-height: 1.5em;
-    float: right;
     user-select: none;
     -webkit-user-select: none;
     i {
       color: $white;
-      vertical-align: middle;
     }
   }
 }
@@ -148,11 +152,14 @@ div.nav-wrapper {
 @media screen and (min-width: 1024px) and (max-width: 1450px) {
   .main-nav {
     .logo-wrapper {
-      display: block;
-      margin: 0 auto !important;
+      display: flex;
     }
+
+    .container {
+      justify-content: center !important;
+    }
+
     .menu {
-      margin-top: 1rem;
       float: none !important;
       display: flex !important;
       justify-content: center;
@@ -165,6 +172,9 @@ div.nav-wrapper {
 
 @media screen and (min-width: 1024px) {
   .main-nav {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+
     .nav-toggle {
       display: none;
     }
@@ -172,11 +182,13 @@ div.nav-wrapper {
     .container {
       padding-top: 0;
       padding-bottom: 0;
-    }
-
-    .logo-wrapper {
-      margin: 5px 0;
-      padding: 10px 10px 0 10px;
+      display: flex;
+      flex-wrap: wrap;
+      align-content: center;
+      align-items: center;
+      justify-content: space-between;
+      column-gap: 10rem;
+      row-gap: 1rem;
     }
 
     .menu {


### PR DESCRIPTION
Resolves #1618 

I’ve switched everything (in this area) to flex box. This allowed me to remove various bits of vertical padding that I think were being used to try and get things into position. This slightly upsetting graphic shows the before and after overlaid, with the vertical shift:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/11509290/214660288-c9ad93ed-58c0-449a-b3ff-7c9e42dc27c9.png">

On normal screen, things are unchanged: 

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/11509290/214660524-946649a4-656c-4085-9ef6-f3cffd1a7aa2.png">

I had to do a bit of work to get the the logo and menu to wrap at the same screen width, but I’ve now got the same wrapping behaviour as before. I’m using flex gutters to set the spacing between the elements, which I think is cleaner. 

On medium sized screens, where the logo and nav menu stack, the Quarkus logo shifted up by 10 pixels, and the nav bar is 10 pixels smaller. I think this is ok. (Before, everything was positioned a bit below centre.)

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/11509290/214660999-19c3a431-7e8a-4579-a8d6-0d807dcafe78.png">


There’s a bit of ugliness where the vertical padding on the `main-nav` bar is different on mobile and desktop in order to preserve the previous appearance, but I think it’s ok. If we want to tidy it, we could just get rid of one of the special cases and accept the slight change in navbar dimensions. 



I also had to use a `!important` to get wrapped items into the menu, since I didn’t want to risk re-ordering the different @media queries.

Disappointingly, the sass didn’t actually end up shorter, once I’d covered all three cases. It’s hopefully more robust, although there is some fragility still in how the media queries cascade.

