### PR TITLE
Bump standards to Microprofile Telemetry 2.0

### DIFF
--- a/_includes/standards.html
+++ b/_includes/standards.html
@@ -55,7 +55,7 @@
       <br><a href="https://github.com/eclipse/microprofile-reactive-messaging">MicroProfile Reactive Messaging 3.0</a>
       <br><a href="https://github.com/eclipse/microprofile-graphql">MicroProfile GraphQL 2.0</a>
       <br><a href="https://github.com/eclipse/microprofile-lra">MicroProfile Long Running Actions 2.0</a>
-      <br><a href="https://github.com/eclipse/microprofile-telemetry">MicroProfile Telemetry 1.0</a>
+      <br><a href="https://github.com/eclipse/microprofile-telemetry">MicroProfile Telemetry 2.0</a>
     </div>
   </div>
 


### PR DESCRIPTION
Bump standards to Microprofile Telemetry 2.0

MicroProfile Telemetry 2.0 support was added in https://github.com/quarkusio/quarkus/pull/43678 for Quarkus 3.17
