### PR TITLE
Reorder 'features' on front page to emphasise performance

### DIFF
--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -14,12 +14,13 @@
         <span href="{{site.baseurl}}/about/">Why<i class="fas fa-chevron-down"></i></span>
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/about" class="{% if page.url contains '/about/' %}active{% endif %}">WHAT IS QUARKUS?</a></li>
-          <li><a href="{{site.baseurl}}/container-first" class="{% if page.url contains '/container-first/' %}active{% endif %}">CONTAINER FIRST</a></li>
-          <li><a href="{{site.baseurl}}/continuum" class="{% if page.url contains '/continuum/' %}active{% endif %}">VERSATILITY</a></li>
-          <li><a href="{{site.baseurl}}/standards" class="{% if page.url contains '/standards/' %}active{% endif %}">STANDARDS</a></li>
-          <li><a href="{{site.baseurl}}/kubernetes-native" class="{% if page.url contains '/kubernetes-native/' %}active{% endif %}">KUBERNETES NATIVE</a></li>
-          <li><a href="{{site.baseurl}}/performance" class="{% if page.url contains '/performance/' %}active{% endif %}">PERFORMANCE</a></li>
           <li><a href="{{site.baseurl}}/developer-joy" class="{% if page.url contains '/developer-joy/' %}active{% endif %}">DEVELOPER JOY</a></li>
+          <li><a href="{{site.baseurl}}/performance" class="{% if page.url contains '/performance/' %}active{% endif %}">PERFORMANCE</a></li>
+          <li><a href="{{site.baseurl}}/kubernetes-native" class="{% if page.url contains '/kubernetes-native/' %}active{% endif %}">KUBERNETES NATIVE</a></li>
+          <li><a href="{{site.baseurl}}/standards" class="{% if page.url contains '/standards/' %}active{% endif %}">STANDARDS</a></li>
+          <li><a href="{{site.baseurl}}/continuum" class="{% if page.url contains '/continuum/' %}active{% endif %}">VERSATILITY</a></li>
+          <li><a href="{{site.baseurl}}/container-first" class="{% if page.url contains '/container-first/' %}active{% endif %}">CONTAINER FIRST</a></li>
+
           
         </ul>
       </li>

--- a/_includes/homepage-features-icon-band.html
+++ b/_includes/homepage-features-icon-band.html
@@ -6,28 +6,10 @@
   </div>
   <div class="grid-container">
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst-dark.svg">
-      <h3><a href="/container-first">Container First</a></h3>
-      <p>Quarkus tailors your application for GraalVM and HotSpot. Amazingly fast boot time, incredibly low RSS memory (not just heap size!) offering near instant scale up and high density memory utilization in container orchestration platforms like Kubernetes. We use a technique we call compile time boot.</p>
-    </div>
-    <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-reactive.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-reactive-dark.svg">
-      <h3><a href="/continuum">Reactive Core</a></h3>
-      <p>Built on a robust reactive core, Quarkus ensures fast and efficient performance, supporting the development of a wide variety of modern applications.</p>
-    </div>
-    <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg">
-      <h3><a href="/standards">Community and Standards</a></h3>
-      <p>Quarkus provides a cohesive, fun to use, full-stack framework by leveraging a growing list of over fifty best-of-breed libraries that you love and use. All wired on a standard backbone.</p>
-    </div>
-    <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg">
-      <h3><a href="/kubernetes-native">Kube-Native</a></h3>
-      <p>The combination of Quarkus and Kubernetes provides an ideal environment for creating scalable, fast, and lightweight applications. Quarkus significantly increases developer productivity with tooling, pre-built integrations, application services, and more.</p>
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg">
+      <h3><a href="/developer-joy">Developer Joy</a></h3>
+      <p>A cohesive platform for optimized developer joy with unified configuration and no hassle native executable generation. Zero config, live reload in the blink of an eye and streamlined code for the 80% common usages, flexible for the remainder 20%.</p>
     </div>
     <div class="width-4-12 width-12-12-m contrib-block">
       <img class="light-only" src="{{site.baseurl}}/assets/images/performance/icon-performance.svg">
@@ -36,10 +18,29 @@
       <p>Quarkus streamlines framework optimizations in the build phase to reduce runtime dependencies and improve efficiency. By precomputing metadata and optimizing class loading, it ensures fast startup times for JVM and native binary deployments, cutting down on memory usage.</p>
     </div>
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg">
-      <h3><a href="/developer-joy">Developer Joy</a></h3>
-      <p>A cohesive platform for optimized developer joy with unified configuration and no hassle native executable generation. Zero config, live reload in the blink of an eye and streamlined code for the 80% common usages, flexible for the remainder 20%.</p>
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg">
+      <h3><a href="/kubernetes-native">Kube-Native</a></h3>
+      <p>The combination of Quarkus and Kubernetes provides an ideal environment for creating scalable, fast, and lightweight applications. Quarkus significantly increases developer productivity with tooling, pre-built integrations, application services, and more.</p>
     </div>
+    <div class="width-4-12 width-12-12-m contrib-block">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg">
+      <h3><a href="/standards">Community and Standards</a></h3>
+      <p>Quarkus provides a cohesive, fun to use, full-stack framework by leveraging a growing list of over fifty best-of-breed libraries that you love and use. All wired on a standard backbone.</p>
+    </div>
+    <div class="width-4-12 width-12-12-m contrib-block">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-reactive.svg">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-reactive-dark.svg">
+      <h3><a href="/continuum">Reactive Core</a></h3>
+      <p>Built on a robust reactive core, Quarkus ensures fast and efficient performance, supporting the development of a wide variety of modern applications.</p>
+    </div>
+    <div class="width-4-12 width-12-12-m contrib-block">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst.svg">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst-dark.svg">
+      <h3><a href="/container-first">Container First</a></h3>
+      <p>Quarkus tailors your application for GraalVM and HotSpot. Amazingly fast boot time, incredibly low RSS memory (not just heap size!) offering near instant scale up and high density memory utilization in container orchestration platforms like Kubernetes. We use a technique we call compile time boot.</p>
+    </div>
+
   </div>
 </div>


### PR DESCRIPTION
The current order has developer joy and performance as the least prominent benefits, which isn't ideal:

<img width="1519" alt="image" src="https://github.com/user-attachments/assets/c2675c7b-8085-4e4e-836c-ff6ff2dfac6d">


I've also updated the order of the navbar menus to match the new order. (It didn't quite match the old order, either. :) )