### PR TITLE
Add missing word to alpha 5 blog post

### DIFF
--- a/_posts/2023-03-08-quarkus-3-0-0-alpha5-released.adoc
+++ b/_posts/2023-03-08-quarkus-3-0-0-alpha5-released.adoc
@@ -10,7 +10,7 @@ author: maxandersen
 :imagesdir: /assets/images/posts/3.0.0.alpha5
 ifdef::env-github,env-browser,env-vscode[:imagesdir: ../assets/images/posts/3.0.0.alpha5]
 
-We are in the process of getting Quarkus 3 ready - last we got our main branch to Jakarta EE 10 to let us getting more things integrated and tested faster. This time we move from Hibernate 5 to Hibernate 6 - which *will* cause breakages thus please read the section below for details if you are a Hibernate ORM and especially Hibernate Reactive user!
+We are in the process of getting Quarkus 3 ready - last alpha we got our main branch to Jakarta EE 10 to let us getting more things integrated and tested faster. This time we move from Hibernate 5 to Hibernate 6 - which *will* cause breakages thus please read the section below for details if you are a Hibernate ORM and especially Hibernate Reactive user!
 
 On top of it all is a new and improved Dev UI!
 

--- a/_posts/2023-03-08-quarkus-3-0-0-alpha5-released.adoc
+++ b/_posts/2023-03-08-quarkus-3-0-0-alpha5-released.adoc
@@ -10,7 +10,7 @@ author: maxandersen
 :imagesdir: /assets/images/posts/3.0.0.alpha5
 ifdef::env-github,env-browser,env-vscode[:imagesdir: ../assets/images/posts/3.0.0.alpha5]
 
-We are in the process of getting Quarkus 3 ready - last alpha we got our main branch to Jakarta EE 10 to let us getting more things integrated and tested faster. This time we move from Hibernate 5 to Hibernate 6 - which *will* cause breakages thus please read the section below for details if you are a Hibernate ORM and especially Hibernate Reactive user!
+We are in the process of getting Quarkus 3 ready - with the last alpha, we got our main branch to Jakarta EE 10 to let us getting more things integrated and tested faster. This time we move from Hibernate 5 to Hibernate 6 - which *will* cause breakages thus please read the section below for details if you are a Hibernate ORM and especially Hibernate Reactive user!
 
 On top of it all is a new and improved Dev UI!
 


### PR DESCRIPTION
Very minor, but I think something's missing. 

I wasn't sure if it should be 'alpha' or 'release' but I thought a-word was better than no-word.
