### PR TITLE
Update node 12 actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: echo ${{ github.event.number }} > ./_site/pr-id.txt
 
       - name: Publishing directory for PR preview
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: site
           path: ./_site


### PR DESCRIPTION
Resolves #1597. Of the three actions mentioned by @gastaldi in the original issue, one seems to have done a same-version update, and one is no longer used. But I've updated the last one, to resolve the build warning.