### PR TITLE
Center the icon in the "back-to-the-top" box

### DIFF
--- a/_sass/includes/back-to-top.scss
+++ b/_sass/includes/back-to-top.scss
@@ -16,6 +16,7 @@
 
   i {
     margin-top: .5rem;
+    padding: 0;
   }
 }
 #backToTop:hover {


### PR DESCRIPTION
Back to the top icon is currently slightly off-center:

![image](https://github.com/user-attachments/assets/97b2e535-e7bf-4e26-b056-0b1f7e5130d0)

and it was bugging me 🙈 😄 