### PR TITLE
fix bad all-config table rendering

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -260,7 +260,6 @@ input {
 
 table.tableblock {
   border-collapse: collapse;
-  display: block;
   max-width: 100%;
   overflow-x: auto;
 


### PR DESCRIPTION
The "display" style of table is "table" by default, the commit b77ca2df12db838abba1a6121cfecea84df39d88 wrongly forces it to "block". 

Fixed issue reported at https://github.com/quarkusio/quarkusio.github.io/issues/1900
