### PR TITLE
table scroll shadow

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -258,11 +258,33 @@ input {
   color: $black;
 }
 
+
+// table styles 
+
 table.tableblock {
   border-collapse: collapse;
   display: block;
   max-width: 100%;
   overflow-x: auto;
+
+  background-image: 
+  
+    /* Shadows */ 
+    linear-gradient(to right, $white, $white),
+    linear-gradient(to right, $white, $white),
+
+    /* Shadow covers */ 
+    linear-gradient(to right, rgba(0,0,0,.5), rgba(255,255,255,0)),
+    linear-gradient(to left, rgba(0,0,0,.5), rgba(255,255,255,0));
+
+    background-position: left center, right center, left center, right center;
+    background-repeat: no-repeat;
+    background-color: $white;
+    background-size: 20px 100%, 20px 100%, 10px 100%, 20px 100%;
+
+    /* Opera doesn't support this in the shorthand */
+    background-attachment: local, local, scroll, scroll;
+
 
   thead th,
   tbody th {
@@ -290,7 +312,7 @@ table.tableblock {
 
   tbody tr {
     &:nth-child(even) {
-      background-color: $light-blue;
+      background-color: transparent;
     }
     td p {
        margin: 0;


### PR DESCRIPTION
This PR removes adds a shadow to the left and right of a scrollable table to indicate to the user that they can scroll it to see more content.