### PR TITLE
Fix tag list in blog

### DIFF
--- a/_posts/2025-01-13-mcp-server.adoc
+++ b/_posts/2025-01-13-mcp-server.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: ' Implementing a MCP server in Quarkus'
 date: 2025-01-13
-tags: langchain4j, llm, ai
+tags: langchain4j llm ai
 synopsis: Shows how to implement an MCP server in Quarkus and use it in various clients such as Claude Desktop and LangChain4j
 author: maxandersen
 ---

--- a/_posts/2025-03-24-movie-similarity-search-using-vector-databases.adoc
+++ b/_posts/2025-03-24-movie-similarity-search-using-vector-databases.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Movie similarity search using vector databases'
 date: 2025-03-24
-tags: langchain4j, llm, ai
+tags: langchain4j llm ai
 synopsis: Shows how to create a movie similarity search system using a vector database and Quarkus LangChain4j
 author: iocanel
 ---

--- a/_posts/2025-06-25-hibernate7-on-quarkus.adoc
+++ b/_posts/2025-06-25-hibernate7-on-quarkus.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Hibernate ORM 7 on Quarkus: each new version brings a better database experience'
 date: 2025-06-25
-tags: hibernate, database, jpa
+tags: hibernate database jpa
 synopsis: A roundup on the new upgrades of Hibernate on Quarkus.
 author: lmolteni
 ---

--- a/_posts/2025-07-15-quickjs4j.adoc
+++ b/_posts/2025-07-15-quickjs4j.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Introducing Quarkus quickjs4j: Seamless JavaScript Integration in Your Quarkus Applications'
 date: 2025-07-15
-tags: javascript, integration, cdi, build-time
+tags: javascript integration cdi build-time
 synopsis: A new Quarkiverse extension that brings JavaScript execution to your Java applications with compile-time code generation and full CDI integration.
 author: ewittman
 ---

--- a/_posts/2025-10-31-continued-focus-on-native.adoc
+++ b/_posts/2025-10-31-continued-focus-on-native.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Continued Focus on Native'
 date: 2025-11-03
-tags: mandrel, native, graalvm
+tags: mandrel native graalvm
 synopsis: 'Quarkus continues to focus on native for swift start-up time and low memory footprint.'
 author: sgehwolf
 ---


### PR DESCRIPTION
The tags list on https://quarkus.io/blog/ has several additional tags ending with a comma.

Example:
<img width="104" height="168" alt="taglist" src="https://github.com/user-attachments/assets/035661a3-3c56-4453-8c65-a5f23b4ad861" />

The links behind these entries yield a 404 error page.

This is due to the usage of `,` as a separator in the metadata.
This PR fixes the issue.