### PR TITLE
Make the blog band closer to the top of the page

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -3,10 +3,10 @@ layout: base
 ---
 <div class="quarkus-homepage">
   {% include homepage-hero-band-ssjprime.html %}
+  {% include recent-posts-band.html %}
   {% include homepage-features-icon-band.html %}
   {% include homepage-userstory-callout.html %}
   {% include homepage-performance-band.html %}
-  {% include recent-posts-band.html %}
   {% include homepage-newsletter-band.html %}
   {% include feedback-community-band.html %}
 </div>


### PR DESCRIPTION
This moves the blog band closer to the top of the page to ease the access to our blog posts
