### PR TITLE
Fix/localized about sync issue

### DIFF
--- a/.github/workflows/sync-working-groups.yml
+++ b/.github/workflows/sync-working-groups.yml
@@ -27,7 +27,7 @@ jobs:
         uses: jbangdev/jbang-action@v0.119.0
         with:
           script: working-groups/main.java
-          jbangargs: --verbose -Dworking-groups.output=_data/wg.yaml.template
+          jbangargs: --verbose -Dworking-groups.output=_data/wg.yaml
         env:
           JBANG_REPO: /root/.jbang/repository
           GITHUB_TOKEN: ${{ secrets.SYNC_WORKING_GROUP_TOKEN }}

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -39,7 +39,7 @@
       <h2>The inspiration behind Quarkus...</h2>
     </div>
     <div class="width-6-12 width-12-12-m video-container">
-      <iframe src="https://www.youtube.com/embed/SQDR34KoC-8" title="Quarkus why, how and what by Emmanuel Bernard" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/SQDR34KoC-8" title="Quarkus why, how and what by Emmanuel Bernard" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen="true"></iframe>
     </div>
     <div class="width-6-12 width-12-12-m">
       <p>For more about the why, how and what of Quarkus, check out the Devoxx Belgium presentation where Quarkus 1.0 was released in November 2019.</p>


### PR DESCRIPTION
The change in `_includes/about.html` should address another sync issue with the localized sites: 

https://github.com/quarkusio/es.quarkus.io/actions/runs/11649689659/job/32467265667

> ...po4a::xml::treat_attributes: upstream/_includes/about.html:42: Bad attribute syntax

(at least, I think that it should... can't see any possible problems with other attributes)
(link to the iframe attributes: https://www.w3schools.com/tags/tag_iframe.ASP)

I also reverted the change in the output ... it was my wrong assumption that the sync action added a template file, while actually it was added here: https://github.com/quarkusio/quarkusio.github.io/pull/2041/files ... git history tree display was messed up when I was looking at it 😖 and looking at the path... it's to the data directory, not to the template 😖  sorry for that 😔 