### PR TITLE
Fixed broken doc URLS (404s) for security docs

### DIFF
--- a/_redirects/guides/security-openid-connect.md
+++ b/_redirects/guides/security-openid-connect.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-openid-connect/index.html
+newUrl: /guides/security-oidc-bearer-token-authentication-tutorial
+---

--- a/_redirects/guides/security-webauthn.md
+++ b/_redirects/guides/security-webauthn.md
@@ -1,4 +1,4 @@
-----
+---
 permalink: /guides/security-webauthn/index.html
 newUrl: /guides/security-webauthn-concept
-----
+---


### PR DESCRIPTION
This PR includes fixes to 2/6 404 errors identified by @holly-cummins in this Quarkus Zulip thread:

https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Dead.20extension.20guide.20links.20-.20oidc.2C.20webauthn.2C.20kogito/near/353151536

Aims to fix errors: 
-  "https://quarkus.io/guides/security-openid-connect => 404 (Not Found) on http://localhost:9000/io.quarkus/quarkus-oidc",
- "https://quarkus.io/guides/security-webauthn => 404 (Not Found) on http://localhost:9000/io.quarkus/quarkus-security-webauthn",

