### PR TITLE
Exclude all versioned guides (only latest guides are left)

### DIFF
--- a/_only_latest_guides_config.yml
+++ b/_only_latest_guides_config.yml
@@ -1,3 +1,2 @@
 exclude:
-  - _versions/2.13
-  - _versions/2.7
+  - _versions


### PR DESCRIPTION
Version is added time to time. Not to break the preview site deploy by exceeding surge.sh size limit, exclude all the versioned guides except latest guides.

(Japanese localized site preview is affected by recent minor release: https://github.com/quarkusio/ja.quarkus.io/actions/runs/6686496521/job/18165982368?pr=1087)