### PR TITLE
Rewrite allowfullscreen attribute xhtml valid

### DIFF
--- a/_includes/homepage-video-band.html
+++ b/_includes/homepage-video-band.html
@@ -1,7 +1,7 @@
 <div class="full-width-bg component homepage-content-band video-band">
   <div class="grid-wrapper">
     <div class="width-6-12 width-12-12-m video-container">
-      <iframe src="https://www.youtube.com/embed/hhHgurtI674" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/hhHgurtI674" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen="allowfullscreen"></iframe>
     </div>
     <div class="width-6-12 width-12-12-m">
       <h2>Supersonic, Subatomic Java.</h2>


### PR DESCRIPTION
Since text extraction parser used for lozalization can parse XHTML valid mark up only, rewrite allowfullscreen attribute

