### PR TITLE
Allow overriding toc levels at the guide level

### DIFF
--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -59,7 +59,7 @@ layout: base
       {{ content }}
     </div>
     <div class="grid__item width-4-12 width-12-12-m tocwrapper">
-      <div class="hide-mobile toc">{{ page.document | tocify_asciidoc: 2 }}</div>
+      <div class="hide-mobile toc">{{ page.document | tocify_asciidoc }}</div>
     </div>
   </div>
   {% if relations and relations[guide_url] -%}


### PR DESCRIPTION
For reference guides, having a deeper TOC might make sense, typically for the Qute reference guide.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
