### PR TITLE
Give preview jobs higher permissions so that preview comments can work

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      # this should be enough to maintain comments as commenting on pull requests is done through an issues API
+      # needed to maintain comments
       issues: write
-      pull-requests: read
+      pull-requests: write
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
     - name: Download PR Artifact


### PR DESCRIPTION
@maxandersen spotted that his recent blog post didn't get a preview. On investigation, it did get a preview, but it didn't get a comment on the PR with the preview link. On [further investigation](https://github.com/quarkusio/quarkusio.github.io/actions/workflows/preview.yml), previews have been failing for 3 weeks. 

Based on the timing and content, I think the problem must have been caused by https://github.com/quarkusio/quarkusio.github.io/pull/2042. It contains the fatal equivalent of `// this should never happen`, `this should be enough to ... ` :)

```
    permissions:
      actions: read
      # this should be enough to maintain comments as commenting on pull requests is done through an issues API
      issues: write
      pull-requests: read
```

The GitHub workflow changes can only be tested by YOLO-ing them in and then hoping, so regressions are super-easily done. I'm hoping this change fixes it, but, you know ... it can only be tested by YOLO-ing it in. 