### PR TITLE
Fixed 'runtime' typo to 'build-time' on Performance page

### DIFF
--- a/_includes/performance.html
+++ b/_includes/performance.html
@@ -21,7 +21,7 @@
      <div class="width-12-12 width-12-12-m">
        <p>This build-time optimization offers several key benefits:</p>
        <ol>
-         <li><strong>Reduced startup time:</strong> Quarkus performs most of the heavy work at runtime, significantly cutting startup time and allowing the app to reach peak performance faster.</li>
+         <li><strong>Reduced startup time:</strong> Quarkus performs most of the heavy work at build-time, significantly cutting startup time and allowing the app to reach peak performance faster.</li>
          <li><strong>Lower memory consumption:</strong> By minimizing allocations and class loading, Quarkus reduces memory usage. Replacing reflection with build-time bytecode generation further lowers the JVM's runtime workload.</li>
          <li><strong>Better latency and improved throughput:</strong> Quarkus generates highly optimized code at build time and prunes unnecessary classes and methods. For instance, it weaves layers of indirection together, enabling better JIT optimizations. These improvements result in faster code and better latency. </li>
        </ol>


### PR DESCRIPTION
I assume 'build-time' is meant in this context...