### PR TITLE
Fix all config page in dark mode

### DIFF
--- a/_sass/layouts/guides.scss
+++ b/_sass/layouts/guides.scss
@@ -1,8 +1,3 @@
-
-.guides-configuration-reference {
-  background: $white;
-}
-
 div.guides,
 div.guides-configuration-reference {
   padding-bottom: 6rem;
@@ -105,11 +100,11 @@ div.guides-configuration-reference {
       align-self: start;
     }
   }
-  
+
   .guide-categories {
     margin: 0 1rem 0 0;
 
-    h3 { 
+    h3 {
     margin: 0;
 
     }

--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -397,12 +397,6 @@ table.configuration-reference.tableblock > tbody {
   }
 }
 
-
-/* this page has a white background so we put a lighter color */
-body.guides-configuration-reference table.configuration-reference.tableblock tbody tr.odd td {
-  background-color: #eff5fb !important;
-}
-
 mark {
   background-color: $quarkus-blue;
   color: $dark-blue;


### PR DESCRIPTION
Currently, the page looks like this cause it has a mix of dark and light styles:

![Screenshot from 2024-07-20 16-40-08](https://github.com/user-attachments/assets/7b755374-0940-4e50-bb86-b67735909544)

Apparently, this page was forced light on purpose but I'm not sure it's a good idea and I think we should revisit this decision as long pages are typically pages for which you will want to use your preferred background.

So I fixed it to use a dark background.

Ideally, it would be nice to have odd/even backgrounds even for dark mode: atm they are of the same color.

/cc @insectengine @maxandersen 