### PR TITLE
Add missing front matter to old Insights transcripts

### DIFF
--- a/_posts/insights_0_transcription.adoc
+++ b/_posts/insights_0_transcription.adoc
@@ -1,10 +1,18 @@
+---
+layout: post
+title: 'Quarkus Insights #0 transcription: Inception'
+date: 2020-04-20
+tags: insights
+author: ebarnard, maxandersen
+---
+
 http://www.youtube.com/watch?v=YKm8rVzLhNE&t=00m03s[00:03]:
 
-**Emmanuel**: Ready, we're doing this thing, "Okay yes, Quarkus inside number zero inception.
+**Emmanuel**: Ready, we're doing this thing, "Okay yes, Quarkus Insights number zero inception.
 
 Hello and welcome everyone My name is Emmanuel. And I am part of the Quarkus Team. And I think last weekend we decided to do something crazy and I didn't want to do it around actually somebody didn't want to do it and therefore he made me the lead of that. And that's Max. Hello Max. How are you?
 
-**Max**: I sad, you should do it.
+**Max**: I said, you should do it.
 
 That's my...
 
@@ -158,7 +166,7 @@ And one of the issues is like open an extension request, and then you can ask fo
 
 http://www.youtube.com/watch?v=YKm8rVzLhNE&t=18m32s[18:32]:
 
-Okay, so last thing is... Go subscribe to actually... Let me go back to my Chrome here that you got to youtube.com/c/quarkusio You will land on a brand new, actually not a brand new, you already have quite a few set of videos. Some of them will be the Quarkus inception or the Quarkus inside sorry, others will be Q-Tips which are like five-minute videos about a given subject. So they are also quite interesting as well. And then there is other ones you can go on the playlist, but what's important? Go to YouTube.com/c/quarkusio and click the subscribe button and you will be notified of when we wanna do something will probably publish everywhere we can to Twitter on the Zulip and somewhere here, if we figure out to properly set up YouTube live.
+Okay, so last thing is... Go subscribe to actually... Let me go back to my Chrome here that you got to youtube.com/c/quarkusio You will land on a brand new, actually not a brand new, you already have quite a few set of videos. Some of them will be the Quarkus inception or the Quarkus Insights sorry, others will be Q-Tips which are like five-minute videos about a given subject. So they are also quite interesting as well. And then there is other ones you can go on the playlist, but what's important? Go to YouTube.com/c/quarkusio and click the subscribe button and you will be notified of when we wanna do something will probably publish everywhere we can to Twitter on the Zulip and somewhere here, if we figure out to properly set up YouTube live.
 
 http://www.youtube.com/watch?v=YKm8rVzLhNE&t=19m35s[19:35]:
 

--- a/_posts/insights_1_transcription.adoc
+++ b/_posts/insights_1_transcription.adoc
@@ -1,8 +1,17 @@
-**Emmanuel**: Quarkus Inside number one. Test.
+---
+layout: post
+title: 'Quarkus Insights #1 transcription: Test'
+date: 2020-05-07
+tags: insights
+author: ebarnard, maxandersen, geoand
+---
+
+
+**Emmanuel**: Quarkus Insights number one. Test.
 
 Well, Hello everyone. And we're cheap on the budget right now.
 
-Alright, so I'm not alone in this madness. Welcome to this new episode of Quarkus Inside. It's an official one, in the sense that it's not a meta subject. We're gonna have real conversations around test today and to have conversation here. I do have Max, my colegue and partner in crime, but also Georgios which has been a massive contributor to Quarkus, being left and right, so maybe Georgios, do you wanna introduce yourself?
+Alright, so I'm not alone in this madness. Welcome to this new episode of Quarkus Insights. It's an official one, in the sense that it's not a meta subject. We're gonna have real conversations around test today and to have conversation here. I do have Max, my colleague and partner in crime, but also Georgios which has been a massive contributor to Quarkus, being left and right, so maybe Georgios, do you wanna introduce yourself?
 
 **Georgios**: Yeah, thanks, thanks, you Emmanuel.
 
@@ -26,7 +35,7 @@ Yeah, so we need to do this. And over the weekend we had another thing: Tim Fox 
 
 What's yours Emmanuel?
 
-**Emmanuel**: To me it's like, "Spartakus" or it's Quarkus. But I'm Frensh so who knows.
+**Emmanuel**: To me it's like, "Spartakus" or it's Quarkus. But I'm French so who knows.
 
 **Georgios**: And I was on a, I say, Quarkus.
 


### PR DESCRIPTION
I spotted two old blogs with missing frontmatter. I think Jekyll silently ignores them, but Roq publishes them with today's date. Rather than deleting the files, I patched up the frontmatter, since they're kind of interesting, historically.