### PR TITLE
Trivial: Add a couple of dropped words in benchmarks blog

### DIFF
--- a/_posts/2026-03-02-new-benchmarks.adoc
+++ b/_posts/2026-03-02-new-benchmarks.adoc
@@ -33,7 +33,7 @@ Is Quarkus better? Oh yes, definitely. Better than what? Shhh, that's a secret.
 But there's an even bigger problem with our old graphics, in my view. We show Quarkus starts fast, and we show it has a small footprint.
 We do not show anything about throughput. There's a classic performance tradeoff between throughput and memory footprint or startup time.
 It's easy for people looking at the charts to assume that if Quarkus doesn't show its throughput figures, they must be terrible, right?
-Wrong! For Quarkus, _there is no trade-off_. Quarkus is more efficient than alternatives across the board. (Want to know where trade-off strikes back? link:#native-tradeoffs[Read on].)
+Wrong! For Quarkus, _there is no trade-off_. Quarkus is more efficient than alternatives across the board. (Want to know where a trade-off strikes back? link:#native-tradeoffs[Read on].)
 
 But this misconception that Quarkus must have bad throughput turns up all over the place.
 It keeps popping up in external blogs, and if you ask your favourite AI service about the advantages of Quarkus, it's unlikely to mention throughput.
@@ -46,7 +46,7 @@ We often see blogs which compare Quarkus in native mode to other frameworks in J
 Quarkus in JVM mode should be compared to other frameworks in JVM mode, and Quarkus in native mode should be compared to other frameworks in native mode.
 Quarkus happens to be very good at native mode, but whether you want to use native mode is an orthogonal choice to what framework you choose.
 
-Because of all these problems, several members of the Quarkus community have ended up their own benchmarks to use in conference talks, or for demos.
+Because of all these problems, several members of the Quarkus community have ended up rolling their own benchmarks to use in conference talks, or for demos.
 I've done it myself, in fact. Having members of the same team re-doing similar work is wasteful. What's more, benchmarking is hard!
 Getting numbers is trivially easy, but getting numbers which are actually measuring what you think you're measuring is hard.
 Doing it really really right needs the sorts of skills performance specialists have.


### PR DESCRIPTION
Nothing like re-reading something two months later to help you spot errors.