### PR TITLE
add author page linked from blog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :jekyll_plugins do
   gem 'jekyll-asciidoc'
   gem 'jekyll-paginate-v2'
   gem 'jekyll-archives'
+  gem 'jekyll-auto-authors'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,9 @@ GEM
     jekyll-asciidoc (3.0.0)
       asciidoctor (>= 1.5.0)
       jekyll (>= 3.0.0)
+    jekyll-auto-authors (1.0.4)
+      jekyll (>= 3.0.0)
+      jekyll-paginate-v2 (>= 3.0.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate-v2 (3.0.0)
@@ -81,6 +84,7 @@ DEPENDENCIES
   jekyll (~> 4.1.1)
   jekyll-archives
   jekyll-asciidoc
+  jekyll-auto-authors
   jekyll-feed (~> 0.6)
   jekyll-paginate-v2
   minima (~> 2.0)

--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,7 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-archives
+  - jekyll-auto-authors
 
 sass:
   style: compressed
@@ -177,6 +178,30 @@ pagination:
   # indexpage: 'index'
 
 ############################################################
+
+autopages:
+  enabled: true
+  categories:
+    enabled: false
+  tags:
+    enabled: false
+  collections:
+    enabled: false
+
+  # Add this block
+  authors:
+    enabled: true
+    data: '_data/authors.yaml' # Data file with the author details
+    # Uncomment the line below to force exclude certain authors from autopage generation.
+    # exclude: [ "author1", "author2" ]
+    layouts: 
+      - 'author.html' # We'll define this layout later
+    title: 'Posts by :author'
+    permalink: '/author/:author/'
+    slugify:
+      mode: 'default' # choose from [raw, default, pretty, ascii or latin]
+      cased: true # if true, the uppercase letters in slug will be converted to lowercase ones.
+
 
 # Scholar / Bibliography
 publication: 

--- a/_includes/blog-band.html
+++ b/_includes/blog-band.html
@@ -19,7 +19,7 @@
             {% if author.emailhash %}
               <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
             {% endif %}
-            <p class="byline"><span>By</span> {{ author.name }}<br/></p>
+            <p class="byline">By <a href="{{ site.baseurl }}/author/{{ post.author }}">{{ author.name }}</a></p>
           </div>
           <div class="grid__item width-12-12">
             {% if post.synopsis %}

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -4,17 +4,36 @@ layout: base
 
 {% include title-band.html %}
 
+<!-- This has the username of author. The one that you set with "author: name" in front-matter-->
+{% assign author_username = page.pagination.author %}
+
+<!-- Use page.pagination.author_data only if you have data file setup correctly -->
+{% assign author = page.pagination.author_data %}
+<!--
+  Now you can use the author variable anyhow.
+  It has all the data as defined inside _data/authors.yml for the current username.
+-->
+
 
 <div class="full-width-version-bg grey align-self">
   <div class="width-12-12">
-      <p class="returnlink"><a href="{{site.baseurl}}/blog">Blogs</a> <i class="fas fa-chevron-right"></i> {{ page.title }}</p>
+      <p class="returnlink"><a href="{{site.baseurl}}/author">Authors</a> <i class="fas fa-chevron-right"></i> {{ page.title }}</p>
   </div>
 </div>
 
 <div class="grid-wrapper blog-page">
   <div class="grid__item width-9-12 width-12-12-m">
-    <h2 class="title">Tagged posts: '{{ page.title }}'</h2>
-    {% for post in page.posts %}
+    <h2 class="title">
+      {% if author.emailhash %}
+      <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+      {% endif %}
+      {{ author.name }} (<a href="https://twitter.com/{{ author.twitter }}">@{{ author.twitter }}</a>)</h2>
+    <p>
+      {{ author.bio }}
+    </p>
+
+    <h2 class="title">Posts:</h2>
+    {% for post in paginator.posts %}
       {% assign author = site.data.authors[post.author] %}
       <div class="blog-list-item grid-wrapper">
         <div class="grid__item width-12-12">
@@ -44,15 +63,6 @@ layout: base
         <div class="grid__item width-8-12 read-more small"><a href="{{site.baseurl}}{{ post.url }}">Read More &rsaquo;</a></div>
         <div class="grid__item width-4-12 width-12-12-m share-post">{% include share-page.html title=post.title url=post.url %}</div>
       </div>
-    {% endfor %}
-  </div>
-  <div class="grid__item width-3-12 width-12-12-m">
-    <h3 class="tags-label">Tags</h3>
-    {% assign tag_words = site.tags | sort %}
-    {% for stats in tag_words %}
-    {% assign tag = stats | first %}
-    {% assign posts = stats | last %}
-    <a href="{{site.baseurl}}/blog/tag/{{tag | downcase | replace: '.', '-'}}">{{ tag | downcase }}</a></br>
     {% endfor %}
   </div>
 </div>

--- a/_layouts/authors.html
+++ b/_layouts/authors.html
@@ -1,0 +1,15 @@
+---
+layout: base
+---
+
+{% include title-band.html %}
+
+<h3 class="tag-label">Authors</h3>
+    {% assign authors = site.data.authors | sort %}
+    {% for data in authors %}
+    {% assign authorid = data | first %}
+    {% assign author = data | last %}
+
+    <a href="{{site.baseurl}}/author/{{authorid}}">{{authorid}}</a> - {{author.name}}</br>
+    {% endfor %}
+    

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,7 +25,7 @@ layout: base
             {% if author.emailhash %}
               <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
             {% endif %}
-            <p class="byline">By {{ author.name }}</p>
+            <p class="byline">By <a href="{{ site.baseurl }}/author/{{ page.author }}">{{ author.name }}</a></p>
           </div>
           <div class="width-12-12">
               {{ content }}

--- a/_posts/2023-10-19-quarkus-3-2-7-final-released.adoc
+++ b/_posts/2023-10-19-quarkus-3-2-7-final-released.adoc
@@ -4,7 +4,7 @@ title: 'Quarkus 3.2.7.Final released - Maintenance release'
 date: 2023-10-19
 tags: release
 synopsis: 'Quarkus 3.2.7.Final is the seventh maintenance release of our 3.2 LTS release train. It fixes CVE-2023-43642, CVE-2023-34454, CVE-2023-44487 and CVE-2023-39410'
-author: aloubyansky
+author: alexeyloubyansky
 ---
 
 Today, we released Quarkus 3.2.7.Final, the seventh maintenance release of our 3.2 LTS release train.

--- a/author.md
+++ b/author.md
@@ -1,0 +1,7 @@
+---
+layout: authors
+title: "Authors"
+permalink: /author/
+pagination: 
+  enabled: true
+---


### PR DESCRIPTION
as suggested by @Sanne I added a page per authors as he was looking for @FroMage 's posts.

this uses https://github.com/gouravkhunger/jekyll-auto-authors which is explicitly solving this issue
as its missing feature of built in archive/pagination.

~~we have `/blogs/tag/<tag>` so added `/blogs/author/<author>` with same layout
and added bio/twitter/headshot to the page.~~

added `/author/<author>` with same layout as tags but lets us have quarkus.io/author landing/index page
