### PR TITLE
Update infinispan-client-reference.adoc

### DIFF
--- a/_versions/3.15/guides/infinispan-client-reference.adoc
+++ b/_versions/3.15/guides/infinispan-client-reference.adoc
@@ -140,12 +140,12 @@ clusters.
 
 [source,properties]
 ----
-quarkus.infinispan-client.hosts=host1:11222,host2:3122 <1>
+quarkus.infinispan-client.hosts=host1:11222;host2:3122 <1>
 quarkus.infinispan-client.username=admin
 quarkus.infinispan-client.password=password
-quarkus.infinispan-client.backup-cluster.nyc-site.hosts=nyc1:11222,nyc2:21222,nyc3:31222 <2>
+quarkus.infinispan-client.backup-cluster.nyc-site.hosts=nyc1:11222;nyc2:21222;nyc3:31222 <2>
 quarkus.infinispan-client.backup-cluster.nyc-site.client-intelligence=BASIC <3>
-quarkus.infinispan-client.backup-cluster.lon-site.hosts=lon1:11222,lon2:21222,lon3:31222 <4>
+quarkus.infinispan-client.backup-cluster.lon-site.hosts=lon1:11222;lon2:21222;lon3:31222 <4>
 ----
 <1> Sets Infinispan Server address list, separated with commas. This is the default cluster.
 <2> Configures a backup site 'nyc-site' with the provided address list


### PR DESCRIPTION
the separation of the hosts should be according to documentation with semicolons and not commas

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **


[quarkus.infinispan-client.hosts](https://quarkus.io/version/3.15/guides/infinispan-client-reference#quarkus-infinispan-client_quarkus-infinispan-client-hosts)

Sets the host name/port to connect to. Each one is separated by a semicolon (eg. host1:11222;host2:11222).