### PR TITLE
Adjust code font in configuration reference

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -379,7 +379,9 @@ table.configuration-reference.tableblock > tbody {
     > td:nth-child(3) p,
     > td .content p,
     > th:nth-child(2) p,
-    > th:nth-child(3) p {
+    > th:nth-child(3) p,
+    > td .content div.title,
+    > td .content code {
       font-size: 0.8rem;
     }
   }


### PR DESCRIPTION
This is especially useful for quarkus.hibernate-orm.sql-load-script but probably also useful for other configuration properties.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
