### PR TITLE
Update readme to explain mystery build error is usually a memory one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ or
 
         podman compose up
 
-By default, this does not include guides. To include guides, use `podman compose --file docker-compose_with_guides.yml up`, but be aware that serving guides via container is not currently working. 
+By default, this does not include guides. To include guides, use `podman compose --file docker-compose_with_guides.yml up`. If the guides build terminates abruptly before completion, make sure your [container engine has enough memory allocated](https://podman-desktop.io/docs/podman/creating-a-podman-machine#procedure) (it will need at least 5GB).  
 
 > **Note:** The startup process may take several minutes, depending on your system. During this time, you might see logs with warnings or configuration messages (e.g., AutoPages and asciidoctor warnings). This is normal behavior as Jekyll builds the site. Once the server is running, you will see output like this:
 


### PR DESCRIPTION
The root cause of the failures I've been seeing running the Jekyll build in a container is the process running out of memory and being silently killed. I spent a while playing with the compose file to allocate more memory, but this doesn't help if the podman machine hasn't been created at a non-default size. I can't find a mechanism to give a more informative error (podman just silently kills the process, presumably in response to an allocation request outside the limit). I also can't find a way to detect the "minimum memory request is bigger than the container runtime is giving us" situation early and fail fast.

So all I can do is document. :(