### PR TITLE
changed infinispan host documentation from comma to semicolon

### DIFF
--- a/_guides/infinispan-client-reference.adoc
+++ b/_guides/infinispan-client-reference.adoc
@@ -96,7 +96,7 @@ quarkus.infinispan-client.hosts=localhost:11222 <1>
 quarkus.infinispan-client.username=admin <2>
 quarkus.infinispan-client.password=password <3>
 ----
-<1> Sets Infinispan Server address list, separated with commas
+<1> Sets Infinispan Server address list, separated with semicolons
 <2> Sets the authentication username
 <3> Sets the authentication password
 
@@ -140,14 +140,14 @@ clusters.
 
 [source,properties]
 ----
-quarkus.infinispan-client.hosts=host1:11222,host2:3122 <1>
+quarkus.infinispan-client.hosts=host1:11222;host2:3122 <1>
 quarkus.infinispan-client.username=admin
 quarkus.infinispan-client.password=password
-quarkus.infinispan-client.backup-cluster.nyc-site.hosts=nyc1:11222,nyc2:21222,nyc3:31222 <2>
+quarkus.infinispan-client.backup-cluster.nyc-site.hosts=nyc1:11222;nyc2:21222;nyc3:31222 <2>
 quarkus.infinispan-client.backup-cluster.nyc-site.client-intelligence=BASIC <3>
-quarkus.infinispan-client.backup-cluster.lon-site.hosts=lon1:11222,lon2:21222,lon3:31222 <4>
+quarkus.infinispan-client.backup-cluster.lon-site.hosts=lon1:11222;lon2:21222;lon3:31222 <4>
 ----
-<1> Sets Infinispan Server address list, separated with commas. This is the default cluster.
+<1> Sets Infinispan Server address list, separated with semicolons. This is the default cluster.
 <2> Configures a backup site 'nyc-site' with the provided address list
 <3> Configures a backup site 'nyc-site' with the provided client intelligence
 <4> Configures an additional backup site 'lon-site' with the provided address list

--- a/_guides/infinispan-client.adoc
+++ b/_guides/infinispan-client.adoc
@@ -300,7 +300,7 @@ Then, open the `src/main/resources/application.properties` file and add:
 ## Read more about it in the Infinispan Reference Guide
 # %prod.quarkus.infinispan-client.client-intelligence=BASIC <4>
 ----
-<1> Sets Infinispan Server address list, separated with commas
+<1> Sets Infinispan Server address list, separated with semicolons
 <2> Sets the authentication username
 <3> Sets the authentication password
 <4> Sets the client intelligence. Use BASIC as a workaround if using Docker for Mac.

--- a/_versions/3.15/guides/infinispan-client-reference.adoc
+++ b/_versions/3.15/guides/infinispan-client-reference.adoc
@@ -96,7 +96,7 @@ quarkus.infinispan-client.hosts=localhost:11222 <1>
 quarkus.infinispan-client.username=admin <2>
 quarkus.infinispan-client.password=password <3>
 ----
-<1> Sets Infinispan Server address list, separated with commas
+<1> Sets Infinispan Server address list, separated with semicolons
 <2> Sets the authentication username
 <3> Sets the authentication password
 


### PR DESCRIPTION
the hosts need to be separated by semicolon and not comma according to documentation 

[quarkus.infinispan-client.hosts](https://quarkus.io/version/3.15/guides/infinispan-client-reference#quarkus-infinispan-client_quarkus-infinispan-client-hosts)

Sets the host name/port to connect to. Each one is separated by a semicolon (eg. host1:11222;host2:11222).

Environment variable: QUARKUS_INFINISPAN_CLIENT_HOSTS