### PR TITLE
Handle both Roq and Jekyll in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,17 @@ jobs:
           fetch-depth: 5000
           fetch-tags: false
 
+      - name: Check for Jekyll site
+        id: check_jekyll
+        run: |
+          if [ -f "Gemfile" ]; then
+            echo "jekyll_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "jekyll_exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up ruby
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
         with:
           ruby-version: 3.2.3
@@ -31,17 +41,43 @@ jobs:
         run: ./tools/git-restore-mtime
 
       - name: Cache Ruby gems
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
+
       - name: Install dependencies
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+
       - name: Build Jekyll site
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: bundle exec jekyll build --future --config _config.yml,_only_latest_guides_config.yml
+
+      - name: Check for Maven project
+        id: check_maven
+        run: |
+          if [ -f "pom.xml" ]; then
+            echo "maven_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "maven_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up JDK
+        if: steps.check_maven.outputs.maven_exists == 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        if: steps.check_maven.outputs.maven_exists == 'true'
+        run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run
 
       - name: Store PR id
         run: echo ${{ github.event.number }} > ./_site/pr-id.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,17 @@ jobs:
     steps:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check for Jekyll site
+        id: check_jekyll
+        run: |
+          if [ -f "Gemfile" ]; then
+            echo "jekyll_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "jekyll_exists=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up ruby
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
         with:
           ruby-version: 3.2.3
@@ -39,11 +48,35 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
       - name: Install dependencies
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+
       - name: Build Jekyll site
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: bundle exec jekyll build
+
+      - name: Check for Maven project
+        id: check_maven
+        run: |
+          if [ -f "pom.xml" ]; then
+            echo "maven_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "maven_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up JDK
+        if: steps.check_maven.outputs.maven_exists == 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        if: steps.check_maven.outputs.maven_exists == 'true'
+        run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v4.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ npm-debug.log
 .vscode
 .jekyll-cache
 bin
+target
 vendor
+node_modules
 
 .quarkus-main-repository
 


### PR DESCRIPTION
If (when?) we convert our site to Roq, it will be a huuuuge PR with the output of a converter. We'll have to run the conversion many times in the process of getting it right. I'm trying to ensure the generated conversion PR doesn't need to include any human-made changes, by making any changes we need to convert to Roq independently. This updates our CI to handle both; we'd probably only build one at a time, but it gives us flexibility. 

The Roq path of this can be seen in https://github.com/quarkusio/quarkusio.github.io/pull/2684; that CI is broken, waiting for a Roq release, but it does correctly attempt to build Roq and not Jekyll.