### PR TITLE
Add link to qute-debug README in 3.29 announcement

### DIFF
--- a/_posts/2025-10-29-quarkus-3-29-released.adoc
+++ b/_posts/2025-10-29-quarkus-3-29-released.adoc
@@ -45,6 +45,8 @@ You can find more information in the https://quarkus.io/guides/cache#configuring
 The Qute extension now provides support for the Debug Adapter Protocol (DAP),
 which means that you can easily debug your Qute templates in your favorite IDE!
 
+TIP: You can read more about this new feature in the README file of the https://github.com/quarkusio/quarkus/tree/main/independent-projects/qute/debug[qute-debug project].
+
 === Hibernate ORM and Reactive
 
 Both Hibernate ORM and Hibernate Reactive extensions are now enabled even when no entity is defined in your application.


### PR DESCRIPTION
FYI @angelozerr 

We should add some info (link to readme + some basic description) in the Qute ref guide as well.