### PR TITLE
Change name of About prime nav element to Why

### DIFF
--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -11,7 +11,7 @@
     </label>
     <ul id="menu" class="menu">
       <li class="dropdown">
-        <span href="{{site.baseurl}}/about/">About<i class="fas fa-chevron-down"></i></span>
+        <span href="{{site.baseurl}}/about/">Why<i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/about" class="{% if page.url contains '/about/' %}active{% endif %}">WHAT IS QUARKUS?</a></li>
           <li><a href="{{site.baseurl}}/container-first" class="{% if page.url contains '/container-first/' %}active{% endif %}">CONTAINER FIRST</a></li>


### PR DESCRIPTION
Based on a suggestion from the community (@chrischiedo), we're going to change the **About** prime navigation element to **Why**. This needs to be coordinated with @holly-cummins  as the prime navigation needs to be udpated in the Extensions app as well.