### PR TITLE
Direct podman blog readers to the podman guide, which is more current

### DIFF
--- a/_posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
+++ b/_posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
@@ -7,6 +7,8 @@ synopsis: 'Expose a Podman service for usage with Quarkus Dev Services and Testc
 author: mjurc
 ---
 
+_Update: For the latest, simpler, instructions on running Podman with Quarkus, see https://quarkus.io/guides/podman[the Quarkus Podman guide]._
+
 Podman is a daemonless container engine for developing, managing, and running Containers on Linux systems. Since the
 release of version 3, Podman allows the user to run a service emulating a Docker API provided on a  Unix socket. This
 makes it possible for Testcontainers and Quarkus Dev Services to be utilized with Podman.


### PR DESCRIPTION
When I searched for 'podman quarkus' last week, the https://quarkus.io/blog/quarkus-devservices-testcontainers-podman/ blog was the top hit. Our official guide was number six in the latest. The blog is rather badly obseleted by now, so we don't want it to be the top hit. 

When I tried again yesterday, the guide was the top hit, which I *think* is because we pushed an update to it, and that affects the search ranking. Linking to it from the blog should also help, by 
- Improving the ranking of the guide (if it has more inbound links, it ranks higher)
- If the ranking ends up wrong, directing blog readers to the right place
