### PR TITLE
Support multiple authors in blog posts (#1)

### DIFF
--- a/_includes/blog-band.html
+++ b/_includes/blog-band.html
@@ -16,10 +16,26 @@
             </div>
           </div>
           <div class="grid__item width-8-12 width-12-12-m byline-wrapper">
-            {% if author.emailhash %}
-              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
-            {% endif %}
-            <p class="byline">By <a href="{{ site.baseurl }}/author/{{ post.author }}">{{ author.name }}</a></p>
+            {% assign authors_raw = post.author | default: "" | split: "," %}
+            {% assign authors_clean = "" | split: "" %}
+
+            {% for a in authors_raw %}
+              {% assign a_trimmed = a | strip %}
+              {% if a_trimmed != "" %}
+                {% assign authors_clean = authors_clean | push: a_trimmed %}
+              {% endif %}
+            {% endfor %}
+
+            <p class="byline">
+              By 
+              {% for author_key in authors_clean %}
+                {% assign author = site.data.authors[author_key] %}
+                {% if author.emailhash %}
+                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+                {% endif %}
+                <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>{% unless forloop.last %}, {% endunless %}
+              {% endfor %}
+            </p>
           </div>
           <div class="grid__item width-12-12">
             {% if post.synopsis %}

--- a/_includes/recent-posts-band.html
+++ b/_includes/recent-posts-band.html
@@ -2,27 +2,52 @@
   <div class="grid-wrapper">
     <div class="width-12-12">
       <h2 class="text-centered">{{site.data.recent-posts-band.texts.recent_blog_posts}}</h2>
-    </div>
-    {% for post in site.posts %}
-      {% if forloop.index <= 3 %}
-        <div class="block-item width-4-12 width-12-12-m">
-          <div class="post-title">
-            <h6 class="margin-tb-0"><a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a></h6>
+      </div>
+      {% for post in site.posts %}
+        {% if forloop.index <= 3 %}
+          <div class="block-item width-4-12 width-12-12-m">
+            <div class="post-title">
+              <h6 class="margin-tb-0"><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h6>
+            </div>
+
+            <p class="datetag margin-tb-sm">
+              {{ post.date | date: '%B %d, %Y' }} &nbsp;&nbsp;&nbsp;Tags:
+              {% for tag in post.tags %}
+                <a href="{{ site.baseurl }}/blog/tag/{{ tag }}">{{ tag }}</a> 
+              {% endfor %}
+            </p>
+
+            {% assign authors_raw = post.author | default: "" | split: "," %}
+            {% assign authors_clean = "" | split: "" %}
+
+            {% for a in authors_raw %}
+              {% assign a_trimmed = a | strip %}
+              {% if a_trimmed != "" %}
+                {% assign authors_clean = authors_clean | push: a_trimmed %}
+              {% endif %}
+            {% endfor %}
+
+            <p class="byline margin-tb-sm">
+              By
+              {% for author_key in authors_clean %}
+                {% assign author = site.data.authors[author_key] %}
+                {% if author.emailhash %}
+                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+                {% endif %}
+                <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>{% unless forloop.last %}, {% endunless %}
+              {% endfor %}
+            </p>
+
+            {% if post.synopsis %}
+              <p>{{ post.synopsis | strip_html }}</p>
+            {% else %}
+              <p>{{ post.content | strip_html | truncate: 280 }}</p>
+            {% endif %}
+
+            <div class="text-centered">
+              <a href="{{ site.baseurl }}{{ post.url }}" class="button-cta-white">{{ site.data.recent-posts-band.texts.read_full_article }}</a>
+            </div>
           </div>
-          <p class="datetag margin-tb-sm">
-            {{ post.date | date: '%B %d, %Y' }} &nbsp;&nbsp;&nbsp;Tags: {% for tag in post.tags %}<a href="{{site.baseurl}}/blog/tag/{{tag}}">{{ tag}}</a> {% endfor %}
-          </p>
-          {% assign author = site.data.authors[post.author] %}
-          <p class="byline margin-tb-sm">By {{ author.name }}</p>
-          {% if post.synopsis %}
-            <p>{{ post.synopsis | strip_html }}</p>
-          {% else %}
-            <p>{{ post.content | strip_html | truncate: 280 }}</p>
-          {% endif %}
-          <div class="text-centered">
-            <a href="{{site.baseurl}}{{ post.url }}" class="button-cta-white">{{site.data.recent-posts-band.texts.read_full_article}}</a>
-          </div>
-        </div>
       {% endif %}
     {% endfor %}
   </div>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -6,12 +6,8 @@ layout: base
 {% assign author_username = page.pagination.author %}
 
 <!-- Use page.pagination.author_data only if you have data file setup correctly -->
-{% assign author = page.pagination.author_data %}
-{% assign page_title = 'Posts by ' | append: author.name %}
-<!--
-  Now you can use the author variable anyhow.
-  It has all the data as defined inside _data/authors.yml for the current username.
--->
+{% assign author_data = page.pagination.author_data %}
+{% assign page_title = 'Posts by ' | append: author_data.name %}
 
 {% include title-band.html page_title=page_title %}
 
@@ -24,33 +20,60 @@ layout: base
 <div class="grid-wrapper blog-page">
   <div class="grid__item width-9-12 width-12-12-m">
     <h2 class="title byline-wrapper">
-      {% if author.emailhash %}
-      <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+      {% if author_data.emailhash %}
+      <img class="headshot" src="https://www.gravatar.com/avatar/{{ author_data.emailhash }}">
       {% endif %}
       <p class="byline">
-      {{ author.name }} {% if author.twitter %}(<a href="https://twitter.com/{{ author.twitter }}">@{{ author.twitter }}</a>){% endif %}
+        {{ author_data.name }} {% if author_data.twitter %}(<a href="https://twitter.com/{{ author_data.twitter }}">@{{ author_data.twitter }}</a>){% endif %}
       </p>
     </h2>
-    <p>
-      {{ author.bio }}
-    </p>
+    <p>{{ author_data.bio }}</p>
 
     {% if paginator.posts.size > 0 %}
     <h2 class="title">Posts</h2>
     {% for post in paginator.posts %}
-      {% assign author = site.data.authors[post.author] %}
+
+      {% comment %} Build multi-author list for this post {% endcomment %}
+      {% assign authors_raw = post.author | default: "" | split: "," %}
+      {% assign authors_clean = "" | split: "" %}
+      {% for a in authors_raw %}
+        {% assign a_trimmed = a | strip %}
+        {% if a_trimmed != "" %}
+          {% assign authors_clean = authors_clean | push: a_trimmed %}
+        {% endif %}
+      {% endfor %}
+
       <div class="blog-list-item grid-wrapper">
         <div class="grid__item width-12-12">
           <div class="post-title">
-            <a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a>
+            <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
           </div>
           <div class="post-date small">
             {{ post.date | date: '%B %d, %Y' }}
             {% if post.tags %}
-              <span class="tags">tags:{% for tag in post.tags %}<a href="{{site.baseurl}}/blog/tag/{{tag  | downcase | replace: '.', '-' }}">#{{ tag | downcase }}</a>{% endfor %}</span>
+              <span class="tags">
+                tags:{% for tag in post.tags %}
+                  <a href="{{ site.baseurl }}/blog/tag/{{ tag | downcase | replace: '.', '-' }}">#{{ tag | downcase }}</a>
+                {% endfor %}
+              </span>
             {% endif %}
           </div>
         </div>
+
+        <div class="grid__item width-8-12 width-12-12-m byline-wrapper">
+          By 
+          <p class="byline">
+          {% for author_key in authors_clean %}
+            {% assign author = site.data.authors[author_key] %}
+            {% if author.emailhash %}
+              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+            {% endif %}
+            <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>
+            {% unless forloop.last %}, {% endunless %}
+          {% endfor %}
+          </p>
+        </div>
+
         <div class="grid__item width-12-12">
           {% if post.synopsis %}
             <p>{{ post.synopsis | strip_html }}</p>
@@ -58,10 +81,17 @@ layout: base
             <p>{{ post.content | strip_html | truncatewords: 75 }}</p>
           {% endif %}
         </div>
-        <div class="grid__item width-8-12 read-more small"><a href="{{site.baseurl}}{{ post.url }}">Read More &rsaquo;</a></div>
-        <div class="grid__item width-4-12 width-12-12-m share-post">{% include share-page.html title=post.title url=post.url %}</div>
+
+        <div class="grid__item width-8-12 read-more small">
+          <a href="{{ site.baseurl }}{{ post.url }}">Read More &rsaquo;</a>
+        </div>
+        <div class="grid__item width-4-12 width-12-12-m share-post">
+          {% include share-page.html title=post.title url=post.url %}
+        </div>
       </div>
+
     {% endfor %}
+
     {% if paginator.total_pages > 1 %}
       <div class="paginator-btns">
         {% if paginator.next_page %}
@@ -71,8 +101,8 @@ layout: base
           <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}" class="button-cta primary btn-sm">Newer Posts</a>
         {% endif %}
       </div>
-      {% endif %}
-      {% endif %}
+    {% endif %}
+
+    {% endif %}
   </div>
 </div>
-

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,11 +21,28 @@ layout: base
         <h1 class="post-title">{{ page.title }}</h1>
         <div class="grid-wrapper">
           <div class="width-8-12 width-12-12-m byline-wrapper">
-            {% assign author = site.data.authors[page.author] %}
-            {% if author.emailhash %}
-              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
-            {% endif %}
-            <p class="byline">By <a href="{{ site.baseurl }}/author/{{ page.author }}">{{ author.name }}</a></p>
+            <p class="byline">
+              By 
+              {% assign authors_list = page.author | default: "" | split: "," %}
+              {% assign authors_clean = "" | split: "" %}
+
+              {% for author_key_raw in authors_list %}
+                {% assign author_key = author_key_raw | strip %}
+                {% if author_key != "" %}
+                  {% assign authors_clean = authors_clean | push: author_key %}
+                {% endif %}
+              {% endfor %}
+              
+              {% for author_key in authors_clean %}
+                {% assign author_key = author_key_raw | strip %}
+                {% assign author = site.data.authors[author_key] %}
+                {% if author.emailhash %}
+                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+                {% endif %}
+                  <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>
+                  {% unless forloop.last %}, {% endunless %}
+              {% endfor %}
+            </p>
           </div>
           <div class="width-12-12">
               {{ content }}

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -12,25 +12,48 @@ layout: base
   <div class="grid__item width-9-12 width-12-12-m">
     <h2 class="title">Tagged posts: '{{ page.title }}'</h2>
     {% for post in page.posts %}
-      {% assign author = site.data.authors[post.author] %}
       <div class="blog-list-item grid-wrapper">
         <div class="grid__item width-12-12">
           <div class="post-title">
-            <a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a>
+            <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
           </div>
           <div class="post-date small">
-            {{ post.date | date: '%B %d, %Y' }} 
+            {{ post.date | date: '%B %d, %Y' }}
             {% if post.tags %}
-              <span class="tags">tags:{% for tag in post.tags %}<a href="{{site.baseurl}}/blog/tag/{{tag  | downcase | replace: '.', '-' }}">#{{ tag | downcase }}</a>{% endfor %}</span>
+              <span class="tags">
+                tags:
+                {% for tag in post.tags %}
+                  <a href="{{ site.baseurl }}/blog/tag/{{ tag | downcase | replace: '.', '-' }}">#{{ tag | downcase }}</a>
+                {% endfor %}
+              </span>
             {% endif %}
           </div>
         </div>
+
         <div class="grid__item width-8-12 width-12-12-m byline-wrapper">
-          {% if author.emailhash %}
-            <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
-          {% endif %}
-          <p class="byline">By <a href="{{ site.baseurl }}/author/{{ post.author }}">{{ author.name }}</a></p>
+          {% assign authors_list = post.author | default: "" | split: "," %}
+          {% assign authors_clean = "" | split: "" %}
+
+          {% for author_key_raw in authors_list %}
+            {% assign author_key = author_key_raw | strip %}
+            {% if author_key != "" %}
+              {% assign authors_clean = authors_clean | push: author_key %}
+            {% endif %}
+          {% endfor %}
+          <p class="byline">
+          By 
+          {% for author_key in authors_clean %}
+            {% assign author = site.data.authors[author_key] %}
+            {% if author.emailhash %}
+              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+            {% endif %}
+              <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>
+              {% unless forloop.last %}, {% endunless %}
+            </p>
+          {% endfor %}
+          </p>
         </div>
+
         <div class="grid__item width-12-12">
           {% if post.synopsis %}
             <p>{{ post.synopsis | strip_html }}</p>
@@ -38,8 +61,14 @@ layout: base
             <p>{{ post.content | strip_html | truncatewords: 75 }}</p>
           {% endif %}
         </div>
-        <div class="grid__item width-8-12 read-more small"><a href="{{site.baseurl}}{{ post.url }}">Read More &rsaquo;</a></div>
-        <div class="grid__item width-4-12 width-12-12-m share-post">{% include share-page.html title=post.title url=post.url %}</div>
+
+        <div class="grid__item width-8-12 read-more small">
+          <a href="{{ site.baseurl }}{{ post.url }}">Read More &rsaquo;</a>
+        </div>
+
+        <div class="grid__item width-4-12 width-12-12-m share-post">
+          {% include share-page.html title=post.title url=post.url %}
+        </div>
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
Split from #2465 

To test those changes you'd need to add another author to one of the blog posts and re-render.
For example:

```
author: gsmet, andreatp
```
