### PR TITLE
Remove horizontal padding around Quarkus logo

### DIFF
--- a/_sass/includes/header-navigation.scss
+++ b/_sass/includes/header-navigation.scss
@@ -66,7 +66,6 @@ div.nav-wrapper {
     padding-top: 0;
     width: 13rem;
     height: 40px;
-    padding: 0 10px;
     z-index: 0;
     @media screen and (max-width: 768px) {
       width: 8rem;


### PR DESCRIPTION
I spotted that some padding on the Quarkus logo means it's not aligned with other content on the left margin. 

![image](https://user-images.githubusercontent.com/11509290/215745311-7a99c177-8f78-4d99-a8b2-1a5817962b29.png)

I've discussed with @insectengine and we don't think there's any reason to bump the logo right, so I've removed the padding. 