### PR TITLE
List completed working groups in the working group page

### DIFF
--- a/_data/wg.yaml
+++ b/_data/wg.yaml
@@ -1,156 +1,164 @@
 ---
 working-groups:
-    - title: "Quarkus 3.15 LTS"
-      board-url: "https://github.com/orgs/quarkusio/projects/28"
-      short-description: This WG focuses on defining the issues we would like to have in the next-to-be LTS (Quarkus 3.14/3.15)
-      readme: |
-        <p>This working group uses a different board:</p>
-        <ul>
-        <li>The <code>under discussion</code> column contains the issues we would like to have in the next LTS but are still under consideration.</li>
-        <li>The <code>out of scope</code> column contains the issues under discussion' that won't be included. The reason can be time or technical...</li>
-        <li>The <code>in progress</code> means that the work has started and should be completed before the TLS cut date</li>
-        <li>The <code>done</code> column means that the issues have been completed</li>
-        </ul>
-      status: on track
-      last-activity: 2024-10-01
-      last-update: |
-        3.15 has been cut. 
-        The 3.15.x is the new LTS, starting with 3.15.1
-    - title: "Quarkus Config and IDEs"
-      board-url: "https://github.com/orgs/quarkusio/projects/32"
-      short-description: Let's define a format for the files containing the config model we will include in the jars for IDE consumption.
-      readme: |
-        <p>Let's define a format for the files containing the config model we will include in the jars for IDE consumption.</p>
-        <p>See https://github.com/quarkusio/quarkus/discussions/42671 for more details.</p>
-        <p><em>Point of contact</em>: @gsmet (Zulip: @_<strong>Guillaume Smet</strong> )</p>
-      status: on track
-      last-activity: 2024-09-30
-    - title: "Enhanced TLS support"
-      board-url: "https://github.com/orgs/quarkusio/projects/24"
-      short-description: Track the progress around the new TLS configuration centralization and new features (like Let's Encrypt, Cert-Manager, and local experience...)
-      readme: |
-        <p>TLS is becoming increasingly common and recommended. However, for years, each Quarkus extension has been doing its own TLS configuration and management. As a result, the configuration looks different everywhere, and many extensions have incomplete configurations.</p>
-        <p>Based on the newly integrated TLS registry, we now have a single place to configure TLS. At runtime, it provides methods to configure Vert.x and &quot;pure&quot; Java clients (using an <code>SSLContext</code>).</p>
-        <p>The goal of this focus group is to continue integrating the TLS registry and improve Quarkus integration with certificate providers (Let's Encrypt, Cert-Manager). In addition, we would like to provide a frictionless local experience around TLS (i.e., without the infamous untrusted certificate screen).</p>
-        <p><em>Point of contact:</em> @cescoffier (@<strong>Clement Escoffier</strong> on Zulip)</p>
-      status: complete
-      last-activity: 2024-09-29
-      last-update: |
-        This working group is complete! 
-        That does not mean that no work will be done around TLS, but what was defined in the initial scope of the working group has been completed. 
-        Enhancements and bug fixes will follow.
-    - title: "Quarkus to the CommonHaus Foundation"
-      board-url: "https://github.com/orgs/quarkusio/projects/38"
-      short-description: Work needed around moving Quarkus to foundation and streamline open governance.
-      readme: |
-        <p>from Discussion at https://github.com/quarkusio/quarkus/discussions/43013</p>
-        <p>We started the move of Quarkus to a foundation <a href="https://quarkus.io/blog/quarkus-in-a-foundation/">earlier this year</a> and recently <a href="https://quarkus.io/blog/quarkus-moving-to-commonhaus/">set the direction</a> towards <a href="https://www.commonhaus.org/">CommonHaus</a> and during the summer break the CommonHaus council <a href="https://github.com/commonhaus/foundation/pull/183">approved our request</a> to join.</p>
-        <p>Thus, now the real work starts, and it's just fitting we set up a working group for the effort getting Quarkus to CommonHaus foundation.</p>
-        <h1>Goal</h1>
-        <p>Two parts</p>
-        <ul>
-        <li>setup Quarkus to have transparent and open governance</li>
-        <li>Go through the few but important requirements for a CommonHaus project.</li>
-        </ul>
-        <h1>Initial work items/questions:</h1>
-        <p>Current known list, but not limited to:</p>
-        <ul>
-        <li>identify design communication channels (i.e. #41973)</li>
-        <li>which repositories / code will move</li>
-        <li>impact (if any) on quarkiverse projects</li>
-        <li>how will trademarks work/change</li>
-        <li>identify running services and setup/maintain them (registry.quarkus.io, code.quarkus.io etc.)</li>
-        <li>add required metadata/files to the various repositories</li>
-        </ul>
-        <h1>Tracking</h1>
-        <p>We will use the working group board to track publicly all the known relevant work and questions.For the few exception cases where, for legal or personal constraints, the work must happen in private, we will post the outcome and results in public places (like a GitHub discussion of a GitHub issue tracked on the working group board).</p>
-        <h1>When will this working group be done?</h1>
-        <p>When Quarkus has an active working governance model in place and all major work items around setting up Quarkus at CommonHaus are completed - after that, its expected things will just be iteratively improved, and the dedicated working group will not be needed (others might start to continue more specific efforts).</p>
-        <p>The majority of the work must be done before the end of December 2024. The latest deadline for CommonHaus is April 2025, when the bootstrap period of CommonHaus ends.</p>
-      status: on track
-      last-activity: 2024-09-29
-      last-update: |
-        Just got started.
-    - title: "Test classloading"
-      board-url: "https://github.com/orgs/quarkusio/projects/30"
-      short-description: The goal of this working group is to rewrite Quarkus's test classloading, so that tests are run in the same classloader as the application under tests, and Quarkus extensions can do "Quarkus-y" manipulations of test classes.
-      readme: |
-        <p>At the moment, Quarkus tests are invoked using one classloader, and then executed in a different classloader. This mostly works well, but means some use cases don't work: extensions cannot manipulate test classes in the same way that they do normal application classes. For example, anything run via a JUnit @TestTemplate test case will see the un-transformed class.</p>
-        <p>It also means we have extra user-facing complexity, such as the QuarkusTest*Callbacks](https://quarkus.io/guides/getting-started-testing#enrichment-via-quarkustestcallback):</p>
-        <blockquote>
-        <p>While it is possible to use JUnit Jupiter callback interfaces like BeforeEachCallback, you might run into classloading issues because Quarkus has to run tests in a custom classloader which JUnit is not aware of.</p>
-        </blockquote>
-        <p>A final benefit is a reduction in the internal complexity of our code. Hopping between classloaders during test execution takes a lot of work, and adds a lot of code! It also is brittle in places. For example, because the hop between classloaders relies on serialization in some cases, it's becoming harder to do as the JVM tightens up security restrictions. We used to rely on xstream, but that stopped working in Java 17. In https://github.com/quarkusio/quarkus/pull/40601, @dmlloyd moved us to use the JBoss Serializer, which works better, but might still be affected by future restrictions on class access.</p>
-        <p>The goal of this working group is to allow test classes to fully participate in the 'quarkification' of classes. The mechanism for this is probably just to load the test classes with the classloader we intend to run them with, so that JUnit sees the 'correct' version of the class.</p>
-      status: on track
-      last-activity: 2024-09-24
-      last-update: |
-        Since we don't have a target date, and progress is being made, I can declare this on track, with only a slightly murky conscience. 
-        
-        This is a big change, and one which doesn't lend itself well to dividing into smaller chunks. I'm keeping a spreadsheet of build results. In the CI runs, the number of failing jobs was 31 at the last update, and it is now 25. A number of suites, such as `integration-tests/devtools` were failing, and are now passing.
-    - title: "Roq :: Quarkus SSG"
-      board-url: "https://github.com/orgs/quarkiverse/projects/6"
-      short-description: Allow Static Site Generation with Quarkus.
-      readme: |
-        <p>New initiative to allow Static Site Generation with Quarkus.</p>
-        <p>Quarkus already provides most of the pieces to create great web applications (https://quarkus.io/guides/web).</p>
-        <p>I recently added https://github.com/quarkiverse/quarkus-roq. It will allow generating a static website out of any Quarkus application (it starts the app, fetch all the configured pages and assets, generate a static website and stop), it already works but it is still very alpha.</p>
-        <p>What's missing? we now need to incrementally add the toolkit to ease the process of creating static content through Quarkus:</p>
-        <ul>
-        <li>Static Data</li>
-        <li>Markdown/Asciidoc and frontmatter</li>
-        <li>SEO</li>
-        <li>Image processing</li>
-        <li>Easy to configure routing</li>
-        </ul>
-        <p>This will allow to develop the content using Quarkus dev-mode, and then generate for Github Pages or similar when it's ready.</p>
-        <p>Bonus, everything added will benefit any &quot;non-static&quot; Quarkus app and any Static Quarkus app could also become non static.</p>
-        <p>This effort is now tracked using a &quot;Working Group&quot; project: https://github.com/orgs/quarkiverse/projects/6</p>
-        <p>This is a great opportunity to participate in fun effort and be involved with the Quarkus community, if anyone is interested in being a part of this, please reach out to me 🚀</p>
-      status: on track
-      last-activity: 2024-09-23
-      last-update: |
-        0.0.3 has been released, it is the MVP version and allowed to publish the Roq blog: https://quarkiverse.io/quarkus-roq/posts/2024-08-29-welcome-to-roq/
-        
-        From now on, we start adding features incrementally, documenting.
-        
-        The target is to have 1.0.0 the 1 October 2024.
-        
-        For 1.0 we need pagination, tags and SEO.
-    - title: "Docker file generation"
-      board-url: "https://github.com/orgs/quarkusio/projects/27"
-      short-description: A working group focusing on the generation of Dockerfile / ContainerFile
-      readme: |
-        <p>At the moment, when you create a Quarkus project (from code.quarkus.io or the CLI), a set of <code>Dockerfiles</code> is generated. However,</p>
-        <ol>
-        <li>Not all these files are used by the user</li>
-        <li>These files are very quickly outdated</li>
-        <li>It does not allow <em>extensions</em> to customize the content</li>
-        </ol>
-        <p>This working group aims to replace these `Dockerfiles' with a CLI command that generates an up-to-date Dockerfile and includes extension customization.</p>
-        <p>The goal is not to allow updating these files once generated but to provide a one-off generation that the user can consult and use. It will use the recommended and up-to-date <code>FROM</code> image to improve security and, depending on the generated <em>variant</em> (JVM, native, native-micro...), follow good practices (such as using <code>run-java</code> for the JVM one).</p>
-        <p>You can find more details about this working group on <a href="https://github.com/quarkusio/quarkus/discussions/41352">this discussion</a>.
-        Once completed, this working group will be followed by other initiatives focusing on generating the Github Action and Tekton pipelines.</p>
-        <p><em>Point of contact</em>: @iocanel (<code>Ioannis Canellos</code>on Zulip)</p>
-      status: on track
-      last-activity: 2024-09-10
-      last-update: |
-        There is a first draft https://github.com/quarkusio/quarkus/pull/42316
-        The PR introduces a CLI plugin that generates a Dockerfile. 
-        At the moment one can configure:
-        - base image
-        - falvor (jdk or native)
-        
-        With more features to be added in future pull requests.
-        The pull request is on hold due to some concerns raised by @ia3andy. A meeting has been scheduled to discuss those concerns.
-    - title: "WebSocket Next"
-      board-url: "https://github.com/orgs/quarkusio/projects/26"
-      short-description: WebSocket-Next related tasks
-      readme: |
-        <p>The WebSocket Next <em>focus group</em> aims to improve our WebSocket experience.</p>
-        <p>Recently, we delivered a new approach to dealing with WebSocket (both for the server and client). This was the first step. There are still a few areas to improve, such as documentation, security, observability, and testability. The goal of this focus group is to track these efforts.</p>
-        <p>Point of contact: @mkouba (@<strong>Martin Kouba</strong>  on Zulip)</p>
-      status: on track
-      last-activity: 2024-09-05
-      last-update: |
-        The last outstanding issue is OTel integration. @michalvavrik is working on a [pull request](https://github.com/quarkusio/quarkus/pull/41956). I will meet with Michal and Bruno in the coming weeks. The PR is quite massive and we need to review it carefully.
+  - title: "Quarkus 3.15 LTS"
+    board-url: "https://github.com/orgs/quarkusio/projects/28"
+    short-description: This WG focuses on defining the issues we would like to have in the next-to-be LTS (Quarkus 3.14/3.15)
+    readme: |
+      <p>This working group uses a different board:</p>
+      <ul>
+      <li>The <code>under discussion</code> column contains the issues we would like to have in the next LTS but are still under consideration.</li>
+      <li>The <code>out of scope</code> column contains the issues under discussion' that won't be included. The reason can be time or technical...</li>
+      <li>The <code>in progress</code> means that the work has started and should be completed before the TLS cut date</li>
+      <li>The <code>done</code> column means that the issues have been completed</li>
+      </ul>
+    status: on track
+    completed: false
+    last-activity: 2024-10-01
+    last-update: |
+      3.15 has been cut. 
+      The 3.15.x is the new LTS, starting with 3.15.1
+  - title: "Quarkus Config and IDEs"
+    board-url: "https://github.com/orgs/quarkusio/projects/32"
+    short-description: Let's define a format for the files containing the config model we will include in the jars for IDE consumption.
+    readme: |
+      <p>Let's define a format for the files containing the config model we will include in the jars for IDE consumption.</p>
+      <p>See https://github.com/quarkusio/quarkus/discussions/42671 for more details.</p>
+      <p><em>Point of contact</em>: @gsmet (Zulip: @_<strong>Guillaume Smet</strong> )</p>
+    status: on track
+    completed: false
+    last-activity: 2024-09-30
+  - title: "Enhanced TLS support"
+    board-url: "https://github.com/orgs/quarkusio/projects/24"
+    short-description: Track the progress around the new TLS configuration centralization and new features (like Let's Encrypt, Cert-Manager, and local experience...)
+    readme: |
+      <p>TLS is becoming increasingly common and recommended. However, for years, each Quarkus extension has been doing its own TLS configuration and management. As a result, the configuration looks different everywhere, and many extensions have incomplete configurations.</p>
+      <p>Based on the newly integrated TLS registry, we now have a single place to configure TLS. At runtime, it provides methods to configure Vert.x and &quot;pure&quot; Java clients (using an <code>SSLContext</code>).</p>
+      <p>The goal of this focus group is to continue integrating the TLS registry and improve Quarkus integration with certificate providers (Let's Encrypt, Cert-Manager). In addition, we would like to provide a frictionless local experience around TLS (i.e., without the infamous untrusted certificate screen).</p>
+      <p><em>Point of contact:</em> @cescoffier (@<strong>Clement Escoffier</strong> on Zulip)</p>
+    status: complete
+    completed: true
+    last-activity: 2024-09-29
+    last-update: |
+      This working group is complete! 
+      That does not mean that no work will be done around TLS, but what was defined in the initial scope of the working group has been completed. 
+      Enhancements and bug fixes will follow.
+  - title: "Quarkus to the CommonHaus Foundation"
+    board-url: "https://github.com/orgs/quarkusio/projects/38"
+    short-description: Work needed around moving Quarkus to foundation and streamline open governance.
+    readme: |
+      <p>from Discussion at https://github.com/quarkusio/quarkus/discussions/43013</p>
+      <p>We started the move of Quarkus to a foundation <a href="https://quarkus.io/blog/quarkus-in-a-foundation/">earlier this year</a> and recently <a href="https://quarkus.io/blog/quarkus-moving-to-commonhaus/">set the direction</a> towards <a href="https://www.commonhaus.org/">CommonHaus</a> and during the summer break the CommonHaus council <a href="https://github.com/commonhaus/foundation/pull/183">approved our request</a> to join.</p>
+      <p>Thus, now the real work starts, and it's just fitting we set up a working group for the effort getting Quarkus to CommonHaus foundation.</p>
+      <h1>Goal</h1>
+      <p>Two parts</p>
+      <ul>
+      <li>setup Quarkus to have transparent and open governance</li>
+      <li>Go through the few but important requirements for a CommonHaus project.</li>
+      </ul>
+      <h1>Initial work items/questions:</h1>
+      <p>Current known list, but not limited to:</p>
+      <ul>
+      <li>identify design communication channels (i.e. #41973)</li>
+      <li>which repositories / code will move</li>
+      <li>impact (if any) on quarkiverse projects</li>
+      <li>how will trademarks work/change</li>
+      <li>identify running services and setup/maintain them (registry.quarkus.io, code.quarkus.io etc.)</li>
+      <li>add required metadata/files to the various repositories</li>
+      </ul>
+      <h1>Tracking</h1>
+      <p>We will use the working group board to track publicly all the known relevant work and questions.For the few exception cases where, for legal or personal constraints, the work must happen in private, we will post the outcome and results in public places (like a GitHub discussion of a GitHub issue tracked on the working group board).</p>
+      <h1>When will this working group be done?</h1>
+      <p>When Quarkus has an active working governance model in place and all major work items around setting up Quarkus at CommonHaus are completed - after that, its expected things will just be iteratively improved, and the dedicated working group will not be needed (others might start to continue more specific efforts).</p>
+      <p>The majority of the work must be done before the end of December 2024. The latest deadline for CommonHaus is April 2025, when the bootstrap period of CommonHaus ends.</p>
+    status: on track
+    completed: false
+    last-activity: 2024-09-29
+    last-update: |
+      Just got started.
+  - title: "Test classloading"
+    board-url: "https://github.com/orgs/quarkusio/projects/30"
+    short-description: The goal of this working group is to rewrite Quarkus's test classloading, so that tests are run in the same classloader as the application under tests, and Quarkus extensions can do "Quarkus-y" manipulations of test classes.
+    readme: |
+      <p>At the moment, Quarkus tests are invoked using one classloader, and then executed in a different classloader. This mostly works well, but means some use cases don't work: extensions cannot manipulate test classes in the same way that they do normal application classes. For example, anything run via a JUnit @TestTemplate test case will see the un-transformed class.</p>
+      <p>It also means we have extra user-facing complexity, such as the QuarkusTest*Callbacks](https://quarkus.io/guides/getting-started-testing#enrichment-via-quarkustestcallback):</p>
+      <blockquote>
+      <p>While it is possible to use JUnit Jupiter callback interfaces like BeforeEachCallback, you might run into classloading issues because Quarkus has to run tests in a custom classloader which JUnit is not aware of.</p>
+      </blockquote>
+      <p>A final benefit is a reduction in the internal complexity of our code. Hopping between classloaders during test execution takes a lot of work, and adds a lot of code! It also is brittle in places. For example, because the hop between classloaders relies on serialization in some cases, it's becoming harder to do as the JVM tightens up security restrictions. We used to rely on xstream, but that stopped working in Java 17. In https://github.com/quarkusio/quarkus/pull/40601, @dmlloyd moved us to use the JBoss Serializer, which works better, but might still be affected by future restrictions on class access.</p>
+      <p>The goal of this working group is to allow test classes to fully participate in the 'quarkification' of classes. The mechanism for this is probably just to load the test classes with the classloader we intend to run them with, so that JUnit sees the 'correct' version of the class.</p>
+    status: on track
+    completed: false
+    last-activity: 2024-09-24
+    last-update: |
+      Since we don't have a target date, and progress is being made, I can declare this on track, with only a slightly murky conscience. 
+      
+      This is a big change, and one which doesn't lend itself well to dividing into smaller chunks. I'm keeping a spreadsheet of build results. In the CI runs, the number of failing jobs was 31 at the last update, and it is now 25. A number of suites, such as `integration-tests/devtools` were failing, and are now passing.
+  - title: "Roq :: Quarkus SSG"
+    board-url: "https://github.com/orgs/quarkiverse/projects/6"
+    short-description: Allow Static Site Generation with Quarkus.
+    readme: |
+      <p>New initiative to allow Static Site Generation with Quarkus.</p>
+      <p>Quarkus already provides most of the pieces to create great web applications (https://quarkus.io/guides/web).</p>
+      <p>I recently added https://github.com/quarkiverse/quarkus-roq. It will allow generating a static website out of any Quarkus application (it starts the app, fetch all the configured pages and assets, generate a static website and stop), it already works but it is still very alpha.</p>
+      <p>What's missing? we now need to incrementally add the toolkit to ease the process of creating static content through Quarkus:</p>
+      <ul>
+      <li>Static Data</li>
+      <li>Markdown/Asciidoc and frontmatter</li>
+      <li>SEO</li>
+      <li>Image processing</li>
+      <li>Easy to configure routing</li>
+      </ul>
+      <p>This will allow to develop the content using Quarkus dev-mode, and then generate for Github Pages or similar when it's ready.</p>
+      <p>Bonus, everything added will benefit any &quot;non-static&quot; Quarkus app and any Static Quarkus app could also become non static.</p>
+      <p>This effort is now tracked using a &quot;Working Group&quot; project: https://github.com/orgs/quarkiverse/projects/6</p>
+      <p>This is a great opportunity to participate in fun effort and be involved with the Quarkus community, if anyone is interested in being a part of this, please reach out to me 🚀</p>
+    status: on track
+    completed: false
+    last-activity: 2024-09-23
+    last-update: |
+      0.0.3 has been released, it is the MVP version and allowed to publish the Roq blog: https://quarkiverse.io/quarkus-roq/posts/2024-08-29-welcome-to-roq/
+      
+      From now on, we start adding features incrementally, documenting.
+      
+      The target is to have 1.0.0 the 1 October 2024.
+      
+      For 1.0 we need pagination, tags and SEO.
+  - title: "Docker file generation"
+    board-url: "https://github.com/orgs/quarkusio/projects/27"
+    short-description: A working group focusing on the generation of Dockerfile / ContainerFile
+    readme: |
+      <p>At the moment, when you create a Quarkus project (from code.quarkus.io or the CLI), a set of <code>Dockerfiles</code> is generated. However,</p>
+      <ol>
+      <li>Not all these files are used by the user</li>
+      <li>These files are very quickly outdated</li>
+      <li>It does not allow <em>extensions</em> to customize the content</li>
+      </ol>
+      <p>This working group aims to replace these `Dockerfiles' with a CLI command that generates an up-to-date Dockerfile and includes extension customization.</p>
+      <p>The goal is not to allow updating these files once generated but to provide a one-off generation that the user can consult and use. It will use the recommended and up-to-date <code>FROM</code> image to improve security and, depending on the generated <em>variant</em> (JVM, native, native-micro...), follow good practices (such as using <code>run-java</code> for the JVM one).</p>
+      <p>You can find more details about this working group on <a href="https://github.com/quarkusio/quarkus/discussions/41352">this discussion</a>.
+      Once completed, this working group will be followed by other initiatives focusing on generating the Github Action and Tekton pipelines.</p>
+      <p><em>Point of contact</em>: @iocanel (<code>Ioannis Canellos</code>on Zulip)</p>
+    status: on track
+    completed: false
+    last-activity: 2024-09-10
+    last-update: |
+      There is a first draft https://github.com/quarkusio/quarkus/pull/42316
+      The PR introduces a CLI plugin that generates a Dockerfile. 
+      At the moment one can configure:
+      - base image
+      - falvor (jdk or native)
+      
+      With more features to be added in future pull requests.
+      The pull request is on hold due to some concerns raised by @ia3andy. A meeting has been scheduled to discuss those concerns.
+  - title: "WebSocket Next"
+    board-url: "https://github.com/orgs/quarkusio/projects/26"
+    short-description: WebSocket-Next related tasks
+    readme: |
+      <p>The WebSocket Next <em>focus group</em> aims to improve our WebSocket experience.</p>
+      <p>Recently, we delivered a new approach to dealing with WebSocket (both for the server and client). This was the first step. There are still a few areas to improve, such as documentation, security, observability, and testability. The goal of this focus group is to track these efforts.</p>
+      <p>Point of contact: @mkouba (@<strong>Martin Kouba</strong>  on Zulip)</p>
+    status: on track
+    completed: false
+    last-activity: 2024-09-05
+    last-update: |
+      The last outstanding issue is OTel integration. @michalvavrik is working on a [pull request](https://github.com/quarkusio/quarkus/pull/41956). I will meet with Michal and Bruno in the coming weeks. The PR is quite massive and we need to review it carefully.

--- a/_includes/working-group-band.html
+++ b/_includes/working-group-band.html
@@ -9,6 +9,7 @@
 
   
     {% for item in site.data.wg.working-groups %}
+    {% unless item.completed %}
     <div class="card">
       <div class="card-header">
         <p class="card-title">{{ item.title }}</p>
@@ -22,6 +23,24 @@
         <a href="{{ item.board-url }}" class="float-end"> View the {{ item.title }} Board <i class="fa-solid fa-chevron-right"></i></a>
       </div>
     </div>
+    {% endunless %}
     {% endfor %}      
   </div>
+
+  <h2>Completed working groups</h2>
+  <p class="mt-0">
+    These working groups have completed their work and are no longer active:
+  </p>
+  <ul>
+    {% for item in site.data.wg.working-groups %}
+    {% if item.completed %}
+    <li>
+      <a href="{{ item.board-url }}">{{ item.title }} ({{ item.last-activity | date: '%B %d, %Y' }})</a>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+
+
 </div>
+

--- a/working-groups/main.java
+++ b/working-groups/main.java
@@ -208,6 +208,11 @@ public class main implements Callable<Integer> {
             return lastUpdateBody.replaceAll("\n", "\n        ").trim();
         }
 
+        public boolean isCompleted() {
+            var last = getLastUpdate();
+            return last != null && last.status().equals("COMPLETE");
+        }
+
         public Status getStatus() {
             if (statusUpdates.isEmpty()) {
                 return Status.INACTIVE;

--- a/working-groups/templates/wg.yaml.template
+++ b/working-groups/templates/wg.yaml.template
@@ -7,6 +7,7 @@ working-groups:
       readme: |
         {board.getIndentedReadme().raw}
       status: {board.getBadgeText()}
+      completed: {board.isCompleted()}
       last-activity: {board.getLastActivityDate()}
       {#if board.getLastUpdate()  && board.getLastUpdate().body.trim()}
       last-update: |


### PR DESCRIPTION
- Extend working group metadata to detect completed working groups.
- Do not display completed working groups as cards.
- Add a simple list at the bottom of the page.