### PR TITLE
Actions updates: Update download action, and do not claim to have torn down things that were not torn down

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
       - name: Teardown surge preview
         id: deploy
-        run: npx surge teardown https://quarkus-site-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: npx surge teardown https://quarkus-site-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
       - name: Update PR status comment
         uses: actions-cool/maintain-one-comment@v3.0.0
+        if: env.NOT_TORNDOWN != 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,9 +12,10 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
     - name: Download PR Artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v5
       with:
         workflow: ${{ github.event.workflow_run.workflow_id }}
+        run_id: ${{ github.event.workflow_run.id }}
         workflow_conclusion: success
         name: site
     - name: Store PR id as variable


### PR DESCRIPTION
I recently updated the `dawidd6/download-artifact` action over on http://github.com/quarkusio/extensions. Previews stopped working shortly after. On debugging, it seemed like what was happening was that an artifact was still being downloaded, but it wasn't the one we wanted, it was the latest artifact from a scheduled build. Luckily, because the `pr-id.txt` was missing from the archive, a preview was still pushed to surge.sh, but no comment was put onto the PR. Otherwise, there would have been a bad situation where people were reviewing the wrong preview content. 

I couldn't confirm from the release notes, but it looks like there was a breaking change and the download action needs another parameter to reliably download the right thing. This is bad, so sharing the update to other repos proactively, while I still remember what the fix is. 

I'm also sharing another mini fix, which stops irritating 'Preview <whatever> was torn down' messages being posted on PRs where either there was never a preview in the first place, or the preview didn't get torn down properly.

As always with actions updates, this can only really be tested by merging. 