### PR TITLE
Fix template generating invalid wg.yaml

### DIFF
--- a/working-groups/templates/wg.yaml.template
+++ b/working-groups/templates/wg.yaml.template
@@ -3,7 +3,7 @@ working-groups:
   {#for board in boards}
     - title: "{board.title}"
       board-url: "{board.url}"
-      short-description: {board.shortDescription.trim()}
+      short-description: "{board.shortDescription.trim()}"
       readme: |
         {board.getIndentedReadme().raw}
       status: {board.getBadgeText()}


### PR DESCRIPTION
With this fix, YAML remains valid even when commas are included in the short-description like this:

https://github.com/quarkusio/quarkusio.github.io/blob/fb1bdb9a0d89afec8cf3d1d77c6f509bec79f6f0/_data/wg.yaml#L24