### PR TITLE
Improve blog tag page

### DIFF
--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -46,7 +46,8 @@ layout: base
       </div>
     {% endfor %}
   </div>
-  <div class="grid__item width-3-12 width-12-12-m">
+  <div class="grid__item width-1-12 width-12-12-m"></div>
+  <div class="grid__item width-2-12 width-12-12-m">
     <h3 class="tags-label">Tags</h3>
     {% assign tag_words = site.tags | sort %}
     {% for stats in tag_words %}

--- a/_sass/layouts/blog.scss
+++ b/_sass/layouts/blog.scss
@@ -137,6 +137,11 @@ body.post {
 }
 
 .blog-page, .post-page {
+
+  h2 {
+    margin-top: 0;
+  }
+
   p.byline {
     font-size: 1rem;
   }


### PR DESCRIPTION
Add spacing in line with blog index page.

Align `Tagged posts` title with `Tags` title.