### PR TITLE
Enable Bluesky validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,9 +45,10 @@ jobs:
         run: bundle exec jekyll build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v4.0.1
         with:
           path: ./_site
+          include-hidden-files: true
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION


## Summary
- update the GitHub Pages artifact upload action to a version that supports hidden-file inclusion
- enable `include-hidden-files: true` so `.well-known/*` is preserved in the uploaded Pages artifact

## Why
`.well-known` is already present in the repo, but the Pages artifact upload step excluded dot-prefixed paths. This can prevent files like `/.well-known/atproto-did` from reaching production.

## Validation
- confirmed the workflow currently uploads `./_site`
- updated `actions/upload-pages-artifact` from v4.0.0 to v4.0.1
- enabled hidden-file inclusion explicitly
