### PR TITLE
Update cli-tooling.adoc

### DIFF
--- a/_guides/cli-tooling.adoc
+++ b/_guides/cli-tooling.adoc
@@ -92,6 +92,15 @@ have a JBang version older than v0.56.0 installed. Please remove or upgrade it t
 
 If you are installing JBang for the first time, start a new session to update your `PATH`.
 ====
+[CAUTION]
+.Dependency required on RHEL 9.x
+====
+In order to install JBang, you need to install the `tar` command on your system.
+[source,bash]
+----
+dnf install tar
+----
+====
 ****
 
 [role="secondary asciidoc-tabs-sync-sdkman"]


### PR DESCRIPTION
Adding more details to install JBang on RHEL 9.x system if a dependency is missing.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
