### PR TITLE
Work around the unavailability of JDK 21 from foojay/disco

### DIFF
--- a/working-groups/main.java
+++ b/working-groups/main.java
@@ -1,5 +1,4 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
-//JAVA 21
 //JAVAC_OPTIONS -parameters
 //DEPS io.quarkus.platform:quarkus-bom:3.12.1@pom
 //DEPS io.quarkus:quarkus-picocli


### PR DESCRIPTION
** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
