### PR TITLE
Remove confusing tag from codestart documentation

### DIFF
--- a/_posts/2020-08-20-codestarts-preview.adoc
+++ b/_posts/2020-08-20-codestarts-preview.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Codestarts - Preview the new way to start coding with Quarkus'
 date: 2020-08-20
-tags: extension codestarts quickstart
+tags: extension codestarts
 synopsis: The idea is simple, you pick your extensions and they are able to provide example code to get you started.
 author: adamevin
 ---

--- a/_posts/2020-12-07-extension-codestarts-a-new-way-to-learn-and-discover-quarkus.adoc
+++ b/_posts/2020-12-07-extension-codestarts-a-new-way-to-learn-and-discover-quarkus.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Extension codestarts - A new way to learn & discover Quarkus
 date: 2020-12-07
-tags: extensions codestarts quickstart
+tags: extensions codestarts
 synopsis: All our tooling has been updated and can now generate Quarkus application with example code (Extension Codestarts) showing the true power of the selected extensions...
 author: adamevin
 ---


### PR DESCRIPTION
If I want to understand the differences between a Quarkus quickstart and codestart (and try to decide if they're the same thing), I would google 'Quarkus quickstart codestart'. That gives this:

<img width="1694" alt="image" src="https://github.com/quarkusio/quarkusio.github.io/assets/11509290/b7ed0d46-0f9d-49a1-bcca-c0bac9b21fb0">

The first link is being fixed by https://github.com/quarkusio/quarkus/pull/40389, but the second link is also problematic, because it's a heading saying 'quickstart' with content about codestarts. That reinforces the idea that they're the same thing. 