### PR TITLE
Add URL redirects for 11 renamed security docs - PR 34288

### DIFF
--- a/_redirects/guides/security-architecture-concept.md
+++ b/_redirects/guides/security-architecture-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-architecture-concept/index.html
+newUrl: /guides/security-architecture
+---

--- a/_redirects/guides/security-authentication-mechanisms-concept.md
+++ b/_redirects/guides/security-authentication-mechanisms-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-authentication-mechanisms-concept/index.html
+newUrl: /guides/security-authentication-mechanisms
+---

--- a/_redirects/guides/security-basic-authentication-concept.md
+++ b/_redirects/guides/security-basic-authentication-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-basic-authentication-concept/index.html
+newUrl: /guides/security-basic-authentication
+---

--- a/_redirects/guides/security-identity-providers-concept.md
+++ b/_redirects/guides/security-identity-providers-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-identity-providers-concept/index.html
+newUrl: /guides/security-identity-providers
+---

--- a/_redirects/guides/security-jpa-concept.md
+++ b/_redirects/guides/security-jpa-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-jpa-concept/index.html
+newUrl: /guides/security-jpa
+---

--- a/_redirects/guides/security-oidc-bearer-token-authentication-concept.md
+++ b/_redirects/guides/security-oidc-bearer-token-authentication-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-oidc-bearer-token-authentication-concept/index.html
+newUrl: /guides/security-oidc-bearer-token-authentication
+---

--- a/_redirects/guides/security-oidc-code-flow-authentication-concept.md
+++ b/_redirects/guides/security-oidc-code-flow-authentication-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-oidc-code-flow-authentication-concept/index.html
+newUrl: /guides/security-oidc-code-flow-authentication
+---

--- a/_redirects/guides/security-overview-concept.md
+++ b/_redirects/guides/security-overview-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-overview-concept/index.html
+newUrl: /guides/security-overview
+---

--- a/_redirects/guides/security-proactive-authentication-concept.md
+++ b/_redirects/guides/security-proactive-authentication-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-proactive-authentication-concept/index.html
+newUrl: /guides/security-proactive-authentication
+---

--- a/_redirects/guides/security-vulnerability-detection-concept.md
+++ b/_redirects/guides/security-vulnerability-detection-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-oidc-bearer-token-authentication-concept/index.html
+newUrl: /guides/security-vulnerability-detection
+---

--- a/_redirects/guides/security-webauthn-concept.md
+++ b/_redirects/guides/security-webauthn-concept.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/security-webauthn-concept/index.html
+newUrl: /guides/security-webauthn
+---


### PR DESCRIPTION
This PR adds URL redirects for 11 Quarkus guides currently published on the Quarkus doc portal.

Relates to doc PR [#34288](https://github.com/quarkusio/quarkus/pull/34288)

The filenames of these guides changed during 3.2 development as per the recent style change to drop content type from the filename to reduce the length.

