### PR TITLE
Update classloading blog to mention Eclipse issue and workaround

### DIFF
--- a/_posts/2025-04-30-test-classloading-rewrite.adoc
+++ b/_posts/2025-04-30-test-classloading-rewrite.adoc
@@ -9,7 +9,7 @@ author: hcummins
 == What's changing?
 
 The internals of Quarkus test classloading have been rewritten in 3.22.
-It does not affect production and dev modes, or some Quarkus test modes, such `@QuarkusIntegrationTest`, `@QuarkusComponentTest`.
+It does not affect production and dev modes, or some Quarkus test modes, such as `@QuarkusIntegrationTest`, `@QuarkusComponentTest`.
 However, `@QuarkusTest` has changed.
 This change should make Quarkus testing work better, and it allowed us to fix a pile of longstanding bugs.
 It will also allow us to improve the integration with test frameworks such as Pact.

--- a/_posts/2025-04-30-test-classloading-rewrite.adoc
+++ b/_posts/2025-04-30-test-classloading-rewrite.adoc
@@ -44,7 +44,8 @@ In practice, there have been a few hiccups and we've also discovered some edge c
 
 - *Dev services now start in the JUnit discovery phase*. https://quarkus.io/guides/dev-services[Quarkus Dev Services] are currently started during https://quarkus.io/guides/reaugmentation#what-is-augmentation[the augmentation phase], along with bytecode manipulation and other application initialization steps. With the new testing design, all augmentation happens at the beginning of the test run, during the JUnit discovery phase. This means all Dev Services also start at the beginning of the test run. If several test classes with different Dev Service configuration are augmented before any tests are run, multiple differently-configured Dev Services may be running at the same time. This can cause port conflicts and cross-talk on configuration values. We're hoping to have a https://github.com/quarkusio/quarkus/issues/45785[fix] for this in the next release. As a workaround, splitting conflicting tests into separate projects should fix symptoms.
 - *Config access from JUnit conditions*. Using a `ConfigProvider` from a custom JUnit condition will https://github.com/quarkusio/quarkus/issues/47081[trigger a `ServiceConfigurationError`]. The workaround is to set the thread context classloader to `this.getClass().getClassLoader()` before reading config, and then set it back afterwards.
-- Increased memory footprint running tests. For suites using multiple profiles and resources, more heap or metaspace may be needed.
+- *Eclipse support*. Running `QuarkusTest` tests from the Eclipse IDE is https://github.com/quarkusio/quarkus/issues/47656[more challenging]. Right-clicking and running individual test methods works, and running a whole package also works. But running at the class level gives an error.
+- *Increased memory footprint running tests.* For suites using multiple profiles and resources, more heap or metaspace may be needed.
 
 
 === Things to watch out for


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/issues/47656. 

Preview link: https://quarkus-site-pr-2293-preview.surge.sh/blog/test-classloading-rewrite/