### PR TITLE
fix: workaround jekyll tags bug

### DIFF
--- a/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
+++ b/_posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Quarkus developer joy for VS Code'
-tags: announcement  ide
+tags: announcement ide
 date: 2019-09-23
 synopsis: Showcasing the new Quarkus VS Code extension.
 author: dakwon

--- a/_posts/2021-06-08-quarkus-deploys-apps-on-openshift.adoc
+++ b/_posts/2021-06-08-quarkus-deploys-apps-on-openshift.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: How Quarkus has been used to deploy applications on OpenShift
 date: 2021-06-25
-tags: openShift user-story
+tags: openshift user-story
 synopsis: Find out how Quarkus has been used to deploy application components in Kubernetes, and provision satellite systems such as Vault, adfs and others, with a low memory and CPU footprint, while providing a high level abstraction.
 author: vsevel
 ---

--- a/_posts/2024-06-06-quarkus-infinispan-new.adoc
+++ b/_posts/2024-06-06-quarkus-infinispan-new.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Quarkus and Infinispan: winner combo'
 date: 2024-06-06
-tags: ['infinispan', 'cache']
+tags: infinispan cache
 synopsis: 'Infinispan extension updates from Quarkus 3.9, 3.10 and 3.11'
 author: karesti
 ---

--- a/_posts/2024-11-29-quarkus-jlama.adoc
+++ b/_posts/2024-11-29-quarkus-jlama.adoc
@@ -1,9 +1,10 @@
 ---
 layout: post
-title: "Creating pure Java LLM infused application with Quarkus, Langchain4j and Jlama"
-date: 2024-11-29
-tags: AI LLM local-inference Jlama
-synopsis: "Creating pure Java LLM infused application with Quarkus, LangChain4j and Jlama"
+title: Creating pure Java LLM infused application with Quarkus, Langchain4j and Jlama
+date: 2024-11-29T00:00:00Z
+tags: ai llm local-inference jlama
+synopsis: Creating pure Java LLM infused application with Quarkus, LangChain4j and
+  Jlama
 author: mariofusco
 ---
 


### PR DESCRIPTION
a bug from 2014 (https://github.com/jekyll/jekyll-archives/pull/24) result in when tags has mixed casing the archived list varies dependent on the order of tags.

so basically jekyll messes up tag listing if tags names are mixed casesr
for ai we have "ai", "ai", "AI", "ai" in sequence. the AI overrides the two first, the last ai overrides "AI"
so its some funky hashcollision thing

I wrote a script to spot which posts had mixed cases - seems we are pretty good at it already :)

also cleaned up to have consistent format of tags and frontmatters.

all just so https://quarkus.io/blog/tag/ai and https://quarkus.io/blog/tag/openshift will return consistent result.