### PR TITLE
Update the order of the footer elements on a small screen

### DIFF
--- a/_sass/includes/redhat-footer.scss
+++ b/_sass/includes/redhat-footer.scss
@@ -46,7 +46,7 @@
     @media screen and (max-width: 480px) {
       grid-column: 1/13;
       justify-self: center;
-      order: 2;
+      order: 1;
     }
   }
   .redhat-logo {
@@ -57,7 +57,7 @@
     @media screen and (max-width: 480px) {
       grid-column: 1/13;
       justify-self: center;
-      order: 1;
+      order: 2;
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkusio.github.io/issues/2162
so that "sponsored by " goes before the logo