### PR TITLE
Fix HTML structure errors in 5 include files

### DIFF
--- a/_includes/ai-quarkus-for-ai.html
+++ b/_includes/ai-quarkus-for-ai.html
@@ -30,7 +30,7 @@
     </div>
 
     <div class="width-9-12 width-12-12-m">
-      <p>Quarkus is comprehensive, it supports both </strong>predictive AI</p> and <strong>data pipeline automation</strong>:</p>
+      <p>Quarkus is comprehensive, it supports both <strong>predictive AI</strong> and <strong>data pipeline automation</strong>:</p>
       <ul>
         <li>Integrate directly with ML toolkits such as DL4J to train or run models within a single Quarkus application.</li>
         <li>Build scalable, production-grade ETL and embedding workflows that connect to message brokers, databases, and file systems easily - a must-have for preparing data for both model training and RAG patterns.</li>

--- a/_includes/benefactors.html
+++ b/_includes/benefactors.html
@@ -53,7 +53,6 @@
         <p>Zulip is an organized team chat app designed for efficient communication.</p>
         <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://zulip.com/" target="blank"> Learn more about Zulip</a></p>
       </div>
-      </div>
     </div>
 
     <div class="component-wrapper options-band">

--- a/_includes/discussion.html
+++ b/_includes/discussion.html
@@ -6,7 +6,7 @@
       <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://github.com/quarkusio/quarkus/discussions">Go to the Quarkus GitHub Discussions<i class="fas fa-external-link-alt"></i></a></p>
     </div>
     <div class="width-4-12 width-12-12-m">
-      <h3>Community Call</h4>
+      <h3>Community Call</h3>
       <p>We host a biweekly Quarkus Community Call at 2PM (Paris time) to discuss technical topics and project updates. To attend, <a href="https://calendar.google.com/calendar/embed?src=935090aaae38be35eda437d018782b7827f3770f7a0344013677acd861570b20%40group.calendar.google.com&ctz=Europe%2FParis" target="blank">view the calendar</a> or <a href="https://calendar.google.com/calendar/ical/935090aaae38be35eda437d018782b7827f3770f7a0344013677acd861570b20%40group.calendar.google.com/public/basic.ics">subscribe (iCal)</a>  to the calendar so you don't miss one. The calls are posted to Youtube you can view the <a href="https://www.youtube.com/playlist?list=PLsM3ZE5tGAVZ_rG48SFUFpEyTYGai0YLw" target="blank">Community Call Playlist</a> to access all of the calls.</p>
     </div>
     <div class="width-4-12 width-12-12-m">

--- a/_includes/spring-features-band.html
+++ b/_includes/spring-features-band.html
@@ -6,12 +6,11 @@
         <p class="img-content">Already a Spring pro? You're in the right place. This guide shows you how to leverage your existing skills to build next-generation Java applications. Ditch the slow startup times and heavy memory footprint without ditching your knowledge. See how familiar concepts like DI, JPA, and MVC map directly to Quarkus and get ready to build cloud native, AI-infused apps.</p>
       </div>
       <div class="width-2-12 width-12-12-m">
-        <a href="https://developers.redhat.com/e-books/quarkus-spring-developers" alt="Quarkus for Spring Developers free link"><img class="imagereducer" src="{{site.baseurl}}/assets/images/books/quarkus-for-spring-developers.png" alt="Quarkus for Spring Developers book image"></a>
+        <a href="https://developers.redhat.com/e-books/quarkus-spring-developers" aria-label="Quarkus for Spring Developers free link"><img class="imagereducer" src="{{site.baseurl}}/assets/images/books/quarkus-for-spring-developers.png" alt="Quarkus for Spring Developers book image"></a>
       </div>
       <div class="width-4-12 width-12-12-m">
-        <p class="img-content">
           <p>Want to get started using Quarkus and leverage your hard-earned Spring skills?</p>
