### PR TITLE
Update header navigation with new 'Why Quarkus' tab

### DIFF
--- a/_includes/ecosystem.html
+++ b/_includes/ecosystem.html
@@ -1,0 +1,42 @@
+<div class="full-width-bg component">
+    <div class="grid-wrapper">
+      <div class="width-3-12 width-12-12-m">
+        <img src="{{site.baseurl}}/assets/images/about/icon-standards.svg">
+      </div>
+      <div class="width-9-12 width-12-12-m">
+        <p class="intropara">Quarkus heavily leverages other mature projects from the Java Ecosystem. Quarkus favours the philosophy of building on the shoulders of giants, rather than re-inventing the wheel. Below are some of the community projects that Quarkus builds upon.</p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://vertx.io/">Eclipse Vert.x</a></h3>
+        <p>The Eclipse Vert.x project enables writing of reactive applications that run on the JVM. The project powers the reactive aspects of Quarkus.</p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://smallrye.io/">SmallRye</a></h3>
+        <p>The SmallRye project offers implementations of the <a href="https://microprofile.io/">Eclipse MicroProfile</a> specifications that are used by the Quarkus runtime. Examples of the MicroProfile specifications implemented by SmallRye and leveraged by Quarkus are <a href="https://github.com/eclipse/microprofile-metrics">Metrics</a>, <a href="https://github.com/eclipse/microprofile-health">Health</a>, and <a href="https://github.com/eclipse/microprofile-fault-tolerance">Fault Tolerance.</a></p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://hibernate.org/">Hibernate</a></h3>
+        <p>The Hibernate project provides an implementation of the Java Persistence API (JPA) that is leveraged by the Quarkus runtime to enable working with databases.</p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://netty.io/">Netty</a></h3>
+        <p>The Netty project offers capabilities for building asynchronous, event-driven, network applications. Together with Vert.x, Netty powers the reactive + async core of Quarkus, enabling event-driven architectures.</p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://resteasy.dev/">RESTEasy</a></h3>
+        <p>RESTEasy provides implementations for both the <a href="https://github.com/jakartaee/rest">JAX-RS</a> and <a href="https://github.com/eclipse/microprofile-rest-client">MicroProfile REST Client</a> specifications. Quarkus leverages these RESTEasy implementations to allow building of applications that follow the REST architectural style.</p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://camel.apache.org/">Apache Camel</a></h3>
+        <p>The Apache Camel project provides capabilities for integrating heterogeneous (messaging/event-based) systems. The support for Apache Camel on top of Quarkus is provided by the <a href="https://github.com/apache/camel-quarkus">Apache Camel Quarkus project.</a></p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://microprofile.io/">Eclipse MicroProfile</a></h3>
+        <p>The Eclipse MicroProfile project brings together a set of specifications that makes it easier to write Java applications based on the microservices architecture.</p>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3><a href="https://github.com/graalvm/mandrel">Mandrel</a></h3>
+        <p>Mandrel is a <a href="https://developers.redhat.com/blog/2020/06/05/mandrel-a-community-distribution-of-graalvm-for-the-red-hat-build-of-quarkus">downstream distribution</a> of the <a href="https://www.graalvm.org/">GraalVM</a> community edition. Mandrel focuses on GraalVM's <i>native-image</i> component in order to provide an easy way for Quarkus users to generate native images for their applications.</p>
+      </div>
+    </div>
+</div>

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -14,6 +14,12 @@
         <span href="{{site.baseurl}}/about/">About<i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/about" class="{% if page.url contains '/about/' %}active{% endif %}">WHAT IS QUARKUS?</a></li>
+          <li><a href="{{site.baseurl}}/ecosystem" class="{% if page.url contains '/ecosystem/' %}active{% endif %}">ECOSYSTEM</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <span href="{{site.baseurl}}/why-quarkus/">Why Quarkus<i class="fas fa-chevron-down"></i></span>
+        <ul class="submenu">
           <li><a href="{{site.baseurl}}/container-first" class="{% if page.url contains '/container-first/' %}active{% endif %}">CONTAINER FIRST</a></li>
           <li><a href="{{site.baseurl}}/continuum" class="{% if page.url contains '/continuum/' %}active{% endif %}">REACTIVE</a></li>
           <li><a href="{{site.baseurl}}/developer-joy" class="{% if page.url contains '/developer-joy/' %}active{% endif %}">DEVELOPER JOY</a></li>
@@ -25,7 +31,7 @@
         <span href="{{site.baseurl}}/learn/">Learn<i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/get-started" class="{% if page.url contains '/get-started/' %}active{% endif %}">GET STARTED</a></li>
-          <li><a href="{{site.baseurl}}/guides" class="{% if page.url contains '/guides/' %}active{% endif %}">DOCUMENTATION</a></li>
+          <li><a href="{{site.baseurl}}/guides" class="{% if page.url contains '/guides/' %}active{% endif %}">GUIDES</a></li>
           <li><a href="{{site.baseurl}}/qtips" class="{% if page.url contains '/qtips/' %}active{% endif %}">"Q" TIP VIDEOS</a></li>          
           <li><a href="{{site.baseurl}}/books" class="{% if page.url contains '/books/' %}active{% endif %}">BOOKS</a></li>
           </ul>

--- a/_layouts/ecosystem.html
+++ b/_layouts/ecosystem.html
@@ -1,0 +1,7 @@
+---
+layout: base
+---
+
+{% include title-band.html %}
+
+{% include ecosystem.html %}

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -1,0 +1,6 @@
+---
+layout: ecosystem
+title: Ecosystem
+subtitle: Quarkus is made up of community projects.
+permalink: /ecosystem/
+---


### PR DESCRIPTION
**Short summary**:
This PR updates the header navigation with a new "Why Quarkus" menu tab that contains five of the six items that were previously under the "About" tab.

**Changes made**:

- Add a new "Why Quarkus" dropdown menu tab with links to the main reasons for choosing/using Quarkus (container-first, reactive, developer joy, kubernetes, standards).
![image](https://github.com/quarkusio/quarkusio.github.io/assets/8336086/1ce320eb-0430-4ca2-b38b-819322820b38)
**Motivation**: 
I think that having the strengths/advantages of Quarkus listed under the _About_ tab seems a bit odd (and less conspicuous). I think having them under the "Why Quarkus" tab clearly speaks to the reasons WHY one would/should choose Quarkus.
- Add a new item under the "About" dropdown tab that describes the Quarkus ecosystem of community projects (I'd appreciate feedback on the description of some of the projects - I'm not an expert in Quarkus...yet).
![image](https://github.com/quarkusio/quarkusio.github.io/assets/8336086/8468cdb7-6f38-4467-ac20-7d28fe585326)
**Motivation**: 
Instead of having only a single item under the "About" menu tab (having moved the rest to the "Why Quarkus" section), I think adding a section giving brief descriptions of some of the community projects that Quarkus leverages makes sense (and aligns with the theme of sharing something extra "about" the Quarkus framework).
- Rename "Documentation" to "Guides" under the "Learn" menu tab.
![image](https://github.com/quarkusio/quarkusio.github.io/assets/8336086/807e2ddc-c850-4ed7-8e62-f8491d43a192)
**Motivation**: 
While "guides" can technically be considered as a subset/type of documentation, I think documentation "proper" has a more broader sense. The existing content has a mix of tutorials, how-to guides, conceptual docs, and references. My point of view is that only the first two categories fit well under "guides", and perhaps we need to introduce another section for documentation (maybe quarkus.io/docs?). That would then host the conceptual docs, references, and a "user guide" (that covers things like: Dependency Injection in Quarkus, Testing in Quarkus, Data Access/ ORM in Quarkus, Security in Quarkus,etc.). We could even have Quarkus API documentation in there too. I'd be curious to know what other folks think about this suggestion/proposed change.


cc: @gsmet 


