### PR TITLE
fix: temporary fix to have ai tag have actual content

### DIFF
--- a/_posts/2023-11-16-quarkus-meets-langchain4j.adoc
+++ b/_posts/2023-11-16-quarkus-meets-langchain4j.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'When Quarkus meets LangChain4j'
 date: 2023-11-15
-tags: ai langchain llm
+tags: ai
 synopsis: 'Learn about the new quarkus-langchain4j extension to integrate LLMs in Quarkus applications.'
 author: cescoffier
 ---

--- a/_posts/2024-03-27-oidc-proxy.adoc
+++ b/_posts/2024-03-27-oidc-proxy.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Use OIDC Proxy to integrate OIDC service endpoints with custom GPT'
 date: 2024-03-27
-tags: oidc ai chatgpt gpt
+tags: ai oidc
 synopsis: 'Explain how OIDC Proxy can help to integrate OIDC service endpoints with custom GPT'
 author: sberyozkin
 ---

--- a/_posts/2024-11-29-quarkus-jlama.adoc
+++ b/_posts/2024-11-29-quarkus-jlama.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: "Creating pure Java LLM infused application with Quarkus, Langchain4j and Jlama"
 date: 2024-11-29
-tags: AI LLM local-inference Jlama
+tags: ai
 synopsis: "Creating pure Java LLM infused application with Quarkus, LangChain4j and Jlama"
 author: mariofusco
 ---


### PR DESCRIPTION
found that tags archives in jekyll seem to only generate based on first tag so the various ai articles were not shown together.

submitting this as temporary fix until we find out why tags archiving not working as expected.

p.s. we also should curate the tags - it doesn't scale there is arbitrary list of tags added on most posts.