### PR TITLE
Add section about inspiration behind Quarkus

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -30,4 +30,11 @@
       <p>This is helpful for both Java developers who are used to working with the imperative model and don’t want to switch things up, and those working with a cloud-native/reactive approach. The Quarkus development model can adapt itself to whatever app you’re developing. <br><a href="/continuum/">Learn more about Reactive</a></p>
     </div>
   </div>
+  <h2>The inspiration behind Quarkus...</h2>
+    <p>Quarkus 1.0 was released back in November 2019. For more about the why, how and what of Quarkus, check out this presentation by Emmanuel Bernard given at Devoxx Belgium in 2019. Emmanuel works at Red Hat as a senior distinguished engineer and he is the co-lead/co-founder of the Quarkus project. He is also a Java Champion. Curious to know where the name "Quarkus" comes from? Check out Emmanuel's presentation!</p>
+    <div class="width-7-12 width-12-12-m">
+      <div class="iframe-container">
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/SQDR34KoC-8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </div>
+    </div>
 </div>


### PR DESCRIPTION
Draft PR to add a section about the inspiration/motivation behind the Quarkus project with a link to a [presentation](https://www.youtube.com/watch?v=SQDR34KoC-8&t=2562s) that was given by Emmanuel Bernard just after the release of Quarkus 1.0. I think that the presentation provides a great background context about the project that most people would highly appreciate.

@insectengine I'd be curious to know if you think this would be a valuable addition to the page (if not, I'll promptly close this PR).

If this change is accepted, it could be merged with the changes proposed in PR #1780.
