### PR TITLE
Update link which has been renamed on the wiki

### DIFF
--- a/_layouts/quarkus3.html
+++ b/_layouts/quarkus3.html
@@ -18,7 +18,7 @@ layout: base
         <p>Quarkus makes Java supersonic and subatomic, with fast startup times, low memory footprint, and a small disk footprint. This release continues to improve the Quarkus framework's performance and efficiency.</p>
         <h3>Hibernate ORM 6.2</h3>
         <p>Hibernate ORM 6.2 is a major upgrade to the main persistence layer of Quarkus. It brings a lot of improvements and new features including migration to the Jakarta Persistence 3.0 specification, performance improvements to JDBC, and more. Learn more about <a href="https://quarkus.io/blog/quarkus-3-0-0-alpha5-released/#hibernate-orm-6">Hibernate 6.2 in Quarkus</a>.</p>
-        <p>While there are a lot of great features the move to Hibernate 6.2 introduces some breaking changes. We created a <a href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration">Hibernate ORM migration guide</a> to make the upgrade from 5 to 6 as smooth as possible.</p>
+        <p>While there are a lot of great features the move to Hibernate 6.2 introduces some breaking changes. We created a <a href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration">Hibernate ORM migration guide</a> to make the upgrade from 5 to 6 as smooth as possible.</p>
         <p></p>
       </div>
     </div>
@@ -97,7 +97,7 @@ layout: base
     <div class="width-8-12 width-12-12-m block-content">
       <h2>Migrating to 3.0 is super easy</h2>
       <p>We want to make the migration to Quarkus 3 seamless for our users. With that in mind, we have created a <a href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0">migration guide</a> as well as tooling to facilitate this process.</p>
-      <p>The move to Hibernate ORM 6.2 is a major upgrade. While it brings a lot of improvements and new features, it also includes some breaking changes. In order to help migrate Quarkus apps with Hibernate, we have created a <a href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration">Hibernate ORM migration guide</a> to help you through the process.</p>
+      <p>The move to Hibernate ORM 6.2 is a major upgrade. While it brings a lot of improvements and new features, it also includes some breaking changes. In order to help migrate Quarkus apps with Hibernate, we have created a <a href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration">Hibernate ORM migration guide</a> to help you through the process.</p>
     </div>
   </div>
 </div>

--- a/_posts/2023-03-08-quarkus-3-0-0-alpha5-released.adoc
+++ b/_posts/2023-03-08-quarkus-3-0-0-alpha5-released.adoc
@@ -34,9 +34,9 @@ The list of highlights for this release is:
 
 Hibernate ORM 6 is a major upgrade to the main persistence layer of Quarkus. It brings a lot of improvements and new features, but also some breaking changes. We will do our best to make the migration as smooth as possible, but some changes are unavoidable. 
 
-We have started a https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[Hibernate ORM 5 to 6 migration] guide for Quarkus users to help you with the migration.
+We have started a https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[Hibernate ORM 5 to 6 migration] guide for Quarkus users to help you with the migration.
 
-Take particular note of the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration#database-orm-compatibility["Best-effort Hibernate ORM 5.6 compatability switch"] which can reduce the impact of the default schema changes in Hibernate 6 and give you more time to migrate.
+Take particular note of the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration#database-orm-compatibility["Best-effort Hibernate ORM 5.6 compatability switch"] which can reduce the impact of the default schema changes in Hibernate 6 and give you more time to migrate.
 
 We want to improve and simplify these migration steps in preparation for Quarkus 3 thus do please https://github.com/quarkusio/quarkus/issues/new/choose[report] migration issues you encounter so we can improve the migration documentation and scripts.
 

--- a/_posts/2023-03-23-quarkus-3-0-0-beta1-released.adoc
+++ b/_posts/2023-03-23-quarkus-3-0-0-beta1-released.adoc
@@ -71,7 +71,7 @@ It doesn't take care of everything but it should take care of most of the heavy-
 ====
 
 If you are using Hibernate ORM or Hibernate Reactive,
-please make sure you have a look to the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[dedicated migration guide].
+please make sure you have a look to the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[dedicated migration guide].
 
 === Automated migration
 

--- a/_posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc
+++ b/_posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc
@@ -88,7 +88,7 @@ It doesn't take care of everything but it should take care of most of the heavy-
 ====
 
 If you are using Hibernate ORM or Hibernate Reactive,
-please make sure you have a look to the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[dedicated migration guide].
+please make sure you have a look to the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[dedicated migration guide].
 
 [[automated-migration]]
 === Automated migration

--- a/_posts/2023-04-05-quarkus-3-0-0-cr2-released.adoc
+++ b/_posts/2023-04-05-quarkus-3-0-0-cr2-released.adoc
@@ -66,7 +66,7 @@ It doesn't take care of everything but it should take care of most of the heavy-
 ====
 
 If you are using Hibernate ORM or Hibernate Reactive,
-please make sure you have a look to the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[dedicated migration guide].
+please make sure you have a look to the https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[dedicated migration guide].
 
 [[automated-migration]]
 === Automated migration

--- a/_posts/2023-04-26-quarkus-3-0-final-released.adoc
+++ b/_posts/2023-04-26-quarkus-3-0-final-released.adoc
@@ -72,7 +72,7 @@ One of the biggest changes in Quarkus 3 is that we upgraded Hibernate ORM from v
 Hibernate ORM 6 is a new major release, and it comes with many changes,
 some of them breaking.
 
-To learn more about the changes in Hibernate ORM 6 from a Quarkus user perspective, see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[Hibernate ORM 5 to 6 migration].
+To learn more about the changes in Hibernate ORM 6 from a Quarkus user perspective, see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[Hibernate ORM 5 to 6 migration].
 
 The Hibernate ORM release announcements have a lot of information about the changes/improvements in Hibernate ORM 6:
 
@@ -264,7 +264,7 @@ We are working with the maintainers of the remaining extensions to get them upda
 
 As usual, we wrote a https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0[very comprehensive migration guide] to help you update to Quarkus 3.0.
 
-It is complemented by a dedicated https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[Hibernate ORM 6.2 update guide].
+It is complemented by a dedicated https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[Hibernate ORM 6.2 update guide].
 
 But that is not all:
 Quarkus 3.0 introduces an update tool that can help you update your projects to Quarkus 3.

--- a/_posts/2023-05-20-quarkus-3-upgrade.adoc
+++ b/_posts/2023-05-20-quarkus-3-upgrade.adoc
@@ -85,7 +85,7 @@ However, you can leverage the source code management tool to see the transformat
 For example, if using Git then run the update tool and execute the `git diff` command afterwards to see the changes.
 And if something went wrong then just use `git checkout .` to revert the changes.
 
-TIP: If your application depends on Hibernate ORM, the dedicated https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[Hibernate ORM 5 to 6] migration guide will come in handy.
+TIP: If your application depends on Hibernate ORM, the dedicated https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[Hibernate ORM 5 to 6] migration guide will come in handy.
 
 That's it.
 Your application should be ready now.
@@ -101,7 +101,7 @@ NOTE: The Quarkus Update Tool is not a one-time thing. The plan is to use this t
 == More resources
 
 - https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0[Migration Guide 3.0]
-- https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration[Migration Guide 3.0 - Hibernate ORM 5 to 6]
+- https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration[Migration Guide 3.0 - Hibernate ORM 5 to 6]
 - https://github.com/quarkusio/quarkus-updates[Quarkus Update Recipes]
 - https://quarkus.io/guides/cli-tooling[Quarkus CLI]
 


### PR DESCRIPTION
It is now https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0-Hibernate-ORM-5-to-6-migration
