### PR TITLE
Blog post: announce the quarkus-quickjs4j extension

### DIFF
--- a/_posts/2025-07-15-quickjs4j.adoc
+++ b/_posts/2025-07-15-quickjs4j.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Introducing Quarkus quickjs4j: Seamless JavaScript Integration in Your Quarkus Applications'
-date: 2025-07-14
+date: 2025-07-15
 tags: javascript, integration, cdi, build-time
 synopsis: A new Quarkiverse extension that brings JavaScript execution to your Java applications with compile-time code generation and full CDI integration.
 author: ewittman
@@ -14,7 +14,8 @@ ifdef::env-github,env-browser,env-vscode[:imagesdir: ../assets/images/posts/quic
 We're excited to announce the release of the Quarkus quickjs4j extension, a powerful new addition to the 
 Quarkus ecosystem that enables seamless execution of JavaScript code within your Java applications. Built 
 on top of the https://github.com/roastedroot/quickjs4j[quickjs4j library], this extension brings the 
-lightweight QuickJS JavaScript engine to Quarkus with full CDI integration and compile-time optimizations.
+lightweight QuickJS JavaScript engine to both JVM and Native Quarkus, with full CDI integration and
+compile-time optimizations.
 
 Whether you need to execute dynamic business logic, implement configurable rules engines, or integrate with
 JavaScript-based algorithms, the Quarkus quickjs4j extension provides a type-safe, performant solution that
@@ -180,7 +181,10 @@ public interface Calculator {
     int add(int a, int b);
     int multiply(int a, int b);
 }
+----
 
+[source,java]
+----
 @ApplicationScoped
 public class CalculatorContext {
     public void log(String message) {
@@ -292,8 +296,14 @@ community feedback. We're actively working on:
 
 - Enhanced error reporting and debugging capabilities
 - Performance optimizations
-- Additional JavaScript engine options
+- Configurable JavaScript engine options
 - Improved IDE integration and tooling
+
+In particular, we have a lot of work to do in optimizing performance.  There are
+clear tradeoffs to consider around flexibility and speed, as well as customization.
+The current experimental implementation takes a very conservative approach to 
+ensure full sandboxing and thread safety.  The result is a slower implementation, 
+but one that is guaranteed to be thread safe and fully sandboxed.
 
 == Getting Involved
 
@@ -305,7 +315,9 @@ contributions. Whether you're interested in:
 - Sharing use cases and examples
 - Improving documentation
 
-Visit our https://github.com/quarkiverse/quarkus-quickjs4j[GitHub repository] to get involved!
+Visit our https://github.com/quarkiverse/quarkus-quickjs4j[GitHub repository] to get involved.
+We would really love for you to try out quickjs4j in Quarkus and give us feedback.  The best
+way to evolve the functionality is by hearing from users!
 
 == Conclusion
 
@@ -318,9 +330,9 @@ Try it out and let us know what you think! We're excited to see what the communi
 capability.
 
 == Links and Resources
+If you want to learn more about QuickJS itself, or the upstream quickjs4j Java project,
+here are some helpful links:
 
 - https://github.com/quarkiverse/quarkus-quickjs4j[Quarkus quickjs4j GitHub Repository]
 - https://github.com/roastedroot/quickjs4j[quickjs4j Library]
 - https://bellard.org/quickjs/[QuickJS JavaScript Engine]
-- https://quarkus.io/extensions/[Quarkus Extensions]
-- https://github.com/quarkiverse[Quarkiverse Hub]


### PR DESCRIPTION
This pull request adds a new blog post to announce the new quickjs4j extension in the quarkiverse.  Links to quickjs4j and the new extension:

* https://github.com/roastedroot/quickjs4j
* https://github.com/quarkiverse/quarkus-quickjs4j/