### PR TITLE
Fix tag links breaking when post tags are comma-separated

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: base
         <div class="post-date">
           {{ page.date | date: '%B %d, %Y' }} 
           {% if page.tags %}
-            <span class="tags">{% for tag in page.tags %}<a href="{{site.baseurl}}/blog/tag/{{ tag | downcase | replace: '.', '-' }}">#{{ tag | downcase }}</a>{% endfor %}</span>
+            <span class="tags">{% for tag in page.tags %}<a href="{{site.baseurl}}/blog/tag/{{ tag | downcase | replace: ',', '' | replace: '.', '-' }}">#{{ tag | downcase | replace: ',', '' }}</a>{% endfor %}</span>
           {% endif %}
         </div>
         <h1 class="post-title">{{ page.title }}</h1>


### PR DESCRIPTION
## Problem

When a blog post declares its `tags` front matter using a comma-separated list (e.g. `tags: ai, mcp, agent, development-tips`) instead of the usual space-separated form, the rendered tag links include the trailing comma in the URL and produce a 404.

### Example

Post: https://quarkus.io/blog/introducing-agent-mcp/

Front matter (`_posts/2026-05-07-introducing-agent-mcp.adoc`):

```yaml
tags: ai, mcp, agent, development-tips
```

The `#ai` chip in the UI links to:

```
https://quarkus.io/blog/tag/ai,
```

…which 404s. The expected destination is:

```
https://quarkus.io/blog/tag/ai
```

## Fix

In `_layouts/post.html`, strip commas from the tag value when building both the URL and the displayed text, so the links work regardless of whether front matter uses spaces or commas as separators.

```diff
-<span class="tags">{% for tag in page.tags %}<a href="{{site.baseurl}}/blog/tag/{{ tag | downcase | replace: '.', '-' }}">#{{ tag | downcase }}</a>{% endfor %}</span>
+<span class="tags">{% for tag in page.tags %}<a href="{{site.baseurl}}/blog/tag/{{ tag | downcase | replace: ',', '' | replace: '.', '-' }}">#{{ tag | downcase | replace: ',', '' }}</a>{% endfor %}</span>
```

## Test plan

- [ ] Build the site locally and open a post that uses comma-separated tags; click each tag chip and confirm it lands on the matching `/blog/tag/<name>` page.
- [ ] Open a post that uses space-separated tags and confirm behavior is unchanged.