### PR TITLE
verify bsky domain

### DIFF
--- a/.well-known/atproto-did
+++ b/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:a3ckxd7pwewp7dn555oskvqe

--- a/_config.yml
+++ b/_config.yml
@@ -241,3 +241,6 @@ jekyll-archives:
 ############################################################
 feed:
   posts_limit: 50
+
+include:
+  - ".well-known"


### PR DESCRIPTION
so we can get quarkus.io as bsky handle.