### PR TITLE
fix blown out width and prep tables for dark mode

### DIFF
--- a/_sass/colormode.scss
+++ b/_sass/colormode.scss
@@ -10,6 +10,9 @@ html {
 	--sec-background-color: #EFEFEF;
 	--title-background-color: #0d1c2c;
 	--breadcrumb-background-color: #4695EB;
+	
+	--table-head-background-color: #aaaaaa;
+	--table-row-stripe: #e4edf7;
 
 	--card-outline: #AAAAAA;
 	--card-background-color: #FFFFFF;
@@ -30,6 +33,9 @@ html {
     	--title-background-color: #0e0e0e;
 		--breadcrumb-background-color: #0d1c2c;
 
+		--table-head-background-color: #0d1c2c;
+		--table-row-stripe: #0e0e0e;
+		
    		--card-outline: #555555;
 		--card-background-color: #0f0f0f;
 		--card-background-color-hover: #333333;

--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -100,7 +100,7 @@ p {
   margin: 0 0 1.5rem;
   font-weight: 400;
   code {
-    word-wrap: break-word;
+    word-break:break-word;
   }
 }
 
@@ -265,25 +265,7 @@ table.tableblock {
   border-collapse: collapse;
   max-width: 100%;
   overflow-x: auto;
-
-  background-image: 
-  
-    /* Shadows */ 
-    linear-gradient(to right, $white, $white),
-    linear-gradient(to right, $white, $white),
-
-    /* Shadow covers */ 
-    linear-gradient(to right, rgba(0,0,0,.5), rgba(255,255,255,0)),
-    linear-gradient(to left, rgba(0,0,0,.5), rgba(255,255,255,0));
-
-    background-position: left center, right center, left center, right center;
-    background-repeat: no-repeat;
-    background-color: $white;
-    background-size: 20px 100%, 20px 100%, 10px 100%, 20px 100%;
-
-    /* Opera doesn't support this in the shorthand */
-    background-attachment: local, local, scroll, scroll;
-
+  background-color: var(--main-background-color);
 
   thead th,
   tbody th {
@@ -293,8 +275,8 @@ table.tableblock {
     font-weight: 600 !important;
     text-align: left;
     padding: 1rem;
-    background-color: $grey-1;
-    border: 1px solid $grey-1;
+    background-color: var(--table-head-background-color);
+    border: 1px solid var(--table-head-background-color);
     > p,
     > div,
     > div > span {
@@ -306,12 +288,12 @@ table.tableblock {
   
   tbody td {
     padding: .25rem 1rem;
-    border: 1px solid $grey-1;
+    border: 1px solid var(--sec-border-color);
   }
 
   tbody tr {
     &:nth-child(even) {
-      background-color: transparent;
+      background-color: var(--table-row-stripe);
     }
     td p {
        margin: 0;
@@ -331,8 +313,8 @@ table.tableblocklightbkg {
     font-weight: 400;
     text-align: left;
     padding: 1rem;
-    background-color: $quarkus-blue;
-    border: 1px solid $quarkus-blue;
+    background-color: var(--table-head-background-color);
+    border: 1px solid var(--table-head-background-color);
     > p,
     > div,
     > div > span {
@@ -350,10 +332,10 @@ table.tableblocklightbkg {
   }
 
   tbody tr {
-      background-color: $white;
+      background-color: var(--main-background-color);
 
     &:nth-child(even) {
-      background-color: $light-blue;
+      background-color: var(--table-row-stripe);
     }
     td p {
        margin: 0;


### PR DESCRIPTION
This addresses table width issue (too wide for space and runs behind TOC) by allowing the code elements to break.

Also prepped colors for future dark mode.

Resolves #1900 