### PR TITLE
Enable dependabot (just for actions, for now)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    labels:
+      - area/infra


### PR DESCRIPTION
I intended to enable dependabot management of our github actions, and then I realised we didn't have dependabot looking at anything. Do we perhaps want dependabot updating the Ruby dependencies?

For now, I've just turned dependabot on for the actions. 
- The good: we don't have to manually update actions, or use deprecated actions
- The bad: none of the PRs dependabot raises can be tested, except by merging-and-hoping