### PR TITLE
Minor MCP OAuth2 blog post updates

### DIFF
--- a/_posts/2025-09-22-secure-mcp-server-oauth2.adoc
+++ b/_posts/2025-09-22-secure-mcp-server-oauth2.adoc
@@ -154,6 +154,7 @@ quarkus.http.cors.origins=http://localhost:6274 # <14>
 <11> Ask Keycloak DevService to upload two realms to the Keycloak container, `alpha-realm.json` and `bravo-realm.json`.
 <12> Keycloak DevService must set the default OIDC tenant properies, we point to `alpha-realm.json` for Keycloak DevService to use it to set properties such as `quarkus.oidc.auth-server-url`.
 <13> Ask Keycloak not to add `quarkus.oidc.client-id`. Using the realm verification keys, the configured audience, expiry checks is sufficient to verify Keycloak JWT access tokens; we also plan to deal with dynamically registered OIDC clients in the next blog post.
+<14> Allow https://github.com/modelcontextprotocol/inspector[MCP Inspector] CORS requests.
 
 You can read about how https://datatracker.ietf.org/doc/html/rfc9728[OAuth2 Protected Resource Metadata] is supported in Quarkus OIDC in the https://quarkus.io/guides/security-oidc-expanded-configuration#resource-metadata-properties[Expanded OpenId Connect Configuration guide].
 
@@ -310,7 +311,7 @@ We are now going to connect to two individual MCP _Streamable HTTP_ endpoints in
 
 See the <<demo-flow-diagram>> section for an overview of how https://github.com/modelcontextprotocol/inspector[MCP Inspector] performs a `Connect` request. 
 
-Please keep your browser's `Developer Tools`'s `Network` tab open if you would like to observe how MCP Inspector probes various MCP server and Keycloak endpoints and eventually succeeds in getting a user logged in and acquiring the access token.
+Please keep your browser's `Developer Tools Network` tab open if you would like to observe how MCP Inspector probes various MCP server and Keycloak endpoints and eventually succeeds in getting a user logged in and acquiring the access token.
 
 [[mcp-inspector-connect-to-alpha]]
 ==== Connect to the default MCP Server `alpha` endpoint
@@ -396,7 +397,7 @@ Please keep in mind that it might be considered sensitive information, especiall
 
 == Conclusion
 
-In this blog, we used https://github.com/modelcontextprotocol/inspector[MCP Inspector] version 0.16.7 to demonstrate how MCP Client can use OAuth2 Flow to login users and access secure Quarkus MCP _Streamable HTTP_ servers, when only an MCP Server address and OAuth2 Client ID can provide enough context for the flow to succeed.
+In this blog, we used https://github.com/modelcontextprotocol/inspector[MCP Inspector] to demonstrate how MCP Client can use OAuth2 Flow to login users and access secure Quarkus MCP _Streamable HTTP_ servers, when only an MCP Server address and OAuth2 Client ID can provide enough context for the flow to succeed.
 
 We also demonstrated how Quarkus MCP Server can https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html#_multiple_server_configurations[support multiple MCP HTTP configurations] with their own unique security constraints supported with the https://quarkus.io/guides/security-openid-connect-multitenancy#configure-tenant-paths[Quarkus OIDC multi-tenancy resolver].
 


### PR DESCRIPTION
Added a missing bullet description, dropped the MCP inspector version number from the summary as it was already mentioned earlier