### PR TITLE
Add service status link in project footer

### DIFF
--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -69,7 +69,7 @@ links:
         url: https://github.com/quarkusio/quarkus/discussions
       - page: Development mailing list
         url: https://groups.google.com/forum/#!forum/quarkus-dev
-      - page: Service Status
+      - page: Quarkus Service Status
         url: https://stats.uptimerobot.com/ze1PfweT2p
 
   - title: Languages


### PR DESCRIPTION
- Add "Service Status" link to project footer for better accessibility to uptime monitoring information.
