### PR TITLE
Fix guide version dropdown on All config page and Build Items page

### DIFF
--- a/_layouts/guides-configuration-reference.html
+++ b/_layouts/guides-configuration-reference.html
@@ -15,7 +15,7 @@ layout: base
   <a class="guidebarcol returnlink" href="{{site.baseurl}}/{% if versioned_page %}version/{{docversion}}/guides/{% else %}guides/{% endif %}"> Back to Guides</a>
   <div class="guidebarcol version">
     <label id="guides-version-label" class="guide-dropdown-label">Select Guide Version</label>
-    <select id="guides-version-dropdown" class="guide-dropdown">
+    <select id="guide-version-dropdown" class="guide-dropdown">
     {% for version in site.data.versions.documentation %}
       <option value="{{ version }}" {% if docversion == version %}selected{% endif %}>{% if version == 'latest' %}{{ site.data.versions.quarkus.version | replace_regex: "\.[0-9+]\.Final", "" }} - {% endif %}{{ version | capitalize }}{% if version == 'main' %} - SNAPSHOT{% endif %}</option>
     {% endfor %}


### PR DESCRIPTION
Fixes guide version selection dropdown on All config page and Build Items page as it doesn't work due to typo in CSS ID selector. You can try that it doesn't work here https://quarkus.io/guides/all-config