### PR TITLE
fix: #2580 - Add redirects for /doc and /docs to /guides

### DIFF
--- a/_redirects/doc.md
+++ b/_redirects/doc.md
@@ -1,0 +1,4 @@
+---
+permalink: /doc/
+redirect_to: /guides/
+---

--- a/_redirects/docs.md
+++ b/_redirects/docs.md
@@ -1,0 +1,4 @@
+---
+permalink: /docs/
+redirect_to: /guides/
+---


### PR DESCRIPTION
Adds redirects for:

- /doc → /guides
- /docs → /guides

Motivation:
Some LLMs point to /doc as Quarkus documentation location.