### PR TITLE
Blog: Bump minimum GraalVM version to 25.0

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -509,7 +509,7 @@ zakkak:
   emailhash: "3772ed72c143c2f0fe110d1a4124a46a"
   job_title: "Software Engineer"
   twitter: "zakkak"
-  bio: "Software Engineer at Red Hat on Mandrel and other projects."
+  bio: "Software Engineer at IBM (previously at Red Hat) working on GraalVM / Mandrel native image and other projects."
 christophd:
   name: "Christoph Deppisch"
   email: "cdeppisc@redhat.com"

--- a/_posts/2026-05-29-mandrel-25-minimum-version.adoc
+++ b/_posts/2026-05-29-mandrel-25-minimum-version.adoc
@@ -1,0 +1,30 @@
+---
+layout: post
+title: Bumping the minimum officially supported GraalVM version to 25.0
+date: 2026-05-29
+tags: native graalvm mandrel
+synopsis: Understanding the rationale behind dropping official support for GraalVM/Mandrel 23.1 for JDK 21 on native image builds.
+author: zakkak
+---
+
+Starting with Quarkus 3.36, the minimum officially supported GraalVM/Mandrel version for building native executables has been updated from 23.1 to 25.0.
+
+== Why?
+
+This decision was made to reduce the maintenance overhead and focus our efforts on better supporting the latest versions of GraalVM/Mandrel.
+
+GraalVM/Mandrel 25.0 was released in September 2025 and became the default version used by Quarkus in January 2026 (starting with Quarkus 3.31).
+It is also the default version used by the latest Quarkus LTS release, 3.33, which was released in March 2026.
+It is thus considered well tested and mature enough to be the main driver for the foreseeable future Quarkus releases.
+
+== What does this mean for users?
+
+This change does not affect JVM mode at all.
+Quarkus continues to support JDKs from 17 to 25 for JVM mode.
+
+[NOTE]
+====
+The minimum JDK version is https://github.com/quarkusio/quarkus/issues/51951[planned to be raised to 21 in Quarkus 4] for JVM mode.
+====
+
+For native image builds, moving forward users explicitly using GraalVM for JDK 21 or Mandrel 23.1 for JDK 21 should upgrade their workflows to use GraalVM/Mandrel 25.0 instead.


### PR DESCRIPTION
Blog post bringing awareness about https://github.com/quarkusio/quarkus/pull/53661 and https://github.com/quarkusio/quarkus/pull/53820