### PR TITLE
Add redirect for Quarkus portal doc page `security-oidc-bearer-authentication-concept`

### DIFF
--- a/_redirects/guides/security-oidc-bearer-authentication-concept.md
+++ b/_redirects/guides/security-oidc-bearer-authentication-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-oidc-bearer-authentication-concept/index.html
+newUrl: /guides/security-oidc-bearer-token-authentication-concept.adoc
+---


### PR DESCRIPTION
Redirect for filename change in the main quarkusio repo as per PR [#33502](https://github.com/quarkusio/quarkus/pull/33502)

To handle the rename of doc file `security-oidc-bearer-authentication-concept.adoc`  to `security-oidc-bearer-token-authentication-concept.md 
