### PR TITLE
Pull the "read full article" button to the bottom of the block

### DIFF
--- a/_sass/includes/recent-posts-band.scss
+++ b/_sass/includes/recent-posts-band.scss
@@ -4,6 +4,8 @@
     background: var(--tile-background-color);
     padding: 2rem;
     margin: .5rem 0;
+    display: flex;
+    flex-direction: column;
 
     p {
     color: var(--tile-text-color);
@@ -31,6 +33,10 @@
     font-size: 1rem;
     margin: 0;
     padding: 0;
+    }
+
+    div.text-centered {
+      margin-top: auto;
     }
   }
 }


### PR DESCRIPTION
Right now, the `read full article` seems a bit randomly positioned, so I've tried to make them stick to the bottom.

With the change:

<img width="1503" height="608" alt="Screenshot From 2025-10-05 20-25-57" src="https://github.com/user-attachments/assets/c4c29d36-b181-4fbd-8f15-d5255eb15d7b" />


currently:

<img width="1503" height="640" alt="Screenshot From 2025-10-05 20-26-21" src="https://github.com/user-attachments/assets/3d77b26f-df4f-48f2-bf29-510d531b10db" />
