### PR TITLE
Fixed broken links in FAQ and some other places

### DIFF
--- a/_includes/homepage-container_first-band.html
+++ b/_includes/homepage-container_first-band.html
@@ -4,7 +4,7 @@
       <h2>Container First</h2>
     </div>
     <div class="width-12-12 block-content">
-      <p>Quarkus tailors your application for GraalVM and HotSpot. Amazingly fast boot time, incredibly low RSS memory (not just heap size!) offering near instant scale up and high density memory utilization in container orchestration platforms like Kubernetes. We use a technique we call compile time boot. <a href="/vision/container-first">Learn more.</a></p>
+      <p>Quarkus tailors your application for GraalVM and HotSpot. Amazingly fast boot time, incredibly low RSS memory (not just heap size!) offering near instant scale up and high density memory utilization in container orchestration platforms like Kubernetes. We use a technique we call compile time boot. <a href="/container-first">Learn more.</a></p>
       <pre class="highlightjs highlight"><code class="bash">$ ./my-native-java-rest-app
 Quarkus started in 0.008s</code></pre>
       <img src="{{site.baseurl}}/assets/images/quarkus_metrics_graphic_bootmem_wide.png">

--- a/_includes/homepage-developer_joy-band.html
+++ b/_includes/homepage-developer_joy-band.html
@@ -24,7 +24,7 @@
 $ gradle build -Dquarkus.package.type=native</code></pre>
           </div>
         </div>
-        <a href="/vision/developer-joy">Learn more</a>
+        <a href="/developer-joy">Learn more</a>
     </div>
     <div class="width-6-12 width-12-12-m block-image justify-self-start align-self-end">
       <img src="{{site.baseurl}}/assets/images/homepage_comic_1.png"/ class="img-md">

--- a/_includes/homepage-extensions-band.html
+++ b/_includes/homepage-extensions-band.html
@@ -4,7 +4,7 @@
       <h2>Best of Breed Libraries and Standards</h2>
     </div>
     <div class="grid__item width-5-12 width-12-12-m">
-      <p>Quarkus provides a cohesive, fun to use, full-stack framework by leveraging a growing list of hundreds of best-of-breed libraries that you love and use. All wired on a standard backbone. <a href="/vision/standards">Learn more about Quarkus Extensions</a>.</p>
+      <p>Quarkus provides a cohesive, fun to use, full-stack framework by leveraging a growing list of hundreds of best-of-breed libraries that you love and use. All wired on a standard backbone. <a href="/standards">Learn more about Quarkus Extensions</a>.</p>
     </div>
     <div class="width-7-12 width-12-12-m block-image justify-self-center">
       <img src="{{site.baseurl}}/assets/images/homepage_extensions_graphic.png"/ class="img-md">

--- a/_includes/homepage-imperative_and_reactive-band.html
+++ b/_includes/homepage-imperative_and_reactive-band.html
@@ -5,7 +5,7 @@
     </div>
     <div class="width-12-12 width-12-12-m">
       <p>Combine both the familiar imperative code and the reactive style when developing applications.
-      <a href="/vision/continuum">Learn more</a>.</p>
+      <a href="/continuum">Learn more</a>.</p>
     </div>
     <div class="width-12-12 width-12-12-m">
       <div class="grid-wrapper">

--- a/_posts/2021-09-15-adoptium-customer-story.adoc
+++ b/_posts/2021-09-15-adoptium-customer-story.adoc
@@ -38,7 +38,7 @@ ____
 
 In July 2019 the team discovered Quarkus through its related work with other frameworks in the Java ecosystem. They were especially interested in Quarkus’ promise of stellar performance and smaller footprint, which is comparable to Node.js and even Golang. Even better, Quarkus’ https://quarkus.io/guides/kotlin[first class support for Kotlin^] meant the team could re-use both their Java and Kotlin experience with Quarkus.
 
-The team found Quarkus extremely easy to develop, especially the https://quarkus.io/vision/developer-joy#live-coding[Live Coding capability^]. The familiar JAX-RS APIs in Quarkus made it easy to create the necessary endpoints. The lead engineer explains further:
+The team found Quarkus extremely easy to develop, especially the https://quarkus.io/developer-joy#live-coding[Live Coding capability^]. The familiar JAX-RS APIs in Quarkus made it easy to create the necessary endpoints. The lead engineer explains further:
 
 [quote]
 ____

--- a/faq.adoc
+++ b/faq.adoc
@@ -58,16 +58,16 @@ For example by default reflection in GraalVM will not work, unless a class/membe
 
 ## How do you unify imperative and reactive programming?
 
-link:/vision/continuum[Learn more].
+link:/continuum[Learn more].
 
 ## What does Container First mean?
 
-link:/vision/container-first[Learn more].
+link:/container-first[Learn more].
 
 ## What is your view on standards?
 
-link:/vision/standards[Learn more].
+link:/standards[Learn more].
 
 ## What are you doing to improve developer joy?
 
-link:/vision/developer-joy[Learn more].
+link:/developer-joy[Learn more].


### PR DESCRIPTION
Links at the bottom of [the FAQ page](https://quarkus.io/faq) are currently pointing to non-existing pages