### PR TITLE
Fix author for 2023-11-08-quarkus-3-2-8-final-released.adoc

### DIFF
--- a/_posts/2023-11-08-quarkus-3-2-8-final-released.adoc
+++ b/_posts/2023-11-08-quarkus-3-2-8-final-released.adoc
@@ -4,7 +4,7 @@ title: 'Quarkus 3.2.8.Final released - Maintenance release'
 date: 2023-11-08
 tags: release
 synopsis: 'Quarkus 3.2.8.Final is the eighth maintenance release of the 3.2 LTS release train. It fixes CVE-2023-5720 and other bug fixes'
-author: aloubyansky
+author: alexeyloubyansky
 ---
 
 Today, we released Quarkus 3.2.8.Final, the eighth maintenance release of the 3.2 LTS release train.


### PR DESCRIPTION
Defined author is alexeyloubyansky
See https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/authors.yaml#L92


Current state (no author details) for 3.2.8 announce compared to 3.5.0 one:

<img width="931" alt="Screenshot 2023-11-08 at 20 54 41" src="https://github.com/quarkusio/quarkusio.github.io/assets/925259/7b695ecb-d7db-4de6-b9c8-23b7777d6edc">