-          <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://developers.redhat.com/e-books/quarkus-spring-developers" alt="Quarkus for Spring Developers free link">Download a free copy of “Quarkus for Spring Developers”</a></p>
+          <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://developers.redhat.com/e-books/quarkus-spring-developers" aria-label="Quarkus for Spring Developers free link">Download a free copy of “Quarkus for Spring Developers”</a></p>
       </div>
     </div>
   </div>
@@ -22,12 +21,11 @@
         <p class="img-content">Time to get your hands dirty. Quarkus in Action is your practical, hands-on guide to building production-grade applications from the ground up. Go from project initialization to a fully-realized, cloud-native service. You'll tackle real-world challenges, master the essentials, and learn the patterns that make Quarkus development so fast and fun. Directly from the experts.</p>
       </div>
       <div class="width-2-12 width-12-12-m">
-        <a href="https://developers.redhat.com/e-books/quarkus-action?extIdCarryOver=true&sc_cid=701f2000001Css0AAC" alt="Quarkus in Action free download link"><img class="imagereducer" src="{{site.baseurl}}/assets/images/books/quarkus-in-action-ebook.png" alt="Quarkus in Action ebook image"></a>
+        <a href="https://developers.redhat.com/e-books/quarkus-action?extIdCarryOver=true&sc_cid=701f2000001Css0AAC" aria-label="Quarkus in Action free download link"><img class="imagereducer" src="{{site.baseurl}}/assets/images/books/quarkus-in-action-ebook.png" alt="Quarkus in Action ebook image"></a>
       </div>
       <div class="width-4-12 width-12-12-m">
-        <p class="img-content">
           <p>Get a practical introduction to Quarkus, the full-stack framework for building cloud-native Java applications.</p>
-          <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://developers.redhat.com/e-books/quarkus-action?extIdCarryOver=true&sc_cid=701f2000001Css0AAC" alt="Quarkus in Action free download link">Download a free copy of “Quarkus in Action”</a></p>
+          <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://developers.redhat.com/e-books/quarkus-action?extIdCarryOver=true&sc_cid=701f2000001Css0AAC" aria-label="Quarkus in Action free download link">Download a free copy of “Quarkus in Action”</a></p>
       </div>
     </div>
   </div>
@@ -42,9 +40,8 @@
         <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-workshop-dark.svg" alt="Workshop icon">
       </div>
       <div class="width-4-12 width-12-12-m">
-        <p class="img-content">
           <p>Get coding with the “Quarkus LangChain4j Workshop”, designed to help you get started with AI-Infused applications using Quarkus and LangChain4j.</p>
-          <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://quarkus.io/quarkus-workshop-langchain4j/" alt="Start the free workshop">Get started with this free workshop!</p>
+          <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://quarkus.io/quarkus-workshop-langchain4j/" aria-label="Start the free workshop">Get started with this free workshop!</a></p>
       </div>
     </div>
   </div>

--- a/_includes/spring-migrate-main.html
+++ b/_includes/spring-migrate-main.html
@@ -43,7 +43,7 @@
           <p>Build and test native images for fast cold starts and minimal memory.</p>
           <p><strong>Containerize and deploy</strong></p>
           <p>Use Dev Services and Kubernetes-native features for smooth rollout.</p>
-        </dl>
+        
       </div>
       <div class="width-6-12 width-12-12-m">
         <img class="light-only" src="{{site.baseurl}}/assets/images/spring/migrate-code-img3.png" alt="Migration code image 3">


### PR DESCRIPTION
Fixed invalid HTML/XHTML structure that prevented localization (Since localization sites like ja.quarkus.io parse html files to replace texts, HTML markup must be valid)

- `_includes/ai-quarkus-for-ai.html`
- `_includes/benefactors.html`
- `_includes/spring-features-band.html`
- `_includes/spring-migrate-main.html`
- `_includes/discussion.html` — mismatched `<h3>` / `</h4>` closing tag