### PR TITLE
Fix breadcrumb styling on tag page and remove title bar

### DIFF
--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -2,12 +2,9 @@
 layout: base
 ---
 
-{% include title-band.html %}
-
-
-<div class="full-width-version-bg grey align-self">
+<div class="full-width-breadcrumb-bg align-self">
   <div class="width-12-12">
-      <p class="returnlink"><a href="{{site.baseurl}}/blog">Blogs</a> <i class="fas fa-chevron-right"></i> {{ page.title }}</p>
+      <p class="returnlink"><a href="{{site.baseurl}}/blog">Blog</a> <i class="fas fa-chevron-right"></i> {{ page.title }}</p>
   </div>
 </div>
 


### PR DESCRIPTION
This fix takes care of a color mode issue and cleans up the presentation of the tag list to let the breadcrumb be positioned the same.
