### PR TITLE
Improve searchability of OIDC documents

### DIFF
--- a/_data/guides-latest.yaml
+++ b/_data/guides-latest.yaml
@@ -370,43 +370,43 @@ categories:
       - title: Using OpenID Connect (OIDC) to Protect Service Applications
         url: /guides/security-openid-connect
         description: This guide demonstrates how to use the OpenID Connect extension to protect your Quarkus JAX-RS service application using Bearer Token Authorization where the tokens are issued by OpenID Connect Providers such as Keycloak.
-        keywords: sso,jwt,security
+        keywords: sso,oidc,oauth2,jwt,security
       - title: Using OpenID Connect (OIDC) to Protect Web Applications
         url: /guides/security-openid-connect-web-authentication
         description: This guide demonstrates how to use the OpenID Connect extension to protect your Quarkus JAX-RS web application using the Authorization Code Flow and OpenID Connect Providers such as Keycloak.
-        keywords: sso,security
+        keywords: sso,oidc,oauth2,security
       - title: Using OpenID Connect (OIDC) Multi-Tenancy
         url: /guides/security-openid-connect-multitenancy
         description: This guide demonstrates how your OpenID Connect application can support multi-tenancy so that you can serve multiple tenants from a single application.
-        keywords: sso,security
+        keywords: sso,oidc,oauth2,security
       - title: Using OpenID Connect (OIDC) and Keycloak to Centralize Authorizations
         url: /guides/security-keycloak-authorization
         description: This guide demonstrates how your Quarkus application can authorize access to protected resources using Keycloak Authorization Services.
-        keywords: sso,security
+        keywords: sso,oidc,security
       - title: Using OpenID Connect (OIDC) and OAuth2 Client and Filters
         url: /guides/security-openid-connect-client
         description: This guide explains how to use OpenID Connect and OAuth2 Client and Filters to acquire, refresh and propagate access tokens.
-        keywords: sso,security
+        keywords: sso,oidc,oauth2,security
       - title: OpenID Connect (OIDC) and OAuth2 Client and Filters Reference
         url: /guides/security-openid-connect-client-reference
         description: Reference guide for OpenID Connect and OAuth2 Client and Filters.
-        keywords: sso,security
+        keywords: sso,oidc,oauth2,security
       - title: Configuring Well-Known OpenID Connect (OIDC) Providers
         url: /guides/security-openid-connect-providers
         description: This guide explains how to configure Quarkus to authenticate against well-known OpenID Connect providers such as GitHub, Google, Microsoft, Apple...
-        keywords: sso,security
+        keywords: sso,oidc,oauth2,github,google,microsoft,apple,facebook,twitter,spotify,security
       - title: OpenID Connect (OIDC) Dev Services
         url: /guides/security-openid-connect-dev-services
         description: Start Keycloak or other providers automatically in dev and test modes.
-        keywords: security
+        keywords: sso,oidc,security
       - title: Keycloak Admin Client
         url: /guides/security-keycloak-admin-client
         description: Inject a preconfigured Keycloak Admin Client.
-        keywords: security
+        keywords: keycloak,oidc,security
       - title: Using JWT RBAC
         url: /guides/security-jwt
         description: This guide explains how your application can utilize SmallRye JWT to verify JWT tokens and provide secured access to the JAX-RS endpoints.
-        keywords: security
+        keywords: jwt,security
       - title: Build, Sign and Encrypt JSON Web Tokens (JWT)
         url: /guides/security-jwt-build
         description: This guide explains how your application can build, sign and/or encrypt JWT tokens with a fluent and configurable SmallRye JWT Build API.
@@ -414,7 +414,7 @@ categories:
       - title: Using OAuth2 RBAC
         url: /guides/security-oauth2
         description: This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the JAX-RS endpoints.
-        keywords: security
+        keywords: oauth2,security
       - title: Using Vault
         url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html
         description: This guide explains how you can use HashiCorp Vault to securely store your credentials in Quarkus.


### PR DESCRIPTION
This PR adds more key words to OIDC docs to improve their searchability.
Every OIDC doc gets extra `oidc`, `oauth2` tags because in reality Quarkus OIDC support both `oidc` and `oauth2`. `jwt` is also added since it is a base block of these technologies, so when users type `jwt`, they should be able to see OIDC docs too (in fact for now I added it to the OIDC services doc only which is probably enough).
Additionally the well-known providers doc gets an extra key word per every supported provider as discussed as F2F (CC @maxandersen ) 