### PR TITLE
Quarkus Cheat Sheet removal

### DIFF
--- a/_includes/index-docs.html
+++ b/_includes/index-docs.html
@@ -109,9 +109,6 @@
           <p>{{site.data.index-docs.texts.technical_resource_that_covers_tools_components_and_commands_the_encyclopedia_for_quarkus}}</p>
         </div>
         <div class="grid-wrapper">
-          {% include index-doc-item.html type="pdf" docversion=docversion
-          title="Quarkus Cheat
-          Sheet" url="https://lordofthejars.github.io/quarkus-cheat-sheet/" summary=site.data.index-docs.texts.download_link %}
           {% for guide in values %}
           {% include index-doc-item.html type="reference" docversion=docversion
           title=guide.title url=guide.url summary=guide.summary

--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -56,23 +56,6 @@
         </ul>
       </div>
 
-      <div class="grid__item width-6-12 width-12-12-m callout-wrapper">
-        <div class="grid-wrapper callout">
-          <div class="grid__item width-12-12">
-            <h3>Quarkus Cheat Sheet</h3>
-          </div>
-          <div class="grid__item col">
-            <a href="https://lordofthejars.github.io/quarkus-cheat-sheet/" target="_blank">
-              <span class="col-icon"><i class="far fa-file-pdf"></i></span>
-              <span class="col-link">Download full cheatsheet as PDF</span>
-            </a>
-          </div>
-          <div class="grid__item col">
-            <a href="https://developers.redhat.com/search?t=quarkus&f=type%7Echeat_sheet" target="_blank">Get
-              more cheatsheets on the Red Hat Developers website <i class="fas fa-external-link-alt"></i></a>
-          </div>
-        </div>
-      </div>
       <div class="grid__item width-12-12 click-cards">
         <ul class="list">
           {% for item in site.data[data_source].categories %}


### PR DESCRIPTION
Quarkus Cheat Sheet removal

https://github.com/lordofthejars/quarkus-cheat-sheet/ has last update for Quarkus 2.7, that's 2.5 years ago and thus Quarkus Cheat Sheet does not seem relevant anymore

It's the first item in References section of Guides page - https://quarkus.io/version/main/guides/#reference
