### PR TITLE
Add inline macro for copying of configuration properties in dotted format

### DIFF
--- a/_plugins/asciidoctor-extension.rb
+++ b/_plugins/asciidoctor-extension.rb
@@ -52,6 +52,16 @@ Extensions.register do
   end
 end
 
+Extensions.register do
+  inline_macro do
+    named :config_property_copy_button
+    resolve_attributes false
+    process do |parent, target, attrs|
+      copy_btn = %(<button class="btn-copy fa fa-clipboard inline-btn-copy" data-clipboard-action="copy" data-clipboard-text='#{target}' title="Copy to clipboard" do-not-collapse="true"></button>)
+      create_inline_pass parent, %(#{copy_btn})
+    end
+  end
+end
 
 ### ALL CONFIG page processors
 


### PR DESCRIPTION
This new inline macro is required for https://github.com/quarkusio/quarkus/pull/44403.