### PR TITLE
Fix appearance of dd

### DIFF
--- a/_sass/asciidoc.scss
+++ b/_sass/asciidoc.scss
@@ -131,3 +131,15 @@ pre.highlight {
      margin-bottom: 0;
   }
 }
+
+.hdlist td {
+  padding: 0.3em .625em;
+
+  &.hdlist1 {
+    font-weight: bold;
+  }
+
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
This was especially off in https://quarkus.io/guides/logging.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
