### PR TITLE
Fix darkmode input text problem on config widget

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -245,7 +245,7 @@ form input[type="submit"] {
 }
 
 input {
-  color: $black;
+  color: var(--main-text-color);
 }
 
 


### PR DESCRIPTION
Fixes a darkmode input text problem on docs "config" widgets

![](https://files.slack.com/files-pri/T030G10V24F-F07FSL2MM6U/image.png)
