### PR TITLE
Make the commonhaus logo in the footer a hyperlink

### DIFF
--- a/_includes/CF-footerband.html
+++ b/_includes/CF-footerband.html
@@ -1,7 +1,7 @@
 <div class="content cf-footer">
   <div class="flexcontainer">
     <span class="cf-logo">
-      <img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_reverse.svg"/>
+      <a href="https://www.commonhaus.org/" target="_blank"><img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_reverse.svg"/></a>
     </span>
     <span class="license">
       Copyright © Quarkus. All rights reserved. For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>. Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association.


### PR DESCRIPTION
The Red Hat logo is a hyperlink, but not the CommonHaus one. Should they both be?