### PR TITLE
Do not build guides in containers so container build works

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ These instructions will get you a copy of the Quarkus.io website up and running 
 
 ### Installation
 
-#### Using Docker
+#### Using Docker or Podman
 
-1. Install [Docker Desktop](https://docs.docker.com/install/).
+1. Install [Docker Desktop](https://docs.docker.com/install/) or [Podman Desktop](https://podman-desktop.io/)
 2. Fork the [project repository](https://github.com/quarkusio/quarkusio.github.io), then clone your fork:
 
         git clone git@github.com:YOUR_USER_NAME/quarkusio.github.io.git
@@ -17,11 +17,17 @@ These instructions will get you a copy of the Quarkus.io website up and running 
 
         cd quarkusio.github.io
 
-4. Run Docker Compose:
+4. Run Docker Compose or Podman Compose:
 
         docker compose up
 
-    > **Note:** The startup process may take several minutes, depending on your system. During this time, you might see logs with warnings or configuration messages (e.g., AutoPages and asciidoctor warnings). This is normal behavior as Jekyll builds the site. Once the server is running, you will see output like this:
+or 
+
+        podman compose up
+
+By default, this does not include guides. To include guides, use `podman compose --file docker-compose_with_guides.yml up`, but be aware that serving guides via container is not currently working. 
+
+> **Note:** The startup process may take several minutes, depending on your system. During this time, you might see logs with warnings or configuration messages (e.g., AutoPages and asciidoctor warnings). This is normal behavior as Jekyll builds the site. Once the server is running, you will see output like this:
 
     ```
     jekyll-1  |   Server address: http://0.0.0.0:4000/

--- a/docker-compose_with_guides.yml
+++ b/docker-compose_with_guides.yml
@@ -6,7 +6,7 @@ services:
     # Add --incremental to the commandline
     # https://github.com/BretFisher/jekyll-serve/blob/2119a31476e1c6004a4bea4739b9160fc73e7bda/Dockerfile#L27C5-L27C94
     # Also, enable dev config
-    command: [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000", "--incremental", "--config", "_config.yml,_config_dev.yml,_noguides_config.yml" ]
+    command: [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000", "--incremental", "--config", "_config.yml,_config_dev.yml" ]
     volumes:
       - .:/site:Z
     ports:


### PR DESCRIPTION
For a while, the container version of our getting started instructions hasn't been working. This is not ideal, and it's particularly unfortunate now that installing Ruby on MacOS laptops is hard (the install is breaking with ssl compatibility issues, and the fix requires an older version of Ruby to be present). 

Serving via container works for simpler sites, and the problem isn't our Gemfile. I've narrowed the problem down to something pulled in via the `_guides` directory, perhaps the `_generated-doc` directory. While I continue to debug, I've got a tactical fix. This has the benefit of speeding up container serving a lot, by just not serving the guides.