### PR TITLE
Add Spring Migration to Primary navigation and sitemap

### DIFF
--- a/_data/sitemap-links.yaml
+++ b/_data/sitemap-links.yaml
@@ -94,14 +94,22 @@ sections:
         description: "Container-native approach"
         priority: 0.7
         changefreq: "monthly"
-      
-      - title: "Using Spring?"
-        url: "/spring"
-        description: "Migrate from Spring Boot"
-        priority: 0.8
-        changefreq: "monthly"
-    
+
     subsections:
+      - title: "Spring Migration to Quarkus"
+        links:
+          - title: "Leverage your Spring expertise on Quarkus"
+            url: "/spring"
+            description: "Spring compatibility with Quarkus"
+            priority: 0.8
+            changefreq: "monthly"
+          
+          - title: "Migrate to Quarkus"
+            url: "/spring/migrate/"
+            description: "Migrate from Spring Boot to Quarkus"
+            priority: 0.8
+            changefreq: "monthly"
+      
       - title: "AI Capabilities"
         links:
           - title: "AI Overview"

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -20,7 +20,13 @@
           <li><a href="{{site.baseurl}}/standards" class="{% if page.url contains '/standards/' %}active{% endif %}">STANDARDS</a></li>
           <li><a href="{{site.baseurl}}/versatility" class="{% if page.url contains '/versatility/' %}active{% endif %}">VERSATILITY</a></li>
           <li><a href="{{site.baseurl}}/container-first" class="{% if page.url contains '/container-first/' %}active{% endif %}">CONTAINER FIRST</a></li>
-          <li><a href="{{site.baseurl}}/spring" class="{% if page.url contains '/spring/' %}active{% endif %}">USING SPRING?</a></li>
+          <li class="tertiarydropdown">
+            <span href="#">USING SPRING?<i class="fas fa-chevron-down"></i></span>
+            <ul class="tertiarymenu">
+              <li><a href="{{site.baseurl}}/spring" class="{% if page.url contains '/spring' %}{% unless page.url contains '/spring/migrate/' %}active{% endunless %}{% endif %}">SPRING OVERVIEW</a></li>
+              <li><a href="{{site.baseurl}}/spring/migrate/" class="{% if page.url contains '/spring/migrate/' %}active{% endif %}">MIGRATE TO QUARKUS</a></li>
+            </ul>
+          </li>
           <li class="tertiarydropdown">
             <span href="#">AI<i class="fas fa-chevron-down"></i></span>
             <ul class="tertiarymenu">

--- a/_layouts/spring-migrate.html
+++ b/_layouts/spring-migrate.html
@@ -2,7 +2,6 @@
 layout: base
 ---
 
-{% include spring-breadcrumb.html %}
-{% include springtitle-band.html %}
+{% include title-band.html %}
 
 {% include spring-migrate-content.html %}

--- a/_layouts/spring.html
+++ b/_layouts/spring.html
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-{% include springtitle-band.html %}
+{% include title-band.html %}
 
 {% include spring-roles-band.html %}
 {% include spring-userstory-callout.html %}


### PR DESCRIPTION
The new "Migrate to Quarkus" page is too important of a page to be only linked inside of the /spring page so I added it to the prime nav and restyled it since it's no longer a splash. I also added it to the sitemap.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
