### PR TITLE
Update quarkiverse guide links

### DIFF
--- a/_data/guides-2-13.yaml
+++ b/_data/guides-2-13.yaml
@@ -239,11 +239,11 @@ categories:
         url: /guides/cassandra
         description: This guide covers how to use the Apache Cassandra NoSQL database in Quarkus.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Google Cloud BigQuery
@@ -570,35 +570,35 @@ categories:
         url: /guides/funqy-gcp-functions-http
         description: This guide explains Funqy's Google Cloud Platform Functions HTTP binding.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon KMS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-kms.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-kms.html
         description: This guide covers how to use the Amazon Key Management Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon IAM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-iam.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-iam.html
         description: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SES
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ses.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-ses.html
         description: This guide covers how to use the Amazon Simple Email Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SNS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sns.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-sns.html
         description: This guide covers how to use the Amazon Simple Notification Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SQS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sqs.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-sqs.html
         description: This guide covers how to use the Amazon Simple Queue Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SSM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ssm.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-ssm.html
         description: This guide covers how to use the AWS Systems Manager in Quarkus.
         origin: quarkiverse-hub
       - title: Access Google Cloud services

--- a/_data/guides-2-7.yaml
+++ b/_data/guides-2-7.yaml
@@ -227,11 +227,11 @@ categories:
         url: /guides/cassandra
         description: This guide covers how to use the Apache Cassandra NoSQL database in Quarkus.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Google Cloud BigQuery
@@ -533,35 +533,35 @@ categories:
         url: /guides/funqy-gcp-functions-http
         description: This guide explains Funqy's Google Cloud Platform Functions HTTP binding.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon KMS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-kms.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-kms.html
         description: This guide covers how to use the Amazon Key Management Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon IAM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-iam.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-iam.html
         description: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SES
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ses.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-ses.html
         description: This guide covers how to use the Amazon Simple Email Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SNS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sns.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-sns.html
         description: This guide covers how to use the Amazon Simple Notification Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SQS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sqs.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-sqs.html
         description: This guide covers how to use the Amazon Simple Queue Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SSM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ssm.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-ssm.html
         description: This guide covers how to use the AWS Systems Manager in Quarkus.
         origin: quarkiverse-hub
       - title: Access Google Cloud services

--- a/_data/versioned/main/index/quarkiverse.yaml
+++ b/_data/versioned/main/index/quarkiverse.yaml
@@ -6,12 +6,12 @@ types:
     categories: data
     origin: quarkiverse-hub
   - title: Amazon DynamoDB
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-dynamodb.html
     summary: This guide covers how to use the Amazon DynamoDB database in Quarkus.
     categories: data
     origin: quarkiverse-hub
   - title: Amazon S3
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-s3.html
     summary: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
     categories: data
     origin: quarkiverse-hub
@@ -81,42 +81,42 @@ types:
     categories: security
     origin: quarkiverse-hub
   - title: Amazon DynamoDB
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-dynamodb.html
     summary: This guide covers how to use the Amazon DynamoDB database in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon KMS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-kms.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-kms.html
     summary: This guide covers how to use the Amazon Key Management Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon IAM
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-iam.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-iam.html
     summary: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon S3
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-s3.html
     summary: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SES
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ses.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-ses.html
     summary: This guide covers how to use the Amazon Simple Email Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SNS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sns.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-sns.html
     summary: This guide covers how to use the Amazon Simple Notification Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SQS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sqs.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-sqs.html
     summary: This guide covers how to use the Amazon Simple Queue Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SSM
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ssm.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-ssm.html
     summary: This guide covers how to use the AWS Systems Manager in Quarkus.
     categories: cloud
     origin: quarkiverse-hub

--- a/_data/versioned/main/index/quarkiverse.yaml
+++ b/_data/versioned/main/index/quarkiverse.yaml
@@ -8,12 +8,12 @@ types:
   - title: Amazon DynamoDB
     url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-dynamodb.html
     summary: This guide covers how to use the Amazon DynamoDB database in Quarkus.
-    categories: data
+    categories: "data, cloud"
     origin: quarkiverse-hub
   - title: Amazon S3
     url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-s3.html
     summary: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
-    categories: data
+    categories: "data, cloud"
     origin: quarkiverse-hub
   - title: Google Cloud BigQuery
     url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/bigquery.html
@@ -80,11 +80,6 @@ types:
     summary: Generate X.509 certificates with Vault’s PKI Secret Engine.
     categories: security
     origin: quarkiverse-hub
-  - title: Amazon DynamoDB
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-dynamodb.html
-    summary: This guide covers how to use the Amazon DynamoDB database in Quarkus.
-    categories: cloud
-    origin: quarkiverse-hub
   - title: Amazon KMS
     url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-kms.html
     summary: This guide covers how to use the Amazon Key Management Service in Quarkus.
@@ -93,11 +88,6 @@ types:
   - title: Amazon IAM
     url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-iam.html
     summary: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
-    categories: cloud
-    origin: quarkiverse-hub
-  - title: Amazon S3
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-s3.html
-    summary: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SES

--- a/_versions/2.13/guides/_attributes.adoc
+++ b/_versions/2.13/guides/_attributes.adoc
@@ -43,7 +43,7 @@
 // .
 :amazon-services-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html
 :config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html
-:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/dev/index.html
+:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/2.x/index.html
 :neo4j-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-neo4j/dev/index.html
 :vault-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html
 :vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html

--- a/_versions/2.16/guides/_attributes.adoc
+++ b/_versions/2.16/guides/_attributes.adoc
@@ -45,7 +45,7 @@
 // .
 :amazon-services-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html
 :config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html
-:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/dev/index.html
+:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/2.x/index.html
 :neo4j-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-neo4j/dev/index.html
 :vault-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html
 :vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html

--- a/_versions/2.7/guides/attributes.adoc
+++ b/_versions/2.7/guides/attributes.adoc
@@ -34,7 +34,7 @@
 :quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/main
 
 :config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html
-:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/dev/index.html
+:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/2.x/index.html
 :neo4j-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-neo4j/dev/index.html
 :vault-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html
 :vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html

--- a/_versions/3.2/guides/_attributes.adoc
+++ b/_versions/3.2/guides/_attributes.adoc
@@ -53,7 +53,7 @@
 // .
 :amazon-services-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html
 :config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html
-:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/dev/index.html
+:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/3.x/index.html
 :neo4j-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-neo4j/dev/index.html
 :vault-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html
 :vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html


### PR DESCRIPTION
I also noticed that Dynamo and S3 guides were duplicated in data and cloud categories so I've combined those... 
Let me know if this makes sense