### PR TITLE
Enable copy button for config properties

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,6 +100,7 @@ asciidoctor:
     icons: font
     outfilesuffix: ''
     add-copy-button-to-env-var: true
+    add-copy-button-to-config-props: true
 
 # Pages permalink
 defaults:


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/44403 we agreed that copy button for configuration properties needs to be enabled on demand (so that downstream docs is not broken when the copy button is not supported).