### PR TITLE
Add instructions for dynamic Dev UI

### DIFF
--- a/_posts/2026-01-05-new-dev-services-api.adoc
+++ b/_posts/2026-01-05-new-dev-services-api.adoc
@@ -226,14 +226,19 @@ With the old Dev Services model, you might customise your extensions's card with
 ----
 
 This will no longer work, because the url isn't known at build time.
-Instead, replace the `url` method with `dynamicUrlJsonRPCMethodName`, link:guides/dev-ui#runtime-external-links[passing in an RPC method name].
+Instead, replace the `url` method with `dynamicUrlJsonRPCMethodName`, link:/guides/dev-ui#runtime-external-links[passing in an RPC method name].
 
 [source,java]
 ----
      .dynamicUrlJsonRPCMethodName("getMyUrl")
 ----
 
+From 3.32, you can also pass through parameters on the method call. For example,
 
+[source,java]
+----
+     .dynamicUrlJsonRPCMethodName("getMyUrl", Map.of("name", "service-name", "configKey", "some-key");
+----
 
 Add a build step to register the providing class:
 
@@ -245,7 +250,7 @@ Add a build step to register the providing class:
     }
 ----
 
-In your extension's runtime module, create a `MyJsonRPCService` class with a `getMyUrl` method. From 3.32, you can also link:https://github.com/quarkusio/quarkus/pull/51659[pass through parameters] on the method call.
+In your extension's runtime module, create a `MyJsonRPCService` class with a `getMyUrl` method.
 
 === Examples
 


### PR DESCRIPTION
"How can I sort out the urls in my dev UI?" is a FAQ with the new model. 

Direct link to updated section: https://quarkus-site-pr-2523-preview.surge.sh/blog/new-dev-services-api/#how-can-i-publish-links-to-my-service-in-the-dev-ui