### PR TITLE
Add edit-this-page for SNAPSHOT

### DIFF
--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -52,7 +52,7 @@ layout: base
 <div class="guide">
   <div class="grid-wrapper">
     <div class="grid__item width-8-12 width-12-12-m">
-      {% if docversion == 'latest' or version == 'main' %}
+      {% if docversion == 'latest' or docversion == 'main' %}
       <a class="editlink" href="https://github.com/quarkusio/quarkus/edit/main/docs/src/main/asciidoc/{{ page_filename }}">Edit this Page</a>
       {% endif %}
       <h1 class="text-caps">{{page.title}} {{page.docversion}}</h1>

--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -52,7 +52,7 @@ layout: base
 <div class="guide">
   <div class="grid-wrapper">
     <div class="grid__item width-8-12 width-12-12-m">
-      {% if docversion == 'latest' %}
+      {% if docversion == 'latest' or version == 'main' %}
       <a class="editlink" href="https://github.com/quarkusio/quarkus/edit/main/docs/src/main/asciidoc/{{ page_filename }}">Edit this Page</a>
       {% endif %}
       <h1 class="text-caps">{{page.title}} {{page.docversion}}</h1>


### PR DESCRIPTION
Rather than only displaying the edit-this-page link for the latest release, we also display it for the "main" version i.e. the latest SNAPSHOT.

Fixes #1878
