### PR TITLE
Renamed hibernate-panache to hibernate-panache-next

### DIFF
--- a/_posts/2025-12-24-hibernate-panache-next.asciidoc
+++ b/_posts/2025-12-24-hibernate-panache-next.asciidoc
@@ -11,7 +11,7 @@ author: fromage
 
 …which was never called Panache, by the way, it was called Hibernate ORM with Panache,
 or Hibernate Reactive with Panache, and this new version, is a new module, designed to
-unify both, and is currently called https://quarkus.io/version/main/guides/hibernate-panache[Hibernate with Panache]
+unify both, and is currently called https://quarkus.io/version/main/guides/hibernate-panache-next[Hibernate with Panache]
 (although the name could change).
 
 Anyway, first a disclaimer: this is a new extension, which is experimental, which means everything
@@ -57,7 +57,7 @@ queries. It's very flexible and it's still clearly a continuation of the old Pan
 link:https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0[Jakarta Data]
 and all mixed in a way that we hope you will like.
 
-https://quarkus.io/version/main/guides/hibernate-panache[The documentation] has a lot of
+https://quarkus.io/version/main/guides/hibernate-panache-next[The documentation] has a lot of
 information as to how to set it up, and all the options, so I will focus on some
 bite-sized samples for this blog post. Here's your first entity with type-safe queries:
 
@@ -249,6 +249,6 @@ public class Cat extends PanacheEntity {
 
 Just in time for the holidays, we're merging this to `main` so it will be in a release near you very soon.
 
-Give it a try, https://quarkus.io/version/main/guides/hibernate-panache[read the documentation], and give us feedback either on
+Give it a try, https://quarkus.io/version/main/guides/hibernate-panache-next[read the documentation], and give us feedback either on
 link:https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Panache.2ENext/with/562916276[Zulip]
 or via link:https://github.com/orgs/quarkusio/projects/50/views/1[GitHub issues].


### PR DESCRIPTION
This is the blog fixing the guide changing URI: https://github.com/quarkusio/quarkus/pull/51930