### PR TITLE
lra-coordinator docker image has been moved to quay.io

### DIFF
--- a/_posts/2021-09-01-using-lra.adoc
+++ b/_posts/2021-09-01-using-lra.adoc
@@ -23,7 +23,7 @@ IMPORTANT: The extension provides an implementation of the https://download.ecli
 
 == LRA coordinators
 
-The `narayana-lra` extension requires the presence of a running coordinator in the environment. Coordinators can be obtained from `https://hub.docker.com/r/jbosstm/lra-coordinator`
+The `narayana-lra` extension requires the presence of a running coordinator in the environment. Coordinators can be obtained from `https://quay.io/repository/jbosstm/lra-coordinator`
 or you can build your own coordinator using a maven pom that includes the appropriate dependencies. For the purpose of this blog we'll show how to create one from scratch using the `quarkus-maven-plugin`.
 There is some extra information about configuring the coordinator in one of the https://jbossts.blogspot.com/2021/07/narayana-lra-update.html[narayana blogs].
 


### PR DESCRIPTION
Updating documentation, docker image repository changed.