### PR TITLE
Add Playwright end-to-end tests for link checking and general sense checking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,11 @@ jobs:
         with:
           ruby-version: 3.2.3
 
-      # git restore-mtime is currently broken in the GH Actions images so using our own updated local copy
-      # see https://github.com/MestreLion/git-tools/blob/main/git-restore-mtime
-      - name: Restore mtime
-        run: ./tools/git-restore-mtime
+      - name: Set up JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Cache Ruby gems
         if: steps.check_jekyll.outputs.jekyll_exists == 'true'
@@ -48,7 +49,26 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
 
-      - name: Install dependencies
+      - name: Cache Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pom.xml') }}
+
+      # git restore-mtime is currently broken in the GH Actions images so using our own updated local copy
+      # see https://github.com/MestreLion/git-tools/blob/main/git-restore-mtime
+      - name: Restore mtime
+        run: ./tools/git-restore-mtime
+
+      - name: Install Ruby dependencies
         if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: |
           bundle config path vendor/bundle
@@ -58,17 +78,17 @@ jobs:
         if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: bundle exec jekyll build --future --config _config.yml,_only_latest_guides_config.yml
 
-      - name: Check for Maven project
-        id: check_maven
+      - name: Check for Roq project
+        id: check_roq
         run: |
-          if [ -f "pom.xml" ]; then
-            echo "maven_exists=true" >> $GITHUB_OUTPUT
+          if [ -f "src/main" ]; then
+            echo "roq_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "maven_exists=false" >> $GITHUB_OUTPUT
+            echo "roq_exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up JDK
-        if: steps.check_maven.outputs.maven_exists == 'true'
+        if: steps.check_roq.outputs.roq_exists == 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
@@ -76,8 +96,37 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        if: steps.check_maven.outputs.maven_exists == 'true'
+        if: steps.check_roq.outputs.roq_exists == 'true'
         run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run
+
+      - name: Compile tests
+        run: mvn -B test-compile
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps --only-shell chromium"
+
+      # Jekyll serve handles extensionless URLs (e.g. /guides/getting-started)
+      # the same way GitHub Pages does; a plain HTTP server would 404 on them.
+      - name: Start test server
+        run: |
+          bundle exec jekyll serve --port 8090 --no-watch --skip-initial-build &
+          timeout 30 bash -c 'until curl -s http://localhost:8090 > /dev/null 2>&1; do sleep 0.5; done'
+
+      - name: Run smoke tests
+        run: mvn -B test -Dtest.url=http://localhost:8090
+        env:
+          PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
+
+      # Versioned guides (2.x-5.x) are excluded from this build by
+      # _only_latest_guides_config.yml, so skip crawling those paths.
+      - name: Run link crawler
+        run: >-
+          mvn -B test -Pe2e -Dtest.url=http://localhost:8090
+          -Dtest.crawl.check-external=false
+          -Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main/guides/doc-reference
+        env:
+          PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
 
       - name: Store PR id
         run: echo ${{ github.event.number }} > ./_site/pr-id.txt

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.quarkusio</groupId>
+    <artifactId>quarkusio-website-tests</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Quarkus.io - E2E Tests</name>
+    <properties>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <surefire-plugin.version>3.5.5</surefire-plugin.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>1.52.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <excludedGroups>e2e</excludedGroups>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>e2e</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <groups>e2e</groups>
+                            <excludedGroups combine.self="override"/>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/src/test/java/io/quarkusio/BrowserTest.java
+++ b/src/test/java/io/quarkusio/BrowserTest.java
@@ -1,0 +1,57 @@
+package io.quarkusio;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class BrowserTest {
+
+    static final String DEFAULT_BASE_URL = "http://localhost:8080";
+
+    static Playwright playwright;
+    static Browser browser;
+    static String baseUrl;
+
+    BrowserContext context;
+    Page page;
+
+    @BeforeAll
+    static void launchBrowser() {
+        baseUrl = System.getProperty("test.url", DEFAULT_BASE_URL);
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(
+                new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @AfterAll
+    static void closeBrowser() {
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    @BeforeEach
+    void createContext() {
+        context = browser.newContext();
+        page = context.newPage();
+    }
+
+    @AfterEach
+    void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+}

--- a/src/test/java/io/quarkusio/LinkCrawlerTest.java
+++ b/src/test/java/io/quarkusio/LinkCrawlerTest.java
@@ -1,0 +1,316 @@
+package io.quarkusio;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.PlaywrightException;
+import com.microsoft.playwright.Response;
+import com.microsoft.playwright.Route;
+import com.microsoft.playwright.options.WaitUntilState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Tag("e2e")
+public class LinkCrawlerTest extends BrowserTest {
+
+    private static final int DEFAULT_MAX_PAGES = Integer.MAX_VALUE;
+    private static final int DEFAULT_THREADS = 8;
+
+    @BeforeEach
+    @Override
+    void createContext() {
+    }
+
+    @AfterEach
+    @Override
+    void closeContext() {
+    }
+
+    @Test
+    void crawlAndCheckLinks() throws InterruptedException {
+        int maxPages = Integer.getInteger("test.crawl.max-pages", DEFAULT_MAX_PAGES);
+        int threads = Integer.getInteger("test.crawl.threads", DEFAULT_THREADS);
+        boolean checkInternal = Boolean.parseBoolean(System.getProperty("test.crawl.check-internal", "true"));
+        boolean checkExternal = Boolean.parseBoolean(System.getProperty("test.crawl.check-external", "false"));
+        List<String> excludePaths = parseExcludePaths(System.getProperty("test.crawl.exclude-paths", ""));
+
+        Set<String> visited = ConcurrentHashMap.newKeySet();
+        ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
+        Map<String, BrokenLink> broken = new ConcurrentHashMap<>();
+        Map<String, String> foundOn = new ConcurrentHashMap<>();
+        Set<String> checkedExternal = ConcurrentHashMap.newKeySet();
+        AtomicInteger crawledCount = new AtomicInteger();
+
+        queue.add(normalize(baseUrl + "/"));
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                try (Playwright pw = Playwright.create()) {
+                    Browser br = pw.chromium().launch(
+                            new BrowserType.LaunchOptions().setHeadless(true));
+                    BrowserContext ctx = br.newContext();
+                    ctx.route("**/*.{css,png,jpg,jpeg,gif,svg,ico,woff,woff2,ttf,eot}", Route::abort);
+                    Page p = ctx.newPage();
+                    p.setDefaultNavigationTimeout(30_000);
+
+                    crawLoop(p, queue, visited, broken, foundOn, checkedExternal,
+                            crawledCount, maxPages, checkInternal, checkExternal, excludePaths);
+
+                    ctx.close();
+                    br.close();
+                }
+            });
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(30, TimeUnit.MINUTES);
+
+        System.out.println("Crawled " + crawledCount.get() + " internal pages"
+                + (checkExternal ? ", checked " + checkedExternal.size() + " external links" : "")
+                + ", found " + broken.size() + " broken links"
+                + " (" + threads + " threads)");
+
+        if (!broken.isEmpty()) {
+            List<Map.Entry<String, BrokenLink>> sorted = new ArrayList<>(broken.entrySet());
+            sorted.sort(Map.Entry.comparingByKey());
+            fail("Found " + broken.size() + " broken link(s):\n" + buildReport(sorted));
+        }
+    }
+
+    private void crawLoop(Page p,
+                           ConcurrentLinkedQueue<String> queue,
+                           Set<String> visited,
+                           Map<String, BrokenLink> broken,
+                           Map<String, String> foundOn,
+                           Set<String> checkedExternal,
+                           AtomicInteger crawledCount,
+                           int maxPages,
+                           boolean checkInternal,
+                           boolean checkExternal,
+                           List<String> excludePaths) {
+        int idlePolls = 0;
+        while (idlePolls < 3) {
+            if (crawledCount.get() >= maxPages) {
+                break;
+            }
+
+            String currentUrl = queue.poll();
+            if (currentUrl == null) {
+                idlePolls++;
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                continue;
+            }
+            idlePolls = 0;
+
+            if (!visited.add(currentUrl)) {
+                continue;
+            }
+            crawledCount.incrementAndGet();
+
+            Response response;
+            try {
+                response = p.navigate(currentUrl,
+                        new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
+            } catch (Exception e) {
+                // A meta-refresh redirect fires during navigate(), destroying
+                // the execution context. If the browser landed on a different
+                // URL the page redirected successfully — not broken.
+                try {
+                    if (!currentUrl.equals(normalize(p.url()))) {
+                        continue;
+                    }
+                } catch (Exception ignored) {
+                }
+                if (checkInternal) {
+                    broken.put(currentUrl, new BrokenLink(0, e.getMessage(), foundOn.get(currentUrl)));
+                }
+                continue;
+            }
+
+            if (response == null) {
+                if (checkInternal) {
+                    broken.put(currentUrl, new BrokenLink(0, "null response", foundOn.get(currentUrl)));
+                }
+                continue;
+            }
+
+            int status = response.status();
+            if (status >= 400) {
+                if (checkInternal) {
+                    broken.put(currentUrl, new BrokenLink(status, response.statusText(), foundOn.get(currentUrl)));
+                }
+                continue;
+            }
+
+            // Pages with <meta http-equiv="refresh"> or JS redirects can navigate
+            // away between navigate() and evaluate(), destroying the execution
+            // context. Safe to skip: the page returned 200, and the redirect target
+            // will be discovered via other links.
+            List<String> hrefs;
+            try {
+                @SuppressWarnings("unchecked")
+                var result = (List<String>) p.evaluate(
+                        "() => [...document.querySelectorAll('a[href]')].map(a => a.getAttribute('href'))");
+                hrefs = result;
+            } catch (PlaywrightException e) {
+                hrefs = Collections.emptyList();
+            }
+
+            for (String href : hrefs) {
+                if (href == null || href.isBlank()) {
+                    continue;
+                }
+
+                ResolvedLink resolved = resolveLink(currentUrl, href);
+                if (resolved == null) {
+                    continue;
+                }
+
+                if (resolved.internal) {
+                    String normalized = normalize(resolved.url);
+                    if (!visited.contains(normalized) && !isExcluded(normalized, excludePaths)) {
+                        queue.add(normalized);
+                        foundOn.putIfAbsent(normalized, currentUrl);
+                    }
+                } else if (checkExternal && checkedExternal.add(resolved.url)) {
+                    BrokenLink result = checkExternalLink(resolved.url);
+                    if (result != null) {
+                        broken.put(resolved.url, new BrokenLink(result.status, result.statusText, currentUrl));
+                    }
+                }
+            }
+        }
+    }
+
+    private ResolvedLink resolveLink(String currentPageUrl, String href) {
+        if (href.startsWith("mailto:") || href.startsWith("javascript:")
+                || href.startsWith("tel:") || href.startsWith("#")) {
+            return null;
+        }
+
+        String resolved;
+        boolean internal;
+        if (href.startsWith("http://") || href.startsWith("https://")) {
+            if (isLocalhostUrl(href)) {
+                return null;
+            }
+            resolved = href;
+            internal = href.startsWith(baseUrl);
+        } else {
+            try {
+                resolved = URI.create(currentPageUrl).resolve(href).toString();
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+            internal = true;
+        }
+
+        int fragmentIndex = resolved.indexOf('#');
+        if (fragmentIndex >= 0) {
+            resolved = resolved.substring(0, fragmentIndex);
+        }
+
+        return new ResolvedLink(resolved, internal);
+    }
+
+    private static BrokenLink checkExternalLink(String url) {
+        try (HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                    .timeout(Duration.ofSeconds(15))
+                    .build();
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            int status = response.statusCode();
+            if (status >= 400) {
+                return new BrokenLink(status, "HTTP " + status, null);
+            }
+            return null;
+        } catch (Exception e) {
+            return new BrokenLink(0, e.getMessage(), null);
+        }
+    }
+
+    private static List<String> parseExcludePaths(String property) {
+        if (property == null || property.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(property.split(","))
+                .map(String::strip)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    private boolean isExcluded(String url, List<String> excludePaths) {
+        String path = url.startsWith(baseUrl) ? url.substring(baseUrl.length()) : url;
+        for (String prefix : excludePaths) {
+            if (path.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isLocalhostUrl(String href) {
+        return href.startsWith("http://localhost") || href.startsWith("https://localhost");
+    }
+
+    private static String normalize(String url) {
+        if (url.length() > 1 && url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
+
+    private static String buildReport(List<Map.Entry<String, BrokenLink>> entries) {
+        StringBuilder sb = new StringBuilder();
+        for (var entry : entries) {
+            BrokenLink link = entry.getValue();
+            sb.append("  ").append(link.status).append(" ").append(entry.getKey());
+            if (link.referrer != null) {
+                sb.append("\n       linked from: ").append(link.referrer);
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    record ResolvedLink(String url, boolean internal) {
+    }
+
+    record BrokenLink(int status, String statusText, String referrer) {
+    }
+}

--- a/src/test/java/io/quarkusio/SmokePageTest.java
+++ b/src/test/java/io/quarkusio/SmokePageTest.java
@@ -1,0 +1,34 @@
+package io.quarkusio;
+
+import com.microsoft.playwright.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SmokePageTest extends BrowserTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/",
+            "/about/",
+            "/blog/",
+            "/guides/",
+            "/get-started/",
+            "/support/"
+    })
+    void criticalPageReturns200(String path) {
+        Response response = page.navigate(baseUrl + path);
+        assertNotNull(response, "No response for " + path);
+        assertEquals(200, response.status(),
+                "Expected 200 for " + path + " but got " + response.status());
+    }
+
+    @Test
+    void notFoundPageReturns404() {
+        Response response = page.navigate(baseUrl + "/this-path-does-not-exist-xyz/");
+        assertNotNull(response, "No response for nonexistent path");
+        assertEquals(404, response.status());
+    }
+}


### PR DESCRIPTION
Partial resolution of [ #2110](https://github.com/quarkusio/quarkusio.github.io/issues/2110). This only handles the internal links, not the external links. 

These are standalone Playwright + JUnit tests that work against any running server (Jekyll or Quarkus) via a configurable base URL (-Dtest.url=...). It should be straightforward to convert them to `@QuarkusTest`s and use the Roq integration later on, but they'll provide value before-hand (and confidence during the transition). 

Usage:
```
  mvn test -Dtest.url=http://localhost:4000   # against Jekyll
  mvn test -Pe2e -Dtest.crawl.max-pages=100   # link crawler
```

This will fight with #2684, so I'll need to rework after whichever one of them merges first. This one can't really merge until we fix all our dead links (we have ~9 internal ones atm), so the other one should probably merge first.

The site check can be slow, and even though it's only checking internal links, we don't want noise from unrelated things. In a follow-on PR I'll add some logic to be more selective in the crawl (or, at the very least, the reporting) to the scope of what's changed in a PR. I won't do that now, so that we can see what the full test run looks like. 