### PR TITLE
Allow NodeJS 12 containers in GitHub Actions

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -3,6 +3,8 @@ name: Surge.sh Preview Teardown
 on:
   pull_request_target:
     types: [closed]
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   preview-teardown:
@@ -12,7 +14,7 @@ jobs:
         id: deploy
         run: npx surge teardown https://quarkus-website-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment
-        uses: actions-cool/maintain-one-comment@v3.0.0
+        uses: actions-cool/maintain-one-comment@v3.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Build"]
     types:
       - completed
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   preview:
@@ -26,7 +28,7 @@ jobs:
       id: deploy
       run: npx surge ./ --domain https://quarkus-website-pr-${{  steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
     - name: Update PR status comment on success
-      uses: actions-cool/maintain-one-comment@v3.0.0
+      uses: actions-cool/maintain-one-comment@v3.1.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         body: |
@@ -37,7 +39,7 @@ jobs:
         number: ${{ steps.pr.outputs.id }}
     - name: Update PR status comment on failure
       if: ${{ failure() }}
-      uses: actions-cool/maintain-one-comment@v3.0.0
+      uses: actions-cool/maintain-one-comment@v3.1.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         body: |


### PR DESCRIPTION
The actions-cool/maintain-one-comment@v3.1.0 needs to be upgraded to Node 16. Until this is done, we need to set this
environment variable to allow Node 12 containers to run in GitHub Actions.

- See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
for details
- Also done in https://github.com/quarkusio/quarkus/pull/35658