### PR TITLE
Fixed typos in Kotlin Live Reload

### DIFF
--- a/_guides/kotlin.adoc
+++ b/_guides/kotlin.adoc
@@ -389,7 +389,7 @@ If you need to customize the compiler flags used by `kotlinc` in development mod
 ----
 quarkusDev {
     compilerOptions {
-        compiler("kotlin").args(['-Werror'])
+        compiler("kotlinc").args(['-Werror'])
     }
 }
 ----
@@ -399,7 +399,7 @@ quarkusDev {
 ----
 tasks.quarkusDev {
      compilerOptions {
-        compiler("kotlin").args(["-Werror"])
+        compiler("kotlinc").args(listOf("-Werror"))
     }
 }
 ----


### PR DESCRIPTION
Kotlin compiler has name 'kotlinc' instead of 'kotlin'
Method 'compiler().args()' has parameters type 'List' instead of 'Array'