### PR TITLE
Update FAQ with links to extensions.quarkus.io and syntax updates

### DIFF
--- a/faq.adoc
+++ b/faq.adoc
@@ -11,13 +11,15 @@ Quarkus is an Open Source project licensed under the https://www.apache.org/lice
 
 == Where can I get it?
 
-Quarkus is published in Maven Central, check out link:/extensions[which extensions] you need and just import them in your `pom.xml` to get Quarkus. We recommend you start your Quarkus experience via our link:/get-started[Getting Started guides].
+Quarkus is published in Maven Central. We recommend you start your Quarkus experience with our link:/get-started[Getting Started guides] or by downloading a scaffolded application from https://code.quarkus.io[code.quarkus.io].
 
 == Quarkus is stable?
 
-Yes, we consider Quarkus stable. Remember 95% of the features Quarkus apps use are provided by the ecosystem like Hibernate ORM, Eclipse Vert.x, Netty, RESTEasy, etc. These libraries are rock solid :)
+Yes, we consider Quarkus stable.
+Quarkus is used in production by a wide range of organizations (see some link:blog/tag/user-story/[user stories]).
+Remember 95% of the features Quarkus apps use are provided by the ecosystem like Hibernate ORM, Eclipse Vert.x, Netty, RESTEasy, etc. These libraries are rock solid :)
 
-You can go to https://code.quarkus.io/[code.quarkus.io] to see if a particular extension is _stable_ (default) or _preview_.
+You can go to https://quarkus.io/extensions[quarkus.io/extensions] to see if a particular extension is _stable_ (default) or _preview_.
 
 == What is a Quarkus extension?
 
@@ -37,7 +39,7 @@ Extensions have a various degree of maturity when they enter the Quarkus ecosyst
 
 *Deprecated*: backward compatibility and presence in the ecosystem is not guaranteed. Such extensions are likely to be replaced or removed in a future version of Quarkus.
 
-You can find the extension status on https://code.quarkus.io[code.quarkus.io] or in the extension link:/guides/[guides].
+You can find the extension status on https://quarkus.io/extensions[quarkus.io/extensions] or in the extension link:/guides/[guides].
 
 == Can I write an extension?
 
@@ -47,27 +49,26 @@ Oh yeah! We had quite a few extensions written outside the Quarkus "initial" tea
 
 Quarkus is an open ecosystem and we hope to see all the extensions people need to write their apps. We are working as we speak to allow an extension to be published in separate repos and separate GAVs and thus published in Maven repos independently of Quarkus core. This will greatly simplify the publication process. Expect news soon.
 
-The one current restriction is that extensions should work in both OpenJDK and GraalVM native executables. That is the guarantee we give Quarkus users (a cross compilation for their app). We have a link:/guides/extension-maturity-matrix[maturity model] to improve an extension to be fully "Quarked" and benefit from Quarkus, all done in incremental steps. Just hop on our https://quarkus.io/community/#discussions[mailing list] to discuss your ideas and get help. And you can start reading our https://quarkus.io/guides/writing-extensions[Writing extensions guide] as well or more simply get inspiration from the https://github.com/quarkusio/quarkus/tree/main/extensions[existing ones].
+The one current restriction is that extensions should work in both OpenJDK and GraalVM native executables. That is the guarantee we give Quarkus users (a cross compilation for their app). We have a link:/guides/extension-maturity-matrix[maturity model] to improve an extension to be fully "Quarked" and benefit from Quarkus, all done in incremental steps. Just hop on our https://quarkus.io/community/#discussions[mailing list] to discuss your ideas and get help. And you can start reading our https://quarkus.io/guides/writing-extensions[Writing extensions guide] as well or more simply get inspiration from the https://quarkus.io/extensions[existing ones].
 
-
-## What is GraalVM?
+== What is GraalVM?
 
 https://www.graalvm.org[GraalVM] is a universal virtual machine for running applications written in various different languages, as well as providing the ability to compile JVM bytecode to a native executable (this native executable runs a special virtual machine called SubstrateVM). These native executables start much faster and can use a lot less memory than a traditional JVM, however not every JVM feature is supported, and some are more limited than normal.
 
 For example by default reflection in GraalVM will not work, unless a class/member has been explicitly registered for reflection. This is normally achieved by listing every class, method, field and constructor in a JSON file, and passing this as a parameter into the native image build. This obviously gets quite cumbersome for all but the most trivial projects. Quarkus provides a framework that makes it easy to work around these annotations, and programmatically determine what should be registered.
 
-## How do you unify imperative and reactive programming?
+== How do you unify imperative and reactive programming?
 
 link:/continuum[Learn more].
 
-## What does Container First mean?
+== What does Container First mean?
 
 link:/container-first[Learn more].
 
-## What is your view on standards?
+== What is your view on standards?
 
 link:/standards[Learn more].
 
-## What are you doing to improve developer joy?
+== What are you doing to improve developer joy?
 
 link:/developer-joy[Learn more].


### PR DESCRIPTION
I was trying to google for the maturity matrix, but it's not indexed yet. What google did send me to was the general FAQ, which has a line about how we have a maturity model, and no link. There couldn't be a link because the reference is several years old. I can't add a link until the matrix doc is in a 'latest' release, but while I was looking at the doc, I noticed a few other areas that could use some love. 

There's a suggestion to use code.quarkus.io to check extension status, but extensions.quarkus.io is a more natural place to look up that kind of metadata. It also assumes no extensions live in the quarkiverse org, presumably because it was written before there was one. 

The wording about stability is a bit weak, so I strengthened with a link to our user stories. 

I also noticed the headings were markdown ones, so I swapped them to adoc style.

Finally, there was a link to the 'orginal' /extensions page, which now redirects to code.quarkus.io. For that link, code.quarkus.io is a much better destination, so I've replaced /extensions with code.quarkus.io.