### PR TITLE
Fix the definition of the page filename

### DIFF
--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -8,7 +8,13 @@ layout: base
   {% assign docversion = 'latest' %}
 {% endif %}
 {% assign docversion_index = docversion | replace: '.', '-' %}
-{% assign page_filename = page.path | replace: '_guides/', '' %}
+{% comment %}
+'page.path' pattern is different depending on the version
+- "Main - SNAPSHOT" -> _versions/main/guides/*.adoc
+- "x.x.x - Latest" ->  _guides/*.adoc
+=> to extract the page filename you need two different replacement tokens
+{% endcomment %}
+{% assign page_filename = page.path | replace: '_guides/', '' | replace: '_versions/main/guides/', '' %}
 {% assign relations = site.data.versioned[docversion_index].index.relations %}
 {% assign guide_url = page.url | replace_regex: '^/version/[^/]+(/.*)', '\1' %}
 


### PR DESCRIPTION
The original implementation did not consider that `page.path` has a different pattern for the "Main - SNAPSHOT" version. This currently leads to HTTP 404 links in such cases.