### PR TITLE
Improve user experience on All configuration properties page

### DIFF
--- a/_guides/javascript/config.js
+++ b/_guides/javascript/config.js
@@ -7,50 +7,41 @@ var tables = document.querySelectorAll("table.configuration-reference");
 var typingTimer;
 
 if(tables){
-    var idx = 0;
     for (var table of tables) {
         var caption = table.previousElementSibling;
         if (table.classList.contains('searchable')) { // activate search engine only when needed
-          var input = document.createElement("input");
-          input.setAttribute("type", "search");
-          input.setAttribute("placeholder", "FILTER CONFIGURATION");
-          input.id = "config-search-"+(idx++);
-          caption.children.item(0).appendChild(input);
+          var input = caption.firstElementChild.lastElementChild;
           input.addEventListener("keyup", initiateSearch);
           input.addEventListener("input", initiateSearch);
-          var descriptions = table.querySelectorAll(".description");
-          if(descriptions){
-            var heights = new Array(descriptions.length);
-            var h = 0;
-            for (description of descriptions){
-              heights[h++] = description.offsetHeight;
-            }
-            var shadowTable = table.cloneNode(true);
-            var shadowDescriptions = shadowTable.querySelectorAll(".description");
-            h = 0;
-            for (shadowDescription of shadowDescriptions){
-              makeCollapsible(shadowDescription, heights[h++]);
-            }
-            table.parentNode.replaceChild(shadowTable, table);
-            table = shadowTable;
-          }
+          input.attributes.removeNamedItem('disabled');
           inputs[input.id] = {"table": table};
         }
 
-        var rowIdx = 0;
-        for (var row of table.querySelectorAll("table.configuration-reference > tbody > tr")) {
-            var heads = row.querySelectorAll("table.configuration-reference > tbody > tr > th");
-            if(!heads || heads.length == 0){
-                // mark even rows
-                if(++rowIdx % 2){
-                    row.classList.add("odd");
-                }else{
-                    row.classList.remove("odd");
-                }
-            }else{
-                // reset count at each section
-                rowIdx = 0;
+        const collapsibleRows = table.querySelectorAll('tr.row-collapsible');
+        if (collapsibleRows) {
+            for (let row of collapsibleRows) {
+                const td = row.firstElementChild;
+                const decoration = td.firstElementChild.lastElementChild.firstElementChild;
+                const iconDecoration = decoration.children.item(0);
+                const collapsibleSpan = decoration.children.item(1);
+                const descDiv = td.firstElementChild.children.item(1);
+                const collapsibleHandler = makeCollapsibleHandler(descDiv, td, row, collapsibleSpan, iconDecoration);
+                row.addEventListener('click', collapsibleHandler);
             }
+        }
+
+        // render hidden rows asynchronously
+        setTimeout(() => renderHiddenRows());
+    }
+}
+
+function renderHiddenRows() {
+    // some rows are initially hidden so that user can hit the ground running
+    // we render them at this very moment, but when user can already use search function
+    const hiddenRows = document.querySelectorAll('table.configuration-reference-all-rows.tableblock > tbody > tr.row-hidden');
+    if (hiddenRows) {
+        for (row of hiddenRows) {
+            row.classList.remove('row-hidden');
         }
     }
 }
@@ -164,8 +155,8 @@ function reinstallClickHandlers(table){
             var td = getAncestor(descDiv, "td");
             var row = td.parentNode;
             var decoration = content.lastElementChild;
-            var iconDecoration = decoration.children.item(0);
-            var collapsibleSpan = decoration.children.item(1);
+            var iconDecoration = decoration.firstElementChild.children.item(0);
+            var collapsibleSpan = decoration.firstElementChild.children.item(1);
             var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
                                                             collapsibleSpan,
                                                             iconDecoration);
@@ -178,6 +169,12 @@ function reinstallClickHandlers(table){
 function swapShadowTable(input){
     var currentTable = inputs[input.id].table;
     var shadowTable = inputs[input.id].shadowTable;
+
+    // makes sure hidden rows are always displayed when search term is defined
+    if (shadowTable.classList.contains('configuration-reference-all-rows')) {
+        shadowTable.classList.remove('configuration-reference-all-rows');
+    }
+
     currentTable.parentNode.replaceChild(shadowTable, currentTable);
     inputs[input.id].table = shadowTable;
     inputs[input.id].shadowTable = currentTable;
@@ -254,41 +251,9 @@ function getAncestor(element, name){
     return null;
 }
 
-/*
- * COLLAPSIBLE DESCRIPTION
- */
-function makeCollapsible(descDiv, descHeightLong){
-    if (descHeightLong > 25) {
-        var td = getAncestor(descDiv, "td");
-        var row = td.parentNode;
-        var iconDecoration = document.createElement("i");
-        descDiv.classList.add('description-collapsed');
-        iconDecoration.classList.add('fa', 'fa-chevron-down');
-
-        var descDecoration = document.createElement("div");
-        descDecoration.classList.add('description-decoration');
-        descDecoration.appendChild(iconDecoration);
-
-        var collapsibleSpan = document.createElement("span");
-        collapsibleSpan.appendChild(document.createTextNode("Show more"));
-        descDecoration.appendChild(collapsibleSpan);
-
-        var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
-                                                        collapsibleSpan,
-                                                        iconDecoration);
-
-        var parent = descDiv.parentNode;
-
-        parent.appendChild(descDecoration);
-        row.classList.add("row-collapsible", "row-collapsed");
-        row.addEventListener("click", collapsibleHandler);
-    }
-
-};
-
 function makeCollapsibleHandler(descDiv, td, row,
-    collapsibleSpan,
-    iconDecoration) {
+                                collapsibleSpan,
+                                iconDecoration) {
 
     return function(event) {
         var target = event.target;

--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -323,11 +323,19 @@ table.configuration-reference {
 }
 
 
-table.configuration-reference.tableblock > tbody { 
-  
+table.configuration-reference-all-rows.tableblock > tbody {
+
+  > tr.row-hidden {
+    display: none;
+  }
+}
+
+table.configuration-reference.tableblock > tbody {
+
   > tr > th {
     color: $dark-blue;
   }
+
   > tr {
     background: transparent;
     > th:nth-child(1) { width: 70%; }

--- a/_versions/2.13/guides/javascript/config.js
+++ b/_versions/2.13/guides/javascript/config.js
@@ -7,50 +7,41 @@ var tables = document.querySelectorAll("table.configuration-reference");
 var typingTimer;
 
 if(tables){
-    var idx = 0;
     for (var table of tables) {
         var caption = table.previousElementSibling;
         if (table.classList.contains('searchable')) { // activate search engine only when needed
-          var input = document.createElement("input");
-          input.setAttribute("type", "search");
-          input.setAttribute("placeholder", "FILTER CONFIGURATION");
-          input.id = "config-search-"+(idx++);
-          caption.children.item(0).appendChild(input);
+          var input = caption.firstElementChild.lastElementChild;
           input.addEventListener("keyup", initiateSearch);
           input.addEventListener("input", initiateSearch);
-          var descriptions = table.querySelectorAll(".description");
-          if(descriptions){
-            var heights = new Array(descriptions.length);
-            var h = 0;
-            for (description of descriptions){
-              heights[h++] = description.offsetHeight;
-            }
-            var shadowTable = table.cloneNode(true);
-            var shadowDescriptions = shadowTable.querySelectorAll(".description");
-            h = 0;
-            for (shadowDescription of shadowDescriptions){
-              makeCollapsible(shadowDescription, heights[h++]);
-            }
-            table.parentNode.replaceChild(shadowTable, table);
-            table = shadowTable;
-          }
+          input.attributes.removeNamedItem('disabled');
           inputs[input.id] = {"table": table};
         }
 
-        var rowIdx = 0;
-        for (var row of table.querySelectorAll("table.configuration-reference > tbody > tr")) {
-            var heads = row.querySelectorAll("table.configuration-reference > tbody > tr > th");
-            if(!heads || heads.length == 0){
-                // mark even rows
-                if(++rowIdx % 2){
-                    row.classList.add("odd");
-                }else{
-                    row.classList.remove("odd");
-                }
-            }else{
-                // reset count at each section
-                rowIdx = 0;
+        const collapsibleRows = table.querySelectorAll('tr.row-collapsible');
+        if (collapsibleRows) {
+            for (let row of collapsibleRows) {
+                const td = row.firstElementChild;
+                const decoration = td.firstElementChild.lastElementChild.firstElementChild;
+                const iconDecoration = decoration.children.item(0);
+                const collapsibleSpan = decoration.children.item(1);
+                const descDiv = td.firstElementChild.children.item(1);
+                const collapsibleHandler = makeCollapsibleHandler(descDiv, td, row, collapsibleSpan, iconDecoration);
+                row.addEventListener('click', collapsibleHandler);
             }
+        }
+
+        // render hidden rows asynchronously
+        setTimeout(() => renderHiddenRows());
+    }
+}
+
+function renderHiddenRows() {
+    // some rows are initially hidden so that user can hit the ground running
+    // we render them at this very moment, but when user can already use search function
+    const hiddenRows = document.querySelectorAll('table.configuration-reference-all-rows.tableblock > tbody > tr.row-hidden');
+    if (hiddenRows) {
+        for (row of hiddenRows) {
+            row.classList.remove('row-hidden');
         }
     }
 }
@@ -164,8 +155,8 @@ function reinstallClickHandlers(table){
             var td = getAncestor(descDiv, "td");
             var row = td.parentNode;
             var decoration = content.lastElementChild;
-            var iconDecoration = decoration.children.item(0);
-            var collapsibleSpan = decoration.children.item(1);
+            var iconDecoration = decoration.firstElementChild.children.item(0);
+            var collapsibleSpan = decoration.firstElementChild.children.item(1);
             var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
                                                             collapsibleSpan,
                                                             iconDecoration);
@@ -178,6 +169,12 @@ function reinstallClickHandlers(table){
 function swapShadowTable(input){
     var currentTable = inputs[input.id].table;
     var shadowTable = inputs[input.id].shadowTable;
+
+    // makes sure hidden rows are always displayed when search term is defined
+    if (shadowTable.classList.contains('configuration-reference-all-rows')) {
+        shadowTable.classList.remove('configuration-reference-all-rows');
+    }
+
     currentTable.parentNode.replaceChild(shadowTable, currentTable);
     inputs[input.id].table = shadowTable;
     inputs[input.id].shadowTable = currentTable;
@@ -254,41 +251,9 @@ function getAncestor(element, name){
     return null;
 }
 
-/*
- * COLLAPSIBLE DESCRIPTION
- */
-function makeCollapsible(descDiv, descHeightLong){
-    if (descHeightLong > 25) {
-        var td = getAncestor(descDiv, "td");
-        var row = td.parentNode;
-        var iconDecoration = document.createElement("i");
-        descDiv.classList.add('description-collapsed');
-        iconDecoration.classList.add('fa', 'fa-chevron-down');
-
-        var descDecoration = document.createElement("div");
-        descDecoration.classList.add('description-decoration');
-        descDecoration.appendChild(iconDecoration);
-
-        var collapsibleSpan = document.createElement("span");
-        collapsibleSpan.appendChild(document.createTextNode("Show more"));
-        descDecoration.appendChild(collapsibleSpan);
-
-        var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
-                                                        collapsibleSpan,
-                                                        iconDecoration);
-
-        var parent = descDiv.parentNode;
-
-        parent.appendChild(descDecoration);
-        row.classList.add("row-collapsible", "row-collapsed");
-        row.addEventListener("click", collapsibleHandler);
-    }
-
-};
-
 function makeCollapsibleHandler(descDiv, td, row,
-    collapsibleSpan,
-    iconDecoration) {
+                                collapsibleSpan,
+                                iconDecoration) {
 
     return function(event) {
         var target = event.target;

--- a/_versions/2.16/guides/javascript/config.js
+++ b/_versions/2.16/guides/javascript/config.js
@@ -7,50 +7,41 @@ var tables = document.querySelectorAll("table.configuration-reference");
 var typingTimer;
 
 if(tables){
-    var idx = 0;
     for (var table of tables) {
         var caption = table.previousElementSibling;
         if (table.classList.contains('searchable')) { // activate search engine only when needed
-          var input = document.createElement("input");
-          input.setAttribute("type", "search");
-          input.setAttribute("placeholder", "FILTER CONFIGURATION");
-          input.id = "config-search-"+(idx++);
-          caption.children.item(0).appendChild(input);
+          var input = caption.firstElementChild.lastElementChild;
           input.addEventListener("keyup", initiateSearch);
           input.addEventListener("input", initiateSearch);
-          var descriptions = table.querySelectorAll(".description");
-          if(descriptions){
-            var heights = new Array(descriptions.length);
-            var h = 0;
-            for (description of descriptions){
-              heights[h++] = description.offsetHeight;
-            }
-            var shadowTable = table.cloneNode(true);
-            var shadowDescriptions = shadowTable.querySelectorAll(".description");
-            h = 0;
-            for (shadowDescription of shadowDescriptions){
-              makeCollapsible(shadowDescription, heights[h++]);
-            }
-            table.parentNode.replaceChild(shadowTable, table);
-            table = shadowTable;
-          }
+          input.attributes.removeNamedItem('disabled');
           inputs[input.id] = {"table": table};
         }
 
-        var rowIdx = 0;
-        for (var row of table.querySelectorAll("table.configuration-reference > tbody > tr")) {
-            var heads = row.querySelectorAll("table.configuration-reference > tbody > tr > th");
-            if(!heads || heads.length == 0){
-                // mark even rows
-                if(++rowIdx % 2){
-                    row.classList.add("odd");
-                }else{
-                    row.classList.remove("odd");
-                }
-            }else{
-                // reset count at each section
-                rowIdx = 0;
+        const collapsibleRows = table.querySelectorAll('tr.row-collapsible');
+        if (collapsibleRows) {
+            for (let row of collapsibleRows) {
+                const td = row.firstElementChild;
+                const decoration = td.firstElementChild.lastElementChild.firstElementChild;
+                const iconDecoration = decoration.children.item(0);
+                const collapsibleSpan = decoration.children.item(1);
+                const descDiv = td.firstElementChild.children.item(1);
+                const collapsibleHandler = makeCollapsibleHandler(descDiv, td, row, collapsibleSpan, iconDecoration);
+                row.addEventListener('click', collapsibleHandler);
             }
+        }
+
+        // render hidden rows asynchronously
+        setTimeout(() => renderHiddenRows());
+    }
+}
+
+function renderHiddenRows() {
+    // some rows are initially hidden so that user can hit the ground running
+    // we render them at this very moment, but when user can already use search function
+    const hiddenRows = document.querySelectorAll('table.configuration-reference-all-rows.tableblock > tbody > tr.row-hidden');
+    if (hiddenRows) {
+        for (row of hiddenRows) {
+            row.classList.remove('row-hidden');
         }
     }
 }
@@ -164,8 +155,8 @@ function reinstallClickHandlers(table){
             var td = getAncestor(descDiv, "td");
             var row = td.parentNode;
             var decoration = content.lastElementChild;
-            var iconDecoration = decoration.children.item(0);
-            var collapsibleSpan = decoration.children.item(1);
+            var iconDecoration = decoration.firstElementChild.children.item(0);
+            var collapsibleSpan = decoration.firstElementChild.children.item(1);
             var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
                                                             collapsibleSpan,
                                                             iconDecoration);
@@ -178,6 +169,12 @@ function reinstallClickHandlers(table){
 function swapShadowTable(input){
     var currentTable = inputs[input.id].table;
     var shadowTable = inputs[input.id].shadowTable;
+
+    // makes sure hidden rows are always displayed when search term is defined
+    if (shadowTable.classList.contains('configuration-reference-all-rows')) {
+        shadowTable.classList.remove('configuration-reference-all-rows');
+    }
+
     currentTable.parentNode.replaceChild(shadowTable, currentTable);
     inputs[input.id].table = shadowTable;
     inputs[input.id].shadowTable = currentTable;
@@ -254,41 +251,9 @@ function getAncestor(element, name){
     return null;
 }
 
-/*
- * COLLAPSIBLE DESCRIPTION
- */
-function makeCollapsible(descDiv, descHeightLong){
-    if (descHeightLong > 25) {
-        var td = getAncestor(descDiv, "td");
-        var row = td.parentNode;
-        var iconDecoration = document.createElement("i");
-        descDiv.classList.add('description-collapsed');
-        iconDecoration.classList.add('fa', 'fa-chevron-down');
-
-        var descDecoration = document.createElement("div");
-        descDecoration.classList.add('description-decoration');
-        descDecoration.appendChild(iconDecoration);
-
-        var collapsibleSpan = document.createElement("span");
-        collapsibleSpan.appendChild(document.createTextNode("Show more"));
-        descDecoration.appendChild(collapsibleSpan);
-
-        var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
-                                                        collapsibleSpan,
-                                                        iconDecoration);
-
-        var parent = descDiv.parentNode;
-
-        parent.appendChild(descDecoration);
-        row.classList.add("row-collapsible", "row-collapsed");
-        row.addEventListener("click", collapsibleHandler);
-    }
-
-};
-
 function makeCollapsibleHandler(descDiv, td, row,
-    collapsibleSpan,
-    iconDecoration) {
+                                collapsibleSpan,
+                                iconDecoration) {
 
     return function(event) {
         var target = event.target;

--- a/_versions/main/guides/javascript/config.js
+++ b/_versions/main/guides/javascript/config.js
@@ -7,50 +7,41 @@ var tables = document.querySelectorAll("table.configuration-reference");
 var typingTimer;
 
 if(tables){
-    var idx = 0;
     for (var table of tables) {
         var caption = table.previousElementSibling;
         if (table.classList.contains('searchable')) { // activate search engine only when needed
-          var input = document.createElement("input");
-          input.setAttribute("type", "search");
-          input.setAttribute("placeholder", "FILTER CONFIGURATION");
-          input.id = "config-search-"+(idx++);
-          caption.children.item(0).appendChild(input);
+          var input = caption.firstElementChild.lastElementChild;
           input.addEventListener("keyup", initiateSearch);
           input.addEventListener("input", initiateSearch);
-          var descriptions = table.querySelectorAll(".description");
-          if(descriptions){
-            var heights = new Array(descriptions.length);
-            var h = 0;
-            for (description of descriptions){
-              heights[h++] = description.offsetHeight;
-            }
-            var shadowTable = table.cloneNode(true);
-            var shadowDescriptions = shadowTable.querySelectorAll(".description");
-            h = 0;
-            for (shadowDescription of shadowDescriptions){
-              makeCollapsible(shadowDescription, heights[h++]);
-            }
-            table.parentNode.replaceChild(shadowTable, table);
-            table = shadowTable;
-          }
+          input.attributes.removeNamedItem('disabled');
           inputs[input.id] = {"table": table};
         }
 
-        var rowIdx = 0;
-        for (var row of table.querySelectorAll("table.configuration-reference > tbody > tr")) {
-            var heads = row.querySelectorAll("table.configuration-reference > tbody > tr > th");
-            if(!heads || heads.length == 0){
-                // mark even rows
-                if(++rowIdx % 2){
-                    row.classList.add("odd");
-                }else{
-                    row.classList.remove("odd");
-                }
-            }else{
-                // reset count at each section
-                rowIdx = 0;
+        const collapsibleRows = table.querySelectorAll('tr.row-collapsible');
+        if (collapsibleRows) {
+            for (let row of collapsibleRows) {
+                const td = row.firstElementChild;
+                const decoration = td.firstElementChild.lastElementChild.firstElementChild;
+                const iconDecoration = decoration.children.item(0);
+                const collapsibleSpan = decoration.children.item(1);
+                const descDiv = td.firstElementChild.children.item(1);
+                const collapsibleHandler = makeCollapsibleHandler(descDiv, td, row, collapsibleSpan, iconDecoration);
+                row.addEventListener('click', collapsibleHandler);
             }
+        }
+
+        // render hidden rows asynchronously
+        setTimeout(() => renderHiddenRows());
+    }
+}
+
+function renderHiddenRows() {
+    // some rows are initially hidden so that user can hit the ground running
+    // we render them at this very moment, but when user can already use search function
+    const hiddenRows = document.querySelectorAll('table.configuration-reference-all-rows.tableblock > tbody > tr.row-hidden');
+    if (hiddenRows) {
+        for (row of hiddenRows) {
+            row.classList.remove('row-hidden');
         }
     }
 }
@@ -164,8 +155,8 @@ function reinstallClickHandlers(table){
             var td = getAncestor(descDiv, "td");
             var row = td.parentNode;
             var decoration = content.lastElementChild;
-            var iconDecoration = decoration.children.item(0);
-            var collapsibleSpan = decoration.children.item(1);
+            var iconDecoration = decoration.firstElementChild.children.item(0);
+            var collapsibleSpan = decoration.firstElementChild.children.item(1);
             var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
                                                             collapsibleSpan,
                                                             iconDecoration);
@@ -178,6 +169,12 @@ function reinstallClickHandlers(table){
 function swapShadowTable(input){
     var currentTable = inputs[input.id].table;
     var shadowTable = inputs[input.id].shadowTable;
+
+    // makes sure hidden rows are always displayed when search term is defined
+    if (shadowTable.classList.contains('configuration-reference-all-rows')) {
+        shadowTable.classList.remove('configuration-reference-all-rows');
+    }
+
     currentTable.parentNode.replaceChild(shadowTable, currentTable);
     inputs[input.id].table = shadowTable;
     inputs[input.id].shadowTable = currentTable;
@@ -254,41 +251,9 @@ function getAncestor(element, name){
     return null;
 }
 
-/*
- * COLLAPSIBLE DESCRIPTION
- */
-function makeCollapsible(descDiv, descHeightLong){
-    if (descHeightLong > 25) {
-        var td = getAncestor(descDiv, "td");
-        var row = td.parentNode;
-        var iconDecoration = document.createElement("i");
-        descDiv.classList.add('description-collapsed');
-        iconDecoration.classList.add('fa', 'fa-chevron-down');
-
-        var descDecoration = document.createElement("div");
-        descDecoration.classList.add('description-decoration');
-        descDecoration.appendChild(iconDecoration);
-
-        var collapsibleSpan = document.createElement("span");
-        collapsibleSpan.appendChild(document.createTextNode("Show more"));
-        descDecoration.appendChild(collapsibleSpan);
-
-        var collapsibleHandler = makeCollapsibleHandler(descDiv, td, row,
-                                                        collapsibleSpan,
-                                                        iconDecoration);
-
-        var parent = descDiv.parentNode;
-
-        parent.appendChild(descDecoration);
-        row.classList.add("row-collapsible", "row-collapsed");
-        row.addEventListener("click", collapsibleHandler);
-    }
-
-};
-
 function makeCollapsibleHandler(descDiv, td, row,
-    collapsibleSpan,
-    iconDecoration) {
+                                collapsibleSpan,
+                                iconDecoration) {
 
     return function(event) {
         var target = event.target;


### PR DESCRIPTION
Improves UX (mostly) on All config page by:

- moving majority of DOM manipulation to build time so that CSS classes and elements are added at build time so as page is loading, there are no jumps when description is adjusted and background color changes and search input jumps in (now search input is there, but disabled till searching is ready)
- initial loading of page should be quicker and page should be ready for searching sooner (for example in my browser current develop branch loads somewhere between 5s and 14s), majority of time is spend on rendering of HTML elements (rows), so now search is instantiated with not rendered elements (but already in DOM, so available for searching) and then they are being rendered

Cons:

- right now there is no way to alter `<tr>` element via Asciidoc, so I had to manipulate with `<tr>` via string operations which could make for slower `./serve.sh` build; I measured it as I was making final touches and here are times in seconds:
  - with adjustments: 188.046, 163.365, 149.984, 151.844, 182.804, 143.232, 196.535, 153.63, 156.701, 137.191, 272.267, 149.776, 148.65
  - without adjustments (smoke test with 'develop' branch): 102.5, 96,374
- JS DOM manipulation is kinda more robust than Asciidoc macros

IMHO it looks better, so in this special case (config properties) pros have it.