### PR TITLE
Center cf logo in footer, vertically

### DIFF
--- a/_includes/CF-footerband.html
+++ b/_includes/CF-footerband.html
@@ -1,18 +1,18 @@
 <div class="content cf-footer">
   <div class="flexcontainer">
-    <span class="cf-logo">
-      <a href="https://www.commonhaus.org/" target="_blank"><img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_reverse.svg"/></a>
-    </span>
-    <span class="license">
+    <div class="cf-logo">
+      <a class="cf-logo" href="https://www.commonhaus.org/" target="_blank"><img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_reverse.svg"/></a>
+    </div>
+    <div class="license">
       Copyright © Quarkus. All rights reserved. For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>. Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association.
-    </span>
-    <span class="sponsorcontainer">
-      <span class="sponsor">
+    </div>
+    <div class="sponsorcontainer">
+      <div class="sponsor">
         Sponsored by
-      </span>
-      <span class="sponsor-logo">
-        <a href="https://www.redhat.com/" target="_blank"><img src="{{site.baseurl}}/assets/images/redhat_reversed.svg"></a>
-      </span>
-    </span>
+      </div>
+      <div class="sponsor-logo">
+        <a class="sponsor-logo" href="https://www.redhat.com/" target="_blank"><img src="{{site.baseurl}}/assets/images/redhat_reversed.svg"></a>
+      </div>
+    </div>
   </div>
 </div>

--- a/_sass/includes/cf-footer.scss
+++ b/_sass/includes/cf-footer.scss
@@ -5,6 +5,7 @@
 
   .flexcontainer {
   display: flex;
+  gap: 2rem;
   padding: 1rem 0;
   align-items: center;
 
@@ -15,8 +16,8 @@
   }
 
     .cf-logo {
-    padding-right: 2rem;
     align-items: center;
+      display: flex;
     img {min-width: 350px;
 
         @media screen and (max-width: 1024px) {
@@ -47,8 +48,7 @@
     .sponsorcontainer {
     display: flex;
     flex-direction: row;
-    padding-left: 2rem;
-
+    align-items: flex-start;
 
     @media screen and (max-width: 1024px) {
     padding-left: 0;
@@ -62,6 +62,7 @@
       }
 
       .sponsor-logo {
+        display: flex;
       justify-self: end;
         img { width: 6rem; max-width: none !important;
         }


### PR DESCRIPTION
Before: 

<img width="640" height="181" alt="image" src="https://github.com/user-attachments/assets/40f65df0-c394-49f4-9e31-a5891c5db497" />

<img width="2032" height="113" alt="image" src="https://github.com/user-attachments/assets/260e6251-247f-4411-9971-5d4210f3ee9d" />


After:

<img width="534" height="159" alt="image" src="https://github.com/user-attachments/assets/73fad954-c8eb-470a-9cd4-a0c46334459c" />

I think the main thing that made a difference was scattering `display:flex` into the anchors wrapping the images. I also switched from spans to divs, since I think that's closer to what's wanted, semantically, and also used the `gap` feature of flexbox instead of padding the individual containers asymmetrically. 

<img width="2103" height="143" alt="image" src="https://github.com/user-attachments/assets/29661a51-c734-451d-9ba5-c768c57a3de7" />
