### PR TITLE
Pre-connect to the search service on guide search pages

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -70,6 +70,13 @@
   <link rel="alternate" hreflang="x-default" href="https://quarkus.io/" />  
   <script src="{{ site.baseurl }}/assets/javascript/tracking.js"></script>
   {% if search_wc %}
+    {% comment %}
+    The first connection to the remote search service can be slow,
+    and once in this block we're pretty sure to use the remote search service.
+    Pre-connecting in the background speeds up the first call to the service.
+    Note "crossorigin" is necessary for this to work, because we use CORS.
+    {% endcomment %}
+    <link rel="preconnect" href="{{ site.search.host }}" crossorigin />
     <script src="{{ search_script_src }}" type="module" blocking="render"></script>
   {% endif %}
   <script src="{{ '/assets/javascript/colormode.js' | relative_url }}" type="text/javascript"></script>


### PR DESCRIPTION
The first connection to the remote search service can be slow, and on these pages we're pretty sure to use the remote search service. Pre-connecting helps speed up the first call to the service.
