### PR TITLE
Add blog post for the Mandrel 25 release

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -316,6 +316,12 @@ vsevel:
 mmusgrov:
   name: "Michael Musgrove"
   email: "mmusgrov@redhat.com"
+sgehwolf:
+  name: "Severin Gehwolf"
+  email: "sgehwolf@ibm.com"
+  emailhash: "e739e2d699ec96cd985bae3b5271b6e5"
+  job_title: "Engineer (Software)"
+  bio: "Software Engineer at IBM working on OpenJDK and Mandrel."
 galderz:
   name: "Galder Zamarreño"
   email: "galder@redhat.com"

--- a/_posts/2025-10-02-mandrel-25-released.adoc
+++ b/_posts/2025-10-02-mandrel-25-released.adoc
@@ -1,0 +1,98 @@
+---
+layout: post
+title: 'Mandrel 25 is Here!'
+date: 2025-10-02
+tags: release, mandrel, native, graalvm
+synopsis: 'Mandrel 25, based on GraalVM 25, has been released.'
+author: sgehwolf
+---
+
+We are thrilled to announce the official release of Mandrel 25! The beginning
+of the next LTS version of the Quarkus native builder.
+
+Mandrel 25 is a downstream distribution of the
+https://www.graalvm.org/release-notes/JDK_25[GraalVM 25] Community Edition.
+Mandrel's main goal is to provide a native-image release specifically tailored
+to support https://quarkus.io[Quarkus].  The aim is to align the native-image
+capabilities from GraalVM with OpenJDK and Red Hat Enterprise Linux libraries
+to improve maintainability for native Quarkus applications. As such, Mandrel 25
+is the same as GraalVM 25 native-image with some small differences. It's built
+from the same code-base!
+
+[[what-is-new-25]]
+== What's New in GraalVM 25?
+
+While there are too many new features added in GraalVM 25 to name them all it's
+worth highlighting a few. GraalVM 25 includes enhanced support for Foreign
+Function and Memory API in native-image. It enables FFM API support for MacOSX
+Aarch64 and Linux Aarch64 (in addition to Linux x86_64). GraalVM 25 also
+enhances metadata support in native-image. It now throws subclasses of
+LinkageError when missing metadata is being detected at native image runtime.
+This way it enables users to handle missing metadata registrations in a more
+efficient way.
+
+[[based-on-openjdk-25]]
+=== Mandrel 25 is Based on OpenJDK 25
+
+Mandrel 25 is based on the new vanilla Eclipse Temurin 25 LTS release. Temurin
+is an OpenJDK distribution produced at Eclipse. Based on the next LTS release
+of OpenJDK, Mandrel 25 will be the next LTS version supporting Quarkus' native
+compilation capabilities for the Quarkus releases to come.
+
+[[new-monitoring-features]]
+=== New Monitoring Features
+
+GraalVM 25 also introduces several new features in the monitoring area of
+native-image that have been contributed by Red Hat/IBM. Some highlights in JDK
+Flight Recorder support (https://www.graalvm.org/jdk25/reference-manual/native-image/debugging-and-diagnostics/JFR/[JFR]), and https://www.graalvm.org/jdk25/reference-manual/native-image/debugging-and-diagnostics/NMT/[native memory tracking] (NMT) are:
+
+* **JCMD support:** GraalVM 25 adds support for the https://www.graalvm.org/jdk25/reference-manual/native-image/debugging-and-diagnostics/jcmd/[Java Diagnostic Command]
+  (JCMD) to native-image. This is useful to asynchronously request specific
+actions on the running native image. For example a thread dump or a JFR
+recording can be requested after the application has been started.
+* **Added support for more JFR events:** Additional JFR events have been added,
+  specifically tracking native memory when monitoring option NMT is enabled as
+well. Object allocation sampling with the jdk.ObjectAllocationSample event is
+now also supported. For a list of all supported JFR events see the https://www.graalvm.org/jdk25/reference-manual/native-image/debugging-and-diagnostics/JFR/#built-in-events[upstream
+documentation].
+* **Native Memory Tracking:** A new monitoring option for https://www.graalvm.org/jdk25/reference-manual/native-image/debugging-and-diagnostics/NMT/[tracking native
+  memory], NMT, has been added to native-image. This is useful to diagnose
+memory leaks.
+
+[[getting-started-25]]
+== Get Started with Mandrel 25 Today!
+
+Ready to experience the power of Mandrel 25?
+
+* **Download Mandrel 25:** You can download the latest version from the https://github.com/graalvm/mandrel/releases/tag/mandrel-25.0.0.1-Final[Mandrel
+  release page] on Github or install it using https://sdkman.io/[sdkman] by running:
+[source,bash]
+----
+sdk install java 25.0.0.1.r25-mandrel
+----
+* **Builder Image with Quarkus:** Alternatively start using the Mandrel 25
+  builder image for your quarkus application by specifying
+`-Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25`
+to your maven build.
+
+[[quarkus-compatibility-mandrel-25]]
+== Quarkus Compatibility
+
+It's recommended to use at least Quarkus release 3.27.0 when using the Mandrel 25
+native builder. For older versions of Quarkus use the Mandrel 23.1 native
+builder.
+
+[[graalvm-community-gratitude]]
+== Shout Out to GraalVM Community
+
+We are very grateful for the immense support from the upstream GraalVM
+community, especially the Oracle GraalVM team for stewarding and sponsoring the
+development of GraalVM as well as for accepting Mandrel under the GraalVM
+organization. Onward to more collaboration with the community as the next
+version of GraalVM unfolds!
+
+We are incredibly excited about Mandrel 25 and will be making it the default
+native image generator in an upcoming Quarkus release. In the meantime, do let
+us know your experience of using Mandrel 25 with Quarkus!
+
+You can share your feedback with us in Quarkus' https://quarkusio.zulipchat.com/[Zulip chat workspace] or on https://github.com/quarkusio/quarkus/[GitHub].


### PR DESCRIPTION
Release blog post for Mandrel 25, the next LTS native builder for quarkus.