### PR TITLE
Correct dead redirect and add missing redirect for amazon-lambda

### DIFF
--- a/_redirects/guides/amazon-lambda-guide.html
+++ b/_redirects/guides/amazon-lambda-guide.html
@@ -1,4 +1,4 @@
 ---
 permalink: /guides/amazon-lambda-guide.html
-newUrl: /guides/amazon-lambda
+newUrl: /guides/aws-lambda
 ---

--- a/_redirects/guides/amazon-lambda-guide.md
+++ b/_redirects/guides/amazon-lambda-guide.md
@@ -1,4 +1,4 @@
 ---
 permalink: /guides/amazon-lambda-guide/index.html
-newUrl: /guides/amazon-lambda
+newUrl: /guides/aws-lambda
 ---

--- a/_redirects/guides/amazon-lambda.html
+++ b/_redirects/guides/amazon-lambda.html
@@ -1,0 +1,4 @@
+---
+permalink: /guides/amazon-lambda.html
+newUrl: /guides/aws-lambda
+---

--- a/_redirects/guides/amazon-lambda.md
+++ b/_redirects/guides/amazon-lambda.md
@@ -1,0 +1,4 @@
+---
+permalink: /guides/amazon-lambda/index.html
+newUrl: /guides/aws-lambda
+---


### PR DESCRIPTION
We have some dead links out in the wild, which should be fixed with redirects
- https://quarkus.io/guides/amazon-lambda gives a 404
- https://quarkus.io/guides/amazon-lambda-guide redirects, but then 404s

I spotted this because we've just been given a reproducer (https://github.com/dagrammy/lambda-test-reproducer?tab=readme-ov-file) which has a dead link for the [Related guide section...](https://quarkus.io/guides/amazon-lambda). I'll fix the quickstart, but we should also fix the redirects so that links in older quickstarts work. 

At the moment the redirect for `amazon-lambda-guide` redirects to `amazon-lambda`, which no longer exists, and there is no redirect to reflect the rename of the `amazon-lambda` guide to `aws-lamdba` (https://github.com/quarkusio/quarkus/issues/34279).

### Preview

- https://quarkus-site-pr-2347-preview.surge.sh/guides/aws-lambda works (as you'd expect)
- https://quarkus-site-pr-2347-preview.surge.sh/guides/amazon-lambda now works by doing a redirect
- https://quarkus-site-pr-2347-preview.surge.sh/guides/amazon-lambda-guide now redirects to a page that exists