### PR TITLE
Add quarkus calendars

### DIFF
--- a/_includes/support-help-band.html
+++ b/_includes/support-help-band.html
@@ -17,8 +17,18 @@
   <div class="width-3-12 width-12-12-m help-block">
     <img class="light-only" src="{{site.baseurl}}/assets/images/support/icon-discussion.svg">
     <img class="dark-only" src="{{site.baseurl}}/assets/images/support/icon-discussion-dark.svg">
-   <h4>Discussions and Collaboration</h4>
+    <h4>Discussions and Collaboration</h4>
     <p>Check out our <a href="https://github.com/quarkusio/quarkus/discussions">GitHub Discussions</a> collaboration area to interact with other Quarkus users and developers.</p>
+  </div>
+  <div class="width-3-12 width-12-12-m help-block">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/support/icon-calendar.svg">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/support/icon-calendar-dark.svg">
+    <h4>Community Call</h4>
+    <p>We host a Quarkus Community Call on the first and third Tuesday of each month at 2PM (Paris time) to discuss technical topics and project updates. You can view or subscribe to the Quarkus Call calendar:</p>
+    <ul>
+      <li><a href="https://calendar.google.com/calendar/embed?src=96e7edd0aa40dfc869532c230d06bf6502524e5ad4c9e6d1ef775923937451b5%40group.calendar.google.com&ctz=Europe%2FParis">View calendar</a></li>
+      <li><a href="https://calendar.google.com/calendar/ical/96e7edd0aa40dfc869532c230d06bf6502524e5ad4c9e6d1ef775923937451b5%40group.calendar.google.com/public/basic.ics">Subscribe (iCal)</a></li>
+    </ul>
   </div>
   <div class="width-3-12 width-12-12-m help-block">
     <img src="{{site.baseurl}}/assets/images/support/icon-development.svg">


### PR DESCRIPTION
@insectengine Hey! 

I would like to add the Quarkus public call and calendar to the web site. However, I would need the associated icon.

Also, it would be great if we could avoid having a second line with a single entry. 