### PR TITLE
Fix dead links in blog posts

### DIFF
--- a/_posts/2023-02-10-jpastreamer-extension.adoc
+++ b/_posts/2023-02-10-jpastreamer-extension.adoc
@@ -159,6 +159,6 @@ JPA in general, and Hibernate ORM in particular, has greatly simplified applicat
 
 * **GitHub:** link:https://github.com/quarkiverse/quarkus-jpastreamer[github.com/quarkiverse/quarkus-jpastreamer]
 * **Homepage:** link:https://jpastreamer.org[jpastreamer.org]
-* **JPAStreamer Quarkus Demo:** link:https//github.com/speedment/jpa-streamer-demo/tree/master/quarkus-hibernate-panache[github.com/speedment/jpa-streamer-demo/tree/master/quarkus-hibernate-panache]
+* **JPAStreamer Quarkus Demo:** link:https://github.com/speedment/jpa-streamer-demo/tree/master/quarkus-hibernate-panache[github.com/speedment/jpa-streamer-demo/tree/master/quarkus-hibernate-panache]
 * **Documentation:** link:https://speedment.github.io/jpa-streamer[speedment.github.io/jpa-streamer]
 * **Gitter Support Chat:** link:https://gitter.im/jpa-streamer[gitter.im/jpa-streamer]

--- a/_posts/2023-11-08-mandrel-23-1-image-size-increase.md
+++ b/_posts/2023-11-08-mandrel-23-1-image-size-increase.md
@@ -7,7 +7,7 @@ synopsis: A comprehensive analysis attributing binary size increase to specific 
 author: zakkak
 ---
 
-This article is a follow-up to [Exploring why native executables produced with Mandrel 23.0 are bigger than with Mandrel 22.3](../mandrel-23-0-image-size-increase/).
+This article is a follow-up to [Exploring why native executables produced with Mandrel 23.0 are bigger than with Mandrel 22.3](/blog/mandrel-23-0-image-size-increase/).
 
 Starting with Quarkus 3.5 the default Mandrel version was updated from 23.0 to 23.1.
 

--- a/_posts/2026-05-28-panache-next-renamed-to-quarkus-data.asciidoc
+++ b/_posts/2026-05-28-panache-next-renamed-to-quarkus-data.asciidoc
@@ -10,7 +10,7 @@ author: fromage
 == Goodbye Hibernate with Panache Next… welcome Quarkus Data Hibernate 🥳
 
 It's already been a while since we introduced
-xref:2025-12-24-hibernate-panache-next.asciidoc[Quarkus Hibernate with Panache Next], and since then, we've decided to
+link:/blog/hibernate-panache-next[Quarkus Hibernate with Panache Next], and since then, we've decided to
 move closer to the link:https://jakarta.ee/specifications/data/1.1/jakarta-data-1.1-m3[Jakarta Data] standard, as well
 as rename the module to https://quarkus.io/version/main/guides/quarkus-data-hibernate[Quarkus Data Hibernate].
 


### PR DESCRIPTION
I'm trying to group these sort-of-logically for ease of review. Discovered while testing https://github.com/quarkusio/quarkusio.github.io/pull/2685 (see also https://github.com/quarkusio/quarkusio.github.io/issues/2110).

- panache-next-renamed: replace broken xref with absolute link to /blog/hibernate-panache-next
- mandrel-23-1: fix relative link ../mandrel-23-0-image-size-increase that resolved outside /blog/ — use absolute path instead
- jpastreamer-extension: fix missing colon in https URL (https//github.com → https://github.com)
