### PR TITLE
Fixed JDBC server URL

### DIFF
--- a/_posts/2025-01-29-introducing-mcp-servers.adoc
+++ b/_posts/2025-01-29-introducing-mcp-servers.adoc
@@ -39,11 +39,11 @@ Then in your MCP client configure it with:
 
 For example to run the JDBC server to connect to a MariaDB database you would do:
 
-`jbang mcp-jdbc-server@quarkiverse/quarkus-mcp-servers jdbc:mariadb://localhost:3306/test --user root --password mysecretpassword`
+`jbang jdbc@quarkiverse/quarkus-mcp-servers jdbc:mariadb://localhost:3306/test --user root --password mysecretpassword`
 
 or use a downlodable SQLite database of Netflix movies:
 
-`jbang mcp-jdbc-server@quarkiverse/quarkus-mcp-servers jdbc:sqlite:%{https://github.com/lerocha/netflixdb/releases/download/v1.0.0/netflixdb.sqlite}`
+`jbang jdbc@quarkiverse/quarkus-mcp-servers jdbc:sqlite:%{https://github.com/lerocha/netflixdb/releases/download/v1.0.0/netflixdb.sqlite}`
 
 TIP: Tthe `%{}` syntax is a JBang feature to download a file from a URL in the command line and use it as a local file.
 


### PR DESCRIPTION
When running:

`jbang --verbose mcp-jdbc-server@quarkiverse/quarkus-mcp-servers jdbc:sqlite:%{https://github.com/lerocha/netflixdb/releases/download/v1.0.0/netflixdb.sqlite}`

I get:

```
[jbang] [1:854] Obtained catalog from https://github.com/quarkiverse/quarkus-mcp-servers/blob/HEAD/jbang-catalog.json
[jbang] [1:854] [ERROR] No alias found with name 'mcp-jdbc-server'
dev.jbang.cli.ExitException: No alias found with name 'mcp-jdbc-server'

```

Fixed by using:

`jbang jdbc@quarkiverse/quarkus-mcp-servers jdbc:sqlite:%{https://github.com/lerocha/netflixdb/releases/download/v1.0.0/netflixdb.sqlite}`
