### PR TITLE
Update Amazon services versions in the linked docs

### DIFF
--- a/_data/guides-2-13.yaml
+++ b/_data/guides-2-13.yaml
@@ -239,11 +239,11 @@ categories:
         url: /guides/cassandra
         description: This guide covers how to use the Apache Cassandra NoSQL database in Quarkus.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Google Cloud BigQuery
@@ -570,35 +570,35 @@ categories:
         url: /guides/funqy-gcp-functions-http
         description: This guide explains Funqy's Google Cloud Platform Functions HTTP binding.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon KMS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-kms.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-kms.html
         description: This guide covers how to use the Amazon Key Management Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon IAM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-iam.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-iam.html
         description: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SES
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-ses.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-ses.html
         description: This guide covers how to use the Amazon Simple Email Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SNS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-sns.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-sns.html
         description: This guide covers how to use the Amazon Simple Notification Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SQS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-sqs.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-sqs.html
         description: This guide covers how to use the Amazon Simple Queue Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SSM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.12.x/amazon-ssm.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-ssm.html
         description: This guide covers how to use the AWS Systems Manager in Quarkus.
         origin: quarkiverse-hub
       - title: Access Google Cloud services

--- a/_data/guides-2-7.yaml
+++ b/_data/guides-2-7.yaml
@@ -227,11 +227,11 @@ categories:
         url: /guides/cassandra
         description: This guide covers how to use the Apache Cassandra NoSQL database in Quarkus.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Google Cloud BigQuery
@@ -533,35 +533,35 @@ categories:
         url: /guides/funqy-gcp-functions-http
         description: This guide explains Funqy's Google Cloud Platform Functions HTTP binding.
       - title: Amazon DynamoDB
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-dynamodb.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-dynamodb.html
         description: This guide covers how to use the Amazon DynamoDB database in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon KMS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-kms.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-kms.html
         description: This guide covers how to use the Amazon Key Management Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon IAM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-iam.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-iam.html
         description: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon S3
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-s3.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-s3.html
         description: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SES
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-ses.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-ses.html
         description: This guide covers how to use the Amazon Simple Email Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SNS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-sns.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-sns.html
         description: This guide covers how to use the Amazon Simple Notification Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SQS
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-sqs.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-sqs.html
         description: This guide covers how to use the Amazon Simple Queue Service in Quarkus.
         origin: quarkiverse-hub
       - title: Amazon SSM
-        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.4.x/amazon-ssm.html
+        url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/1.x/amazon-ssm.html
         description: This guide covers how to use the AWS Systems Manager in Quarkus.
         origin: quarkiverse-hub
       - title: Access Google Cloud services

--- a/_data/versioned/3-8/index/quarkiverse.yaml
+++ b/_data/versioned/3-8/index/quarkiverse.yaml
@@ -6,12 +6,12 @@ types:
     categories: data
     origin: quarkiverse-hub
   - title: Amazon DynamoDB
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-dynamodb.html
     summary: This guide covers how to use the Amazon DynamoDB database in Quarkus.
     categories: "data, cloud"
     origin: quarkiverse-hub
   - title: Amazon S3
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-s3.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-s3.html
     summary: This guide covers how to use the Amazon S3 cloud storage in Quarkus.
     categories: "data, cloud"
     origin: quarkiverse-hub
@@ -81,32 +81,32 @@ types:
     categories: security
     origin: quarkiverse-hub
   - title: Amazon KMS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-kms.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-kms.html
     summary: This guide covers how to use the Amazon Key Management Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon IAM
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-iam.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-iam.html
     summary: This guide covers how to use the Amazon Identity and Access Management in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SES
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ses.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-ses.html
     summary: This guide covers how to use the Amazon Simple Email Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SNS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sns.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-sns.html
     summary: This guide covers how to use the Amazon Simple Notification Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SQS
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-sqs.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-sqs.html
     summary: This guide covers how to use the Amazon Simple Queue Service in Quarkus.
     categories: cloud
     origin: quarkiverse-hub
   - title: Amazon SSM
-    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-ssm.html
+    url: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/2.18.x/amazon-ssm.html
     summary: This guide covers how to use the AWS Systems Manager in Quarkus.
     categories: cloud
     origin: quarkiverse-hub


### PR DESCRIPTION
Search indexing cannot find some of the Amazon guides: https://github.com/quarkusio/search.quarkus.io/issues/130#issuecomment-2367029278 

So, if I'm reading the compatibility table correctly ... https://github.com/quarkiverse/quarkus-amazon-services/tree/main