### PR TITLE
fix: limit public suffix so work on ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,8 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "webrick", "~> 1.8"
 
+# Pin public_suffix to < 7 for Ruby 3.1 compatibility (bretfisher/jekyll-serve image)
+gem "public_suffix", "< 7"
+
 # Copy search-wc.js from the search-wc server
 gem "open-uri", "~> 0.4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       uri
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (7.0.5)
+    public_suffix (6.0.1)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -98,6 +98,7 @@ DEPENDENCIES
   jekyll-paginate-v2
   minima (~> 2.0)
   open-uri (~> 0.4.1)
+  public_suffix (< 7)
   tzinfo-data
   webrick (~> 1.8)
 


### PR DESCRIPTION
The recent Dependabot upgrade of addressable from 2.8.0 to 2.9.0 (#2597) pulled in public_suffix 7.0.5, which requires Ruby >= 3.2. The
 bretfisher/jekyll-serve Docker image ships Ruby 3.1.7, causing docker compose up to fail with:

 ```
   public_suffix-7.0.5 requires ruby version >= 3.2, which is incompatible with the
   current version, ruby 3.1.7p261
 ```

 This PR pins public_suffix to < 7 in the Gemfile and updates the lockfile to use 6.0.1, which is compatible with Ruby 3.1. 
 
 Alternative is to fork ` bretfisher/jekyll-serve` but thought I would suggest this one first and see if any hard need for public_suffix v7