### PR TITLE
Add Quarkiverse Hub to extensions navigation menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ These instructions will get you a copy of the Quarkus.io website up and running 
   
         ./serve.sh
 
-   Or if you want it faster and okey to not have guides included use the following:
+   Or if you want it faster and okay to not have guides included use the following:
 
         ./serve-noguides.sh
 

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -37,6 +37,7 @@
           <li><a href="https://quarkus.io/extensions/" class="{% if page.url contains '/extensions/' %}active{% endif %}">BROWSE EXTENSIONS</a></li>
           <li><a href="{{site.baseurl}}/faq/#what-is-a-quarkus-extension" class="{% if page.url contains 'what-is-a-quarkus-extension' %}active{% endif %}">USE EXTENSIONS</a></li>
           <li><a href="{{site.baseurl}}/guides/writing-extensions" class="{% if page.url contains '/guides/writing-extensions' %}active{% endif %}">CREATE EXTENSIONS</a></li>
+          <li><a href="https://hub.quarkiverse.io" class="{% if page.url contains 'hub.quarkiverse.io' %}active{% endif %}">SHARE EXTENSIONS</a></li>
         </ul>
       </li>
       <li class="dropdown">


### PR DESCRIPTION
Now that the Quarkiverse hub has a memorable URL, we should link to it from the extensions menu. 

The Quarkiverse Hub content isn't at the same standard as the rest of our documentation, but it's useful to extension authors. Historically, it was hosted on a wiki and wasn't indexed, but having it linked from the rest of our pages will also ensure it's indexed. 