### PR TITLE
Add Quarkus GitHub Lottery to quarkusio/quarkusio.github.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug on quarkus.io website
 title: ''
-labels: kind/bug
+labels: kind/bug,triage/needs-triage
 assignees: ''
 
 ---

--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -1,0 +1,49 @@
+notifications:
+  createIssues:
+    repository: "quarkusio/quarkus-github-lottery-reports"
+buckets:
+  triage:
+    label: "triage/needs-triage"
+    delay: PT0S
+    timeout: P3D
+  maintenance:
+    feedback:
+      labels: ["triage/needs-reproducer", "triage/needs-feedback"]
+      needed:
+        delay: P21D
+        timeout: P3D
+      provided:
+        delay: P7D
+        timeout: P3D
+    stale:
+      delay: P60D
+      timeout: P14D
+  stewardship:
+    delay: P21D
+    timeout: P3D
+participants:
+  - username: "gsmet"
+    timezone: "Europe/Paris"
+    stewardship:
+      days: ["MONDAY"]
+      maxIssues: 3
+  - username: "maxandersen"
+    timezone: "Europe/Paris"
+    triage:
+      days: ["WEDNESDAY", "FRIDAY"]
+      maxIssues: 3
+    stewardship:
+      days: ["WEDNESDAY", "FRIDAY"]
+      maxIssues: 3
+  - username: "marko-bekhta"
+    timezone: "Europe/Warsaw"
+    maintenance:
+      labels: ["area/search"]
+      days: ["WEDNESDAY", "FRIDAY"]
+      feedback:
+        needed:
+          maxIssues: 2
+        provided:
+          maxIssues: 2
+      stale:
+        maxIssues: 2


### PR DESCRIPTION
Also needed, beyond the content of this PR:

- [x] An admin needs to add the Lottery app to this repository
- [x] We need to set up labels (see TODOs and comments) if we want to handle triage/maintenance notifications.
- [ ] We need to ping other people who would want to get notified, so that they register themselves in the config file.