### PR TITLE
Update standards.html

### DIFF
--- a/_includes/standards.html
+++ b/_includes/standards.html
@@ -61,7 +61,7 @@
     </div>
     <div class="width-9-12 width-12-12-m">
       <a href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.18.0/specification/trace">OpenTelemetry Trace 1.18</a>
-      <br></b><a href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.18.0/specification/context">OpenTelemetry Context 1.18</a>
+      <br><a href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.18.0/specification/context">OpenTelemetry Context 1.18</a>
       <br><a href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.18.0/specification/baggage">OpenTelemetry Baggage 1.18</a>
       <br><a href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.18.0/specification/resource">OpenTelemetry Resource 1.18</a>
     </div>


### PR DESCRIPTION
It might be a typo and makes the our translate to Chinese languange process failing  when parsing the html contents.

```
upstream/_includes/standards.html:64: (po4a::xml)
Unexpected closing tag </b> found. The main document may be wrong.
```

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
