### PR TITLE
Make it easier to use podman with the current docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 
 services:
   jekyll:
-    image: bretfisher/jekyll-serve
+    image: docker.io/bretfisher/jekyll-serve
     # Add --incremental to the commandline
     # https://github.com/BretFisher/jekyll-serve/blob/2119a31476e1c6004a4bea4739b9160fc73e7bda/Dockerfile#L27C5-L27C94
     # Also, enable dev config


### PR DESCRIPTION
Patching `docker-compose.yml` to point to the fully qualified image name; this might avoid ambiguity and makes it easier for us poor podman users to preview website changes locally.