### PR TITLE
Add PlantUML theme

### DIFF
--- a/assets/plantuml/themes/puml-theme-quarkus.puml
+++ b/assets/plantuml/themes/puml-theme-quarkus.puml
@@ -1,0 +1,142 @@
+''
+'' Quarkus theme for PlantUML
+'' https://quarkus.io
+''
+
+!define QUARKUS_BLUE #4695EB
+!define QUARKUS_RED #FF004A
+!define QUARKUS_NEAR_BLACK #091313
+!define DARK_BLUE_GRAY #1A3A5C
+!define LIGHT_BLUE #D6E6FA
+!define PALE_BLUE #EBF3FD
+!define MEDIUM_BLUE #7AB3F0
+!define WARM_GRAY #F0EDE8
+!define WARM_GRAY_BORDER #9E9A95
+!define LIGHT_PURPLE #E0D4F5
+!define DARK_PURPLE #6B5B95
+!define LIGHT_GRAY #E8ECF0
+!define LABEL_GRAY #555555
+!define QUARKUS_ICON <$quarkus*0.078>
+
+sprite $quarkus [256x312/16z] {
+xCz10O0040IXQs3_jZutWmuqu7u7000000000000uFcmxdso-QdkfxgVwdwg-uds9zgVwdwY_Ods9zgVQ7-Y_V5FzYVQdsX__9FzyLy_oN_z9F_rayxV_sNd
+Jj8ZnC4O37C3tV-slSgZXJEeMtzXFZTa3fQAj-O29zb8sfApZjJ_2zYX-fXsAZ-ndSsFT4Vp0zxhFvd_b-_r1tpsGlBp_Q__zR_-ro_D6dX-QKxFz4ipUgvV
+0toqNshrR7zVmlUhw-3xfQw1xvUwFDylTMc-NrsOxvUwADylTK6-N-fYVB-w5DylTHc-N-eIVB-I0D-VLqld-NEIT9o_dN_q-j_h__dtV_xcD7_YMRu_o1ze
+bX-Fz__CFVhvRqGz__MFAuCrX_gzBbXvd3--P-3xczcsP_glWEzXU7-k3uRI_RdUmm_ov_ermVTVCNy9SVsLta6ilzGxZFONUkUn_glZkmBfx_NU19v_Hk-D
+0FerjY3z6bnuVeqkmDl_BF-z_VFyrnWVv_zApkabaj_PAJt7xzAfvx_UrEVxNTfV1PntwxFzBbq4fTwj3_QxT56qUhdrgVwbT6Z_rzhwHFzIMbm5biJI-ZJ_
+RwNs5FgbzL7-fJGqvVgrzJd-eBGu_lLpwpFySMa-pJVUr0VuurBh0dtQkjiVb1Rp7vBMdVwmT6qCrkIjk_n9wS_EJ9-rRl6t_rGeqCUjz_kJqdx-OzvwhrzD
+gOkNxvlM-_nIwxVQ-hxr9hz6_5BQcBVUuI-sDBWZR5i_xPSc_ShvSUlhvrp_v_sa-xzv_zR7l_t-dSz_zlj9pt_d_RU__dcMV-Vht_t-dVi_zlj9-x_c_Plt
+V-xsxz__lTDFElunxoST_vht0uv_Vj8FEFxzGJzf_iEydpJ_PTuFcF_qIJzW_ji7_QJvZ_D-olpNUJzf_k_hl-RzjFd_i_v3__uf7WVpowSyu7SbnVyLhVqk
+GlaThlmkWVaZNZw0w7V-l_aTn_fDoFshdkmt8_ElCRpVajpl4DzlJEft0EiFGFO7W-5-K_DVmltvTJeO1lJdzsc1dkzVUVP7UhxVZS5FU7_-d7PPSRBVKFi3
+_Kb-O-sFGto_YvSl1_apZO9zPM1_xf4EzESW_T_yx-NV9FZ-9iFtLoc-ludn_KsGxs-YV7yLvllJDD_VTj7zVHFTt_V0_NqDs1-N_B6Mweyh_beFzmUye8dd
+J_F96A8_JMUZcFvh40RqNvF-2-JFbv4JuVl_QQU-ZXk0WHY8eeFjlrhd79I58G_OVrjwq0q9zLF_Mv5-wlyeq4-oltw-b-Mldvyb-Ukd_fyb-Qd_Tod--gd_
+hrByrFzt6Nxg_wy4Fyd--ZdOS7_z7Cdhhn-ld_3VdwEDzhER7xiV6z_lPpy_k_lPpSzQVjnyd7na780Jy_Bb-Zxu_Tp43oQ_Vt3ZgupHVnwBrTA1xl11B9VJ
+NxzOBezVoZu0lPVfbx8FG8e-0Atin-6FFW3Ldpo0VfRbbw87KFqx3t2d_vno0Fgl3ByKFO0EDT-l8yr-0NMyoGUWKvhhrudD741dDC-lCvlr0kg2vXo0Bcs2
+NrUsym2AhxNMMckjjTPQQ-qH
+}
+
+skinparam dpi 300
+
+skinparam defaultFontName "Open Sans"
+skinparam defaultFontColor QUARKUS_NEAR_BLACK
+skinparam defaultFontSize 14
+skinparam shadowing true
+skinparam shadowColor #DDDDDD
+skinparam roundCorner 10
+
+skinparam node {
+    borderColor DARK_BLUE_GRAY
+    backgroundColor LIGHT_BLUE
+    fontName "Open Sans"
+    fontSize 17
+    fontColor DARK_BLUE_GRAY
+    roundCorner 10
+}
+
+skinparam rectangle {
+    borderColor DARK_BLUE_GRAY
+    backgroundColor LIGHT_BLUE
+    fontName "Open Sans"
+    fontSize 17
+    fontColor DARK_BLUE_GRAY
+    roundCorner 10
+}
+
+skinparam database {
+    borderColor DARK_BLUE_GRAY
+    backgroundColor #A8C4E0
+    fontColor DARK_BLUE_GRAY
+}
+
+skinparam agent {
+    backgroundColor<<frontend>> QUARKUS_BLUE
+    fontColor<<frontend>> #FFFFFF
+    borderColor<<frontend>> DARK_BLUE_GRAY
+    backgroundColor<<application>> WARM_GRAY
+    fontColor<<application>> QUARKUS_NEAR_BLACK
+    borderColor<<application>> WARM_GRAY_BORDER
+}
+
+skinparam participant {
+    backgroundColor<<frontend>> QUARKUS_BLUE
+    fontColor<<frontend>> #FFFFFF
+    borderColor<<frontend>> DARK_BLUE_GRAY
+    backgroundColor<<application>> WARM_GRAY
+    fontColor<<application>> QUARKUS_NEAR_BLACK
+    borderColor<<application>> WARM_GRAY_BORDER
+}
+
+skinparam arrow {
+    fontName "Open Sans"
+    color QUARKUS_RED
+    fontColor LABEL_GRAY
+    thickness 2
+    fontSize 13
+}
+
+skinparam class {
+    backgroundColor WARM_GRAY
+    borderColor WARM_GRAY_BORDER
+    fontColor QUARKUS_NEAR_BLACK
+    attributeFontColor QUARKUS_NEAR_BLACK
+    attributeFontName "Open Sans"
+}
+
+skinparam component {
+    backgroundColor MEDIUM_BLUE
+    borderColor DARK_BLUE_GRAY
+    fontColor #FFFFFF
+}
+
+skinparam package {
+    borderColor DARK_BLUE_GRAY
+    backgroundColor PALE_BLUE
+    fontColor DARK_BLUE_GRAY
+    fontSize 14
+    style rectangle
+}
+
+skinparam hexagon {
+    backgroundColor LIGHT_PURPLE
+    borderColor DARK_PURPLE
+    fontColor QUARKUS_NEAR_BLACK
+}
+
+skinparam cloud {
+    backgroundColor LIGHT_GRAY
+    borderColor DARK_BLUE_GRAY
+    fontColor QUARKUS_NEAR_BLACK
+}
+
+skinparam interface {
+    backgroundColor QUARKUS_BLUE
+    borderColor DARK_BLUE_GRAY
+    fontColor DARK_BLUE_GRAY
+}
+
+skinparam sequence {
+    lifeLineBorderColor DARK_BLUE_GRAY
+    lifeLineBackgroundColor PALE_BLUE
+    activationBackgroundColor LIGHT_BLUE
+    activationBorderColor DARK_BLUE_GRAY
+}


### PR DESCRIPTION
We use plantuml in various places on our estate, and almost all the diagrams are ugly. Once we have this, we should be able to do 

```
  !theme quarkus from https://quarkus.io/assets/plantuml/themes
```

in our files, and have them just look good. I've tested (as far as I can) on the workshops repo, and this styling is taken from there.