### PR TITLE
Do not use a different font-weight for links in footer license

### DIFF
--- a/_sass/includes/cf-footer.scss
+++ b/_sass/includes/cf-footer.scss
@@ -35,7 +35,6 @@
       a {
        color: $grey-1;
         font-size: .75rem;
-       font-weight: 200;
       }
 
       @media screen and (max-width: 1024px) {


### PR DESCRIPTION
Before:

<img width="720" height="81" alt="image" src="https://github.com/user-attachments/assets/f91c8d43-15f8-4e22-972e-6044d075bccb" />

After:

<img  height="81" alt="image" src="https://github.com/user-attachments/assets/0a6afc1c-4d65-4bc1-8f58-93a8ff60c76f" />

