### PR TITLE
Disable the in-browser autocomplete for the search input

### DIFF
--- a/_includes/index-docs.html
+++ b/_includes/index-docs.html
@@ -38,7 +38,7 @@
           </select>
         </div>
         <div class="search">
-          <input name="q" type="search" placeholder="Filter by keyword"/>
+          <input name="q" type="search" placeholder="Filter by keyword" autocomplete="off"/>
         </div>
       </div>
     </section>

--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -18,7 +18,7 @@
     <section class="full-width-version-bg flexfilterbar">
       <div class="flexcontainer">
         <div class="search">
-          <input type="search" name="q" placeholder="Filter by keyword"/>
+          <input type="search" name="q" placeholder="Filter by keyword" autocomplete="off"/>
         </div>
         <div class="flexlabel">
           <label>By Version</label>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/search.quarkus.io/issues/231

I think we should keep the `q` name, as it's also the API parameter. And if we'd wanted to have autocomplete working for the field then we should consider something backed by the search service.. though I'm not sure it would be much helpful in this case.