### PR TITLE
Update 2024-06-12-branching-and-versioning.adoc

### DIFF
--- a/_posts/2024-06-12-branching-and-versioning.adoc
+++ b/_posts/2024-06-12-branching-and-versioning.adoc
@@ -42,7 +42,7 @@ image::3.11.0.CR1-release.png[3.11.0.CR1-release,float="right",align="center"]
 After creating the release branch, all subsequent changes to `main` will target a future release unless they are backported to the release branch.
 
 As we absolutely want a release branch to include the latest bug fixes from `main`, a manual triage needs to occur in order to decide
-which changes in `main` should be backported to the release branch. The maintainers of the Quarkus use the `triage/backport*?` labels
+which changes in `main` should be backported to the release branch. The maintainers of the Quarkus use the `triage/backport*` labels
 on candidate changes.
 
 When time comes to release a new micro version (or the final `.0` version), the selected changes are manually backported to the branch


### PR DESCRIPTION
Remove the question mark

The triage/backport labels no longer end with a question mark