### PR TITLE
mobile navigation fixes on prime nav

### DIFF
--- a/_sass/includes/header-navigation.scss
+++ b/_sass/includes/header-navigation.scss
@@ -57,6 +57,7 @@ div.nav-wrapper {
     color: $white !important;
     white-space: nowrap;
     line-height: 1.8rem;
+    width: auto !important;
   }
 
   .logo-wrapper {
@@ -88,7 +89,7 @@ div.nav-wrapper {
     text-align: center;
     z-index: 1;
 
-    @include position(absolute, 111px, 0, null, 0);
+    @include position(absolute, 75px, 0, null, 0);
 
     a, span {
       display: block;

--- a/_sass/layouts/documentation.scss
+++ b/_sass/layouts/documentation.scss
@@ -65,7 +65,7 @@ Styles for the documentation index page
       font-style:normal;
       font-weight:900;
       position: absolute;
-      z-index: 5;
+      z-index: 0;
       pointer-events: none;
       content:"\f078";
       font-size: .8rem;
@@ -98,7 +98,7 @@ Styles for the documentation index page
     font-style: normal;
     font-weight: 900;
     position: absolute;
-    z-index: 5;
+    z-index: 0;
     font-size: .8rem;
     left: 0.6rem;
     top: 0.6rem;
@@ -125,7 +125,7 @@ Styles for the documentation index page
   font-style:normal;
   font-weight:900;
   position: absolute;
-  z-index: 5;
+  z-index: 0;
   pointer-events: none;
   content:"\f053";
   font-size: .8rem;
@@ -145,7 +145,7 @@ Styles for the documentation index page
       font-style:normal;
       font-weight:900;
       position: absolute;
-      z-index: 5;
+      z-index: 0;
       pointer-events: none;
     }
 

--- a/_sass/project-colors.scss
+++ b/_sass/project-colors.scss
@@ -1,21 +1,21 @@
 // PROJECT color palette
 
-$quarkus-blue : #4695EB;
-$dark-blue : #09131E;
+$quarkus-blue: #4695EB;
+$dark-blue: #09131E;
 $dark-blue-alt: #0D1C2C;
 $dark-blue-1: #205894;
 
-$cta-color: #0B58AB;
-
-
 // Overwrites link colors in /core/colors.scss
-$link : #1259A5;
+$link: #1259A5;
 $link-dark-bg: #9BCAFA;
 $link-light-bg: #1259A5;
-$link-hover : $red;
-$link-visited : #AA4494;
+$link-hover: $red;
+$link-visited: #AA4494;
 
+$cta-color: #0B58AB;
 $cta-hover: $link-hover;
+
+$nav-cta-hover: #1259a5;
 
 $light-blue: #e4edf7;
 $red: #FF004A;

--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -211,8 +211,8 @@ a.button-cta.secondary {
     color: $white !important;
     border-color: $white;
     &:hover, &:active, &:focus {
-      background-color: $dark-blue-alt;
-      border-color: $red;
+      background-color: $nav-cta-hover;
+      border-color: $nav-cta-hover;
       color: $white !important;
     }
   }


### PR DESCRIPTION
1) fixed width issue with the of "start coding" cta at mobile
2) Fixed color issue on "start coding" cta hover
3) fixed z-index issue of icons on mobile filter icon set.
4) move mobile navigation flyout higher on the page to make a better connection with the hamburger.