### PR TITLE
Adding URL redirect for revamped OpenID Connect (OIDC) guide  

### DIFF
--- a/security-openid-connect-web-authentication.md
+++ b/security-openid-connect-web-authentication.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-openid-connect-web-authentication/index.html 
+newUrl: /guides/security-oidc-code-flow-authentication-concept 
+---


### PR DESCRIPTION
Relates to the restructuring work of the "Using OpenID connect (OIDC) to protect web applications using authorization code flow" guide into the new Quarkus diataxis templates:

security-openid-connect-web-authentication.adoc -> :security-oidc-code-flow-authentication-concept.adoc

See quarkusio/quarkus repo [PR: [#30518](https://github.com/quarkusio/quarkus/pull/30518)