### PR TITLE
Fix compose.sh on Linux

### DIFF
--- a/compose.sh
+++ b/compose.sh
@@ -1,3 +1,3 @@
 export _SELINUX_=$(if [[ "$(uname)" == "Linux" ]]; then echo ":Z"; else echo ""; fi)
-echo '$_SELINUX_'
+echo "_SE_LINUX_=$_SELINUX_"
 docker-compose up $*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,6 @@ services:
     volumes:
       ## this Z handling needed to make things
       ## work on podman (see https://github.com/containers/podman/issues/19852)
-      - .:/site #${_SELINUX_?_SELINUX_ variable is required and must be set to ':Z' if SELinux context is needed for volumes or run compose.sh to do it for you.}
+      - .:/site${_SELINUX_?_SELINUX_ variable is required and must be set to ':Z' if SELinux context is needed for volumes or run compose.sh to do it for you.}
     ports:
       - '4000:4000'


### PR DESCRIPTION
@maxandersen I don't get why the variable was commented out, probably a mistake?

As things are, your fix just makes it work for Mac, but no longer on Linux.

With this patch it works on Linux again, but I'll let someone else check it works on Mac...
