### PR TITLE
Spacing tweaks to improve reproducibility of navigation header

### DIFF
--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -11,7 +11,7 @@
     </label>
     <ul id="menu" class="menu">
       <li class="dropdown">
-        <span href="{{site.baseurl}}/about/">About <i class="fas fa-chevron-down"></i></span>
+        <span href="{{site.baseurl}}/about/">About<i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/about" class="{% if page.url contains '/about/' %}active{% endif %}">WHAT IS QUARKUS?</a></li>
           <li><a href="{{site.baseurl}}/container-first" class="{% if page.url contains '/container-first/' %}active{% endif %}">CONTAINER FIRST</a></li>
@@ -22,7 +22,7 @@
         </ul>
       </li>
       <li class="dropdown">
-        <span href="{{site.baseurl}}/learn/">Learn <i class="fas fa-chevron-down"></i></span>
+        <span href="{{site.baseurl}}/learn/">Learn<i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/get-started" class="{% if page.url contains '/get-started/' %}active{% endif %}">GET STARTED</a></li>
           <li><a href="{{site.baseurl}}/guides" class="{% if page.url contains '/guides/' %}active{% endif %}">DOCUMENTATION</a></li>
@@ -31,7 +31,7 @@
           </ul>
       </li>
       <li class="dropdown">
-        <span href="{{site.baseurl}}/community/">Community <i class="fas fa-chevron-down"></i></span>
+        <span href="{{site.baseurl}}/community/">Community<i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/support/" class="{% if page.url contains '/support/' %}active{% endif %}">SUPPORT</a></li>
           <li><a href="{{site.baseurl}}/blog" class="{% if page.url contains '/blog/' %}active{% endif %}">BLOG</a></li>

--- a/_sass/includes/header-navigation.scss
+++ b/_sass/includes/header-navigation.scss
@@ -30,7 +30,6 @@ div.nav-wrapper {
   span, span i {
     font-family: 'Open Sans', sans-serif;
     font-size: 1.2rem;
-    line-height: 1.8rem;
     text-transform: uppercase;
     color: $white !important;
     font-weight: 400;
@@ -49,12 +48,15 @@ div.nav-wrapper {
   span i {
     font-family: "Font Awesome 5 Free";
     font-weight: 600;
+    padding-left: 5px;
   }
   
   a.button-cta.secondary.white {
     margin: .75rem .5rem;
     padding: 0 1rem;
     color: $white !important;
+    white-space: nowrap;
+    line-height: 1.8rem;
   }
 
   .logo-wrapper {
@@ -90,7 +92,7 @@ div.nav-wrapper {
 
     a, span {
       display: block;
-      padding: 15px;
+      padding: 16px 15px;
     }
 
     a:not(.button-cta) {
@@ -102,7 +104,6 @@ div.nav-wrapper {
     }
 
     .dropdown .langicon {
-      padding-right: .3rem;
       color: $white;
     }
 
@@ -155,8 +156,6 @@ div.nav-wrapper {
     }
 
     .menu {
-      float: none !important;
-      display: flex !important;
       justify-content: center;
       
       a, span {
@@ -182,25 +181,21 @@ div.nav-wrapper {
     }
 
     .menu {
-      display: block;
+      display: flex;
       box-shadow: none;
       border: none;
-      float: right;
+      justify-content: space-between;
+      align-items: center;
       background-color: $black;
 
 
       @include position(static);
 
       li {
-        display: inline-block;
         margin: 0;
         z-index: 1;
       }
 
-      span {
-        display: inline-block;
-        vertical-align: middle;
-      }
 
       a, span {
 
@@ -224,7 +219,8 @@ div.nav-wrapper {
 }
 
 .dropdown:hover .submenu {
-  display: block !important;
+  display: flex !important;
+  flex-direction: column;
   background-color: $grey-3;
   min-width: 250px;
   right: 0;
@@ -243,7 +239,7 @@ div.nav-wrapper {
     text-transform: none;
     font-weight: 400;
     padding: 5px 10px;
-    height: 100%;
+    line-height: 1.8rem;
 
     &.active {
       font-weight: 600;


### PR DESCRIPTION
I’ve continued the flexbox-ification of the navigation bar, which should make the layout more maintainable in future. I aimed for basically the same as now, but with a tolerance of a few pixels where the code would be cleaner. 

In particular: 
- My changes reduce the height of the navbar by about 2-3px. Let me know if we want it back, and I can adjust some padding to get it back.
- On mobile, the spacing between the elements got a bit more squished, to 56px from 59px. Again, if we think it’s important I can adjust paddings to get it back, although a round number like 58 or 60 might be best. 
- 
I was able to get rid of a few !importants, which is always a good feeling. (We were using flex on mid-size screens, and block on large screens.)

For the menu chevrons, I switched to using padding to control the spacing, rather than a space character. This gives us more flexibility. 

I was hoping I'd reduce the number of lines of css, and I don't think I did, really, but I'm hoping these are still good changes. They have allowed me to get the extensions sub-site headers 100% aligned with the main site, except for the icons (and see https://github.com/quarkusio/extensions.quarkus.io/issues/87). 
