### PR TITLE
Replace maintain-one-comment action with our own

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -12,12 +12,12 @@ jobs:
         id: deploy
         run: npx surge teardown https://quarkus-site-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
       - name: Update PR status comment
-        uses: actions-cool/maintain-one-comment@v3.2.0
+        uses: quarkusio/action-helpers@main
         if: env.NOT_TORNDOWN != 'true'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          action: maintain-one-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.number }}
           body: |
             🙈 The PR is closed and the preview is expired.
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
-          number: ${{ github.event.number }}
+          body-marker: <!-- Preview status comment marker -->

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      # needed to maintain comments
       issues: write
+      # this is unfortunately needed to be able to write comments on pull requests
       pull-requests: write
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
@@ -37,10 +37,13 @@ jobs:
       run: npx surge ./ --domain https://quarkus-site-pr-${PR_ID}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       env:
         PR_ID: ${{  steps.pr.outputs.id }}
+
     - name: Update PR status comment on success
-      uses: actions-cool/maintain-one-comment@v3.2.0
+      uses: quarkusio/action-helpers@main
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        action: maintain-one-comment
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        pr-number: ${{ steps.pr.outputs.id }}
         body: |
           🎊 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkus-site-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
 
@@ -48,17 +51,15 @@ jobs:
           - Newsletters older than 3 months are not available.
 
           <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'
-        number: ${{ steps.pr.outputs.id }}
+        body-marker: <!-- Preview status comment marker -->
     - name: Update PR status comment on failure
+      uses: quarkusio/action-helpers@main
       if: ${{ failure() }}
-      uses: actions-cool/maintain-one-comment@v3.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        action: maintain-one-comment
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        pr-number: ${{ steps.pr.outputs.id }}
         body: |
           😭 Deploy PR Preview failed.
           <img width="300" src="https://user-images.githubusercontent.com/507615/90250824-4e066700-de6f-11ea-8230-600ecc3d6a6b.png">
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'
-        number: ${{ steps.pr.outputs.id }}
+        body-marker: <!-- Preview status comment marker -->


### PR DESCRIPTION
This is a security hazard as adding/editing a comment to/from a PR requires the pull request write permission.
Given it's very simple to implement what we need, let's avoid using an external action.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
