### PR TITLE
Add configuration for the "created" category in the lottery

### DIFF
--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -7,6 +7,10 @@ buckets:
     delay: PT0S
     timeout: P3D
   maintenance:
+    created:
+      delay: PT0S
+      timeout: P1D
+      expiry: P14D
     feedback:
       labels: ["triage/needs-reproducer", "triage/needs-feedback"]
       needed:
@@ -40,6 +44,8 @@ participants:
     maintenance:
       labels: ["area/search"]
       days: ["WEDNESDAY", "FRIDAY"]
+      created:
+        maxIssues: 3
       feedback:
         needed:
           maxIssues: 2


### PR DESCRIPTION
Withut this, the Quarkus GitHub Lottery just fails.

Similar to https://github.com/quarkusio/quarkus/pull/45092