### PR TITLE
remove RH footer and corporate support band

### DIFF
--- a/_includes/CF-footerband.html
+++ b/_includes/CF-footerband.html
@@ -6,13 +6,5 @@
     <div class="license">
       Copyright © Quarkus. All rights reserved. For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>. Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association.
     </div>
-    <div class="sponsorcontainer">
-      <div class="sponsor">
-        Sponsored by
-      </div>
-      <div class="sponsor-logo">
-        <a class="sponsor-logo" href="https://www.redhat.com/" target="_blank"><img src="{{site.baseurl}}/assets/images/redhat_reversed.svg"></a>
-      </div>
-    </div>
   </div>
 </div>

--- a/_layouts/support.html
+++ b/_layouts/support.html
@@ -5,4 +5,3 @@ layout: base
 {% include title-band.html %}
 
 {% include support-help-band.html %}
-{% include support-options-band.html %}


### PR DESCRIPTION
As per conversation with Sanne about Commonhaus Foundation TOC conditions, I've removed the "Sponsored by Red Hat" and the RHBQ link from the support page.