### PR TITLE
fix: set homepage background size to 100%

### DIFF
--- a/_sass/layouts/home.scss
+++ b/_sass/layouts/home.scss
@@ -6,6 +6,7 @@
 
   background-image: url($baseurl + '/assets/images/bg-home-primary.png');
   background-repeat: no-repeat;
+  background-size: 100%;
   p {
     margin: 2rem 0;
   }


### PR DESCRIPTION
The background image breaks for resolutions higher than 2352px, which is the width of the image. With this change, the background should not look broken.

Before:
<img width="1512" alt="Screenshot 2024-07-02 at 17 49 56" src="https://github.com/quarkusio/quarkusio.github.io/assets/691508/4f1963da-0416-4280-bb0d-435958009591">

After:
<img width="1510" alt="Screenshot 2024-07-02 at 17 50 32" src="https://github.com/quarkusio/quarkusio.github.io/assets/691508/7aad5e37-4d09-4329-941a-c6e31feca801">

