### PR TITLE
Update blog to not use deprecated method

### DIFF
--- a/_posts/2026-01-05-new-dev-services-api.adoc
+++ b/_posts/2026-01-05-new-dev-services-api.adoc
@@ -95,7 +95,8 @@ For example,
 
 [source,java]
 ----
-    DevServicesResultBuildItem = DevServicesResultBuildItem.owned().name(MY_FEATURE_NAME)
+    DevServicesResultBuildItem = DevServicesResultBuildItem.owned()
+                    .feature(MY_FEATURE_NAME)
                     .serviceName(name)
                     .serviceConfig(myConfig)
                     .startable(() -> new MyContainer(


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/51831

The new method is only available in 3.27.something and higher, but I think that's ok. 