### PR TITLE
Convert posts with outlier date format to ISO 8601 instant format

### DIFF
--- a/_posts/2019-05-05-quarkus-has-a-new-logo.adoc
+++ b/_posts/2019-05-05-quarkus-has-a-new-logo.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quarkus has a new logo
-date: 2019-05-08 14:00:00.000 -0600
+date: 2019-05-08T20:00:00Z
 tags: announcement
 author: jcobb
 ---

--- a/_posts/2019-05-08-welcome.adoc
+++ b/_posts/2019-05-08-welcome.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Welcome to Quarkus!
-date: 2019-05-08 14:00:00.000 +0200
+date: 2019-05-08T12:00:00Z
 tags: announcement
 author: ebernard
 ---

--- a/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc
+++ b/_posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quarkus and Web UI Development
-date: 2019-06-05 14:00:00.000 -0600
+date: 2019-06-05T20:00:00Z
 tags: development-tips
 author: kkhan
 ---

--- a/_posts/2019-07-08-runtime-performance.adoc
+++ b/_posts/2019-07-08-runtime-performance.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-date:   2019-07-08 00:00 +0100
+date: 2019-07-07T23:00:00Z
 author: johara
 tags: performance
 synopsis: Quarkus has so far been focused on start-up time and memory footprint, but runtime performance is important as well. Find out how well Quarkus performs in both Native and JVM modes.

--- a/_posts/2019-07-25-quarkus-dependency-injection.adoc
+++ b/_posts/2019-07-25-quarkus-dependency-injection.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-date:   2019-07-25 00:00 +0100
+date: 2019-07-24T23:00:00Z
 author: mkouba
 tags: extension arc development-tips 
 synopsis: Quarkus ArC is a build-time oriented dependency injection based on CDI 2.0. But what does it actually mean and what benefits does a build-time processing DI bring?

--- a/_posts/2019-08-01-hibernate-orm-config-profiles.adoc
+++ b/_posts/2019-08-01-hibernate-orm-config-profiles.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tips to use Hibernate ORM with Quarkus profiles and live coding mode
-date: 2019-08-01 14:00:00.000 +0200
+date: 2019-08-01T12:00:00Z
 synopsis: Hibernate ORM lets you generate or update the database schema. Let's explore when to use such option in combination with live coding.
 tags: extension hibernate development-tips
 author: ebernard

--- a/_posts/2019-10-15-quarkus-on-jboss-asylum-podcast.adoc
+++ b/_posts/2019-10-15-quarkus-on-jboss-asylum-podcast.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quarkus on JBoss Asylum Podcast
-date: 2019-10-15 00:06 +0200
+date: 2019-10-14T22:06:00Z
 author: maxandersen
 synopsis: Jason, Emmanuel, Bill and Max on Asylum podcast about the making of Quarkus
 ---

--- a/_posts/2019-12-11-talkdesk-chooses-quarkus-for-fast-innovation.adoc
+++ b/_posts/2019-12-11-talkdesk-chooses-quarkus-for-fast-innovation.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: For fast innovation and to stay ahead of the competition, Talkdesk chooses Quarkus
-date: 2019-12-11 00:00:00.000 -0600
+date: 2019-12-11T06:00:00Z
 tags: user-story
 author: cesarsaavedra
 thumbnailimage: /assets/images/posts/quarkus-user-stories/talkdesk/td_logo_2019_cmyk_darkblue.png

--- a/_posts/2020-02-24-qute.adoc
+++ b/_posts/2020-02-24-qute.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'Qute - Why (Not Just) Yet Another Templating Engine'
-date:   2020-02-24 00:00 +0100
+date: 2020-02-23T23:00:00Z
 author: mkouba
 synopsis: Qute - a templating engine designed specifically to meet the Quarkus needs.
 ---

--- a/_posts/2020-04-28-quarkus-mutual-tls.adoc
+++ b/_posts/2020-04-28-quarkus-mutual-tls.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Learn how to do Mutual TLS in Quarkus apps
-date:   2020-04-28 00:00 +0100
+date: 2020-04-27T23:00:00Z
 author: mmascia
 synopsis: Let's learn how to enable mutual TLS in a Quarkus app.
 ---

--- a/_posts/2020-07-10-quarkus-test-profiles.adoc
+++ b/_posts/2020-07-10-quarkus-test-profiles.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quarkus now supports test profiles
-date: 2020-07-10 14:00:00.000 -0600
+date: 2020-07-10T20:00:00Z
 tags: feature testing
 author: sdouglas
 ---

--- a/_posts/2022-11-24-reactive-crud-performance-case-study.adoc
+++ b/_posts/2022-11-24-reactive-crud-performance-case-study.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Reactive CRUD Performance: A Case Study"
-date:   2022-11-24 00:00 +0100
+date: 2022-11-23T23:00:00Z
 author: johara
 tags: performance
 synopsis: By carefully fixing and designing a performance test to ensure that only Quarkus is being stressed, throughput improves from 1.75 req/sec to nearly 26,000 req/sec


### PR DESCRIPTION
We use at least three different date formats in our posts. It's easier for Roq to digest the site if there's not *too* much variety, so I've converted six + six very old posts that used a format not used anywhere else to the ISO 8601 instant format (which is more widely used, along with a plain-old date format).