### PR TITLE
Edit Granite LLM Rag post - Changed references of Podman AI Studio to Podman AI Lab

### DIFF
--- a/_posts/2024-06-14-granite-rag.adoc
+++ b/_posts/2024-06-14-granite-rag.adoc
@@ -12,7 +12,7 @@ This blog post demonstrate how to build an AI-infused chatbot application using 
 In this post, we will create an **entirely** local solution, eliminating the need for any cloud services, including the LLM.
 
 Our chatbot leverages the Granite LLM, a language model that generates contextually relevant text based on user prompts.
-To run Granite locally, we'll be utilizing https://instructlab.ai/[InstructLab], though https://github.com/containers/podman-desktop-extension-ai-lab[Podman AI Studio] is another viable option.
+To run Granite locally, we'll be utilizing https://instructlab.ai/[InstructLab], though https://github.com/containers/podman-desktop-extension-ai-lab[Podman AI Lab] is another viable option.
 
 The core of our application is based on the RAG (Retrieval-Augmented Generation) pattern.
 This approach enhances the chatbot's responses by retrieving pertinent information from a vector database — in this case, Infinispan — before generating a response.
@@ -84,7 +84,7 @@ You can find the final version on https://github.com/cescoffier/quarkus-granite-
 
 To implement our chatbot, we rely on the following Quarkus extensions:
 
-* `quarkus-langchain4j-openai`: Integrates LLM providers using the OpenAI API, suitable for both InstructLab and Podman AI Studio.
+* `quarkus-langchain4j-openai`: Integrates LLM providers using the OpenAI API, suitable for both InstructLab and Podman AI Lab.
 * `quarkus-websockets-next`: Provides support for WebSocket communication.
 * `quarkus-langchain4j-infinispan`: Integrates Infinispan with LangChain4j, allowing us to store and retrieve vector representations of text segments.
 * `quarkus-web-bundler`: Bundles frontend resources with the Quarkus application.
@@ -116,8 +116,8 @@ quarkus.langchain4j.embedding-model.provider=dev.langchain4j.model.embedding.Bge
 ----
 <1> Configure the dimension of the vectors stored in Infinispan, which depends on the embedding model (BGE-small in our case).
 <2> Configure the OpenAI service to use InstructLab.
-You can replace the base URL with the one for Podman AI Studio if you prefer.
-Indeed, InstructLab and Podman AI Studio expose an OpenAI-compatible API.
+You can replace the base URL with the one for Podman AI Lab if you prefer.
+Indeed, InstructLab and Podman AI Lab expose an OpenAI-compatible API.
 <3> Set the default embedding model to BGE-small.
 
 === The Ingestor
@@ -256,16 +256,16 @@ First, clone the https://github.com/cescoffier/quarkus-granite-rag-demo/tree/mai
 ----
 
 This command starts the Quarkus application in development mode.
-Ensure you have InstructLab or Podman AI Studio running to use the Granite LLM.
+Ensure you have InstructLab or Podman AI Lab running to use the Granite LLM.
 You will also need Docker or Podman to automatically start Infinispan.
 
 [NOTE]
-.Podman AI Studio or InstructLab?
+.Podman AI Lab or InstructLab?
 ====
-You can use either Podman AI Studio or InstructLab to run the Granite LLM locally.
+You can use either Podman AI Lab or InstructLab to run the Granite LLM locally.
 Depending on the OS, Podman may not have GPU support. Thus, response time can be high.
 In this case, InstructLab is the preferred option for better response times.
-Typically, on a Mac, you would use InstructLab, while on Linux, Podman AI Studio shows great performances.
+Typically, on a Mac, you would use InstructLab, while on Linux, Podman AI Lab shows great performances.
 ====
 
 


### PR DESCRIPTION
Just a tiny little enhancement to reference the [Podman AI Lab](https://podman-desktop.io/extensions/ai-lab).