### PR TITLE
Add BR to the Portuguese menu items

### DIFF
--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -66,7 +66,7 @@ links:
         code: en
         url: https://quarkus.io/
       - page: Português (Brasileiro)
-        code: pt
+        code: pt-br
         url: https://pt.quarkus.io/
       - page: Español
         code: es

--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -65,7 +65,7 @@ links:
       - page: English
         code: en
         url: https://quarkus.io/
-      - page: Português
+      - page: Português (Brasileiro)
         code: pt
         url: https://pt.quarkus.io/
       - page: Español

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -59,7 +59,7 @@
         <span href="{{site.baseurl}}/language/"><div class="fas fa-globe langicon"></div><i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="https://quarkus.io{{ page.url }}" >OFFICIAL (ENGLISH)</a></li>
-          <li><a href="https://pt.quarkus.io{{ page.url }}">PORTUGUÊS</a></li>
+          <li><a href="https://pt.quarkus.io{{ page.url }}">PORTUGUÊS (BRASILEIRO)</a></li>
           <li><a href="https://es.quarkus.io{{ page.url }}">ESPAÑOL</a></li>
           <li><a href="https://cn.quarkus.io{{ page.url }}">简体中文</a></li>
           <li><a href="https://ja.quarkus.io{{ page.url }}">日本語</a></li>

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -59,7 +59,7 @@
         <span href="{{site.baseurl}}/language/"><div class="fas fa-globe langicon"></div><i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="https://quarkus.io{{ page.url }}" >OFFICIAL (ENGLISH)</a></li>
-          <li><a href="https://pt.quarkus.io{{ page.url }}">PORTUGUÊS (BRASILEIRO)</a></li>
+          <li><a href="https://pt.quarkus.io{{ page.url }}">PORTUGUÊS (BR)</a></li>
           <li><a href="https://es.quarkus.io{{ page.url }}">ESPAÑOL</a></li>
           <li><a href="https://cn.quarkus.io{{ page.url }}">简体中文</a></li>
           <li><a href="https://ja.quarkus.io{{ page.url }}">日本語</a></li>


### PR DESCRIPTION
- This makes pt.quarkus.io explicit about being pt_BR and not pt_PT
