### PR TITLE
Fix anchor in developer-joy page

### DIFF
--- a/_includes/developer-joy.html
+++ b/_includes/developer-joy.html
@@ -10,7 +10,7 @@
     <div class="width-6-12 width-12-12-m">
       <h3>Live Coding</h3>
       <p>Improve and expedite the inner loop development process with live coding where code changes are automatically reflected in your running application. code -> refresh browser -> repeat</p>
-      <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{{site.baseurl}}/guides/maven-tooling#dev-mode/">Read the Dev Mode guide</a></p>
+      <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{{site.baseurl}}/guides/maven-tooling#dev-mode">Read the Dev Mode guide</a></p>
     </div>
     <div class="width-6-12 width-12-12-m">
       <h3>Unified Config</h3>


### PR DESCRIPTION
The trailing slash didn't move to the proper section in neither Chrome, Firefox or Safari, ie:
- this doesn't scroll: https://quarkus.io/guides/maven-tooling#dev-mode/
- this scrolls correctly: https://quarkus.io/guides/maven-tooling#dev-mode

(I tried to look for other occurrences but ripgrep / VS Code were not contributing).