### PR TITLE
add governance page and links to threads and socials page

### DIFF
--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -22,10 +22,16 @@ links:
         url: /security
       - page: Usage
         url: /usage
+      - page: Governance
+        url: /governance
 
   - title: Follow Us
     width: 1
     subfolderitems:
+      - page: All Socials
+        url: /socials
+      - page: Threads
+        url: https://www.threads.net/@quarkusio
       - page: Twitter
         url: https://twitter.com/quarkusio
       - page: Mastodon

--- a/_includes/governance.html
+++ b/_includes/governance.html
@@ -1,0 +1,22 @@
+<div class="full-width-bg component">
+  <div class="grid-wrapper">
+    <div class="width-12-12 width-12-12-m">
+      <h2>Stewardship</h2>
+      <p>This project is developed and released by Red Hat with assistance from the Java developer community. The project lead is appointed by Red Hat, and has the power to accept and reject contributions to the project and set the roadmap. Red Hat employees assigned to work on Quarkus as well as community contributors, in this regard, all answer to the project lead.</p>
+      <h2>What Makes Quarkus Different?</h2>
+    </div>
+    <div class="width-12-12 width-12-12-m">
+      <h3>Requirement Definition </h3>
+      <p>The requirements and roadmap for Quarkus are driven by Red Hat and by the community. Typically, when a major release is being planned, the project lead will take input from both Red Hat and the community, and evaluate what can be done in the necessary time. This will define what features will be addressed in a given release. The project lead will then publish the roadmap on the developers mailing list, and update the version information in Github.</p>
+      <p>The best way for you to suggest requirements for a future release of Quarkus is to enter a feature request in <a href="https://github.com/quarkusio/quarkus/issues">Github</a>. Lobbying for features using the voting feature in Github, and posting to the community forums, is a great way to express interest as well. Although, contributing is the single most expedient way to get a capability into a particular release.</p>
+    </div>
+    <div class="width-12-12 width-12-12-m">
+      <h3>Release Cycle </h3>
+      <p>Quarkus releases frequently. We deliver frequent milestones, typically one a month, and support building from "main" for those that wish to be on the bleeding edge.</p>
+    </div>
+    <div class="width-12-12 width-12-12-m">
+      <h3>Contribution</h3>
+      <p>Quarkus welcomes, thrives on and greatly values community contribution.</p>
+    </div>
+  </div>
+</div>

--- a/_layouts/governance.html
+++ b/_layouts/governance.html
@@ -1,0 +1,7 @@
+---
+layout: base
+---
+
+{% include title-band.html %}
+
+{% include governance.html %}

--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,6 @@
+---
+layout: governance
+title: Governance
+subtitle: The underlying principles driving Quarkus development.
+permalink: /governance/
+---


### PR DESCRIPTION
Added a governance page using the Narayana project's as a base. The content needs to be reviewed and updated to better reflect the Quarkus project.