### PR TITLE
Remove container div and checkbox element

### DIFF
--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -3,10 +3,9 @@
     <div class="width-12-12">
       <input type="checkbox" id="checkbox" />
       <nav id="main-nav" class="main-nav">
-  <div class="container">
-    <div class="logo-wrapper">
-        <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_600px_reverse.png" class="project-logo" title="Quarkus"></a>
-    </div>
+        <div class="logo-wrapper">
+           <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_600px_reverse.png" class="project-logo" title="Quarkus"></a>
+        </div>
     <label class="nav-toggle" for="checkbox">
       <i class="fa fa-bars"></i>
     </label>
@@ -56,7 +55,6 @@
           </ul>
       </li>
     </ul>
-  </div>
       </nav>
     </div>
   </div>

--- a/_includes/header-navigation_full.html
+++ b/_includes/header-navigation_full.html
@@ -3,10 +3,9 @@
     <div class="width-12-12">
       <input type="checkbox" id="checkbox" />
       <nav id="main-nav" class="main-nav">
-  <div class="container">
-    <div class="logo-wrapper">
-        <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_600px_reverse.png" class="project-logo" title="Quarkus"></a>
-    </div>
+        <div class="logo-wrapper">
+          <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_600px_reverse.png" class="project-logo" title="Quarkus"></a>
+        </div>
     <label class="nav-toggle" for="checkbox">
       <i class="fa fa-bars"></i>
     </label>
@@ -58,7 +57,6 @@
         <a href="https://code.quarkus.io" class="button-cta secondary white">Start Coding</a>
       </li>
     </ul>
-  </div>
       </nav>
     </div>
   </div>

--- a/_sass/includes/header-navigation.scss
+++ b/_sass/includes/header-navigation.scss
@@ -21,13 +21,10 @@ div.nav-wrapper {
   width: 100%;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-
-  .container {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-  }
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
   a, a i,
   span, span i {
@@ -138,6 +135,7 @@ div.nav-wrapper {
   }
 }
 
+/* This hidden checkbox controls the state of the hamburger menu */
 #checkbox {
   visibility: hidden;
   opacity: 0;
@@ -151,12 +149,10 @@ div.nav-wrapper {
 
 @media screen and (min-width: 1024px) and (max-width: 1450px) {
   .main-nav {
+    justify-content: center !important;
+
     .logo-wrapper {
       display: flex;
-    }
-
-    .container {
-      justify-content: center !important;
     }
 
     .menu {
@@ -174,21 +170,16 @@ div.nav-wrapper {
   .main-nav {
     padding-top: 1rem;
     padding-bottom: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-content: center;
+    align-items: center;
+    justify-content: space-between;
+    column-gap: 10rem;
+    row-gap: 1rem;
 
     .nav-toggle {
       display: none;
-    }
-
-    .container {
-      padding-top: 0;
-      padding-bottom: 0;
-      display: flex;
-      flex-wrap: wrap;
-      align-content: center;
-      align-items: center;
-      justify-content: space-between;
-      column-gap: 10rem;
-      row-gap: 1rem;
     }
 
     .menu {


### PR DESCRIPTION
The container div is the only element in a parent div, and has no styling function that I can see. The checkbox is hidden and there are no forms in the header that it might apply to. Removing these decreases the page weight (slightly), and should also make maintenance simpler.

I've run locally and confirmed things look the same. I've also tried the forms on the guide filtering page and confirmed they still work. 

As discussed with @insectengine .
