### PR TITLE
Update links for Amazon quarkiverse guides

### DIFF
--- a/_data/versioned/main/index/quarkiverse.yaml
+++ b/_data/versioned/main/index/quarkiverse.yaml
@@ -6,12 +6,12 @@ types:
     categories: data
     origin: quarkiverse-hub
   - title: Amazon DynamoDB
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-dynamodb.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
     summary: This guide covers how to use the Amazon DynamoDB database in Quarkus.
     categories: "data, cloud"
     origin: quarkiverse-hub
   - title: Amazon S3
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-s3.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
     summary: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
     categories: "data, cloud"
     origin: quarkiverse-hub
@@ -81,32 +81,32 @@ types:
     categories: security
     origin: quarkiverse-hub
   - title: Amazon KMS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-kms.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-kms.html
     summary: This guide covers how to use the Amazon Key Management Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon IAM
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-iam.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-iam.html
     summary: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SES
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-ses.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ses.html
     summary: This guide covers how to use the Amazon Simple Email Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SNS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-sns.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sns.html
     summary: This guide covers how to use the Amazon Simple Notification Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SQS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-sqs.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sqs.html
     summary: This guide covers how to use the Amazon Simple Queue Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SSM
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/main/amazon-ssm.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ssm.html
     summary: This guide covers how to use the AWS Systems Manager in Quarkus.
     categories: cloud
     origin: quarkiverse-hub


### PR DESCRIPTION
I've updated these back to `dev` (from `main`) as they got changed back ... are these versions something that can be controlled or... 

https://docs.quarkiverse.io/index/explore/index.html

https://github.com/quarkusio/quarkusio.github.io/pull/1896