### PR TITLE
Include the extension status explanation and use status derived from extensions if not defined explicitly

### DIFF
--- a/_sass/asciidoc.scss
+++ b/_sass/asciidoc.scss
@@ -149,10 +149,8 @@ pre.highlight {
   line-height: 1em;
   text-transform: uppercase;
   font-weight: bold;
-  text-decoration: none;
   display: inline-block;
   padding: 4px 12px;
-  margin-bottom: 35px;
   border-radius: 50px;
 }
 
@@ -161,17 +159,9 @@ pre.highlight {
   background-color: var(--tag-stable-background-color);
 }
 
-a.status-stable:hover, a.status-stable:active, a.status-stable:focus {
-  color: var(--tag-stable-text-color);
-}
-
 .status-preview {
   color: var(--tag-preview-text-color);
   background-color: var(--tag-preview-background-color);
-}
-
-a.status-preview:hover, a.status-preview:active, a.status-preview:focus {
-  color: var(--tag-preview-text-color);
 }
 
 .status-deprecated {
@@ -179,15 +169,23 @@ a.status-preview:hover, a.status-preview:active, a.status-preview:focus {
   background-color: var(--tag-deprecated-background-color);
 }
 
-a.status-deprecated:hover, a.status-deprecated:active, a.status-deprecated:focus {
-  color: var(--tag-deprecated-text-color);
-}
-
 .status-experimental {
   color: var(--tag-experimental-text-color);
   background-color: var(--tag-experimental-background-color);
 }
 
-a.status-experimental:hover, a.status-experimental:active, a.status-experimental:focus {
-  color: var(--tag-experimental-text-color);
+.extension-status {
+  display: flex;
+  align-items: center;
+  padding-bottom: 1.25em;
+}
+
+.extension-status-explanation {
+  border-left: 1px solid #aaa;
+  padding: 1.25em;
+  opacity: 0.8;
+}
+
+.extension-status-icon {
+  padding: 1.25em;
 }


### PR DESCRIPTION
- Follows up on https://github.com/quarkusio/quarkusio.github.io/pull/2508
- Requires https://github.com/quarkusio/quarkus/pull/52100

This updated asciidoc extension would inject the status label and explanation next to it, so we wouldn't need to remember to include the `extension-status.adoc` include and make things a bit more "automated"

A few previews: 
<img width="1048" height="543" alt="image" src="https://github.com/user-attachments/assets/293998c9-c701-49d0-8b9f-132b78bffca5" />
<img width="1048" height="543" alt="image" src="https://github.com/user-attachments/assets/44983b80-5cce-4070-8a73-1e1a7aa35bd5" />


cc: @yrodiere @FroMage @insectengine  @rolfedh 