### PR TITLE
Make purpose of quarkus-dev mailing list more clear

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,4 +11,4 @@ contact_links:
     about: If you prefer live chat with the developers, we have a Zulip chat where we all hang out.
   - name: Quarkus Development mailing list 
     url: https://groups.google.com/forum/#!forum/quarkus-dev
-    about: You can also ask questions on our mailing list.
+    about: Mailing list for discussing development of Quarkus itself, and development of Quarkus extensions


### PR DESCRIPTION
The current description makes it sound like a general-purpose user forum, which it is now.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
