### PR TITLE
Revert "Add missing front matter to old Insights transcripts"

### DIFF
--- a/_posts/insights_0_transcription.adoc
+++ b/_posts/insights_0_transcription.adoc
@@ -1,10 +1,3 @@
----
-layout: post
-title: 'Quarkus Insights #0 transcription: Inception'
-date: 2020-04-20
-tags: insights
-author: ebarnard, maxandersen
----
 
 http://www.youtube.com/watch?v=YKm8rVzLhNE&t=00m03s[00:03]:
 

--- a/_posts/insights_1_transcription.adoc
+++ b/_posts/insights_1_transcription.adoc
@@ -1,11 +1,3 @@
----
-layout: post
-title: 'Quarkus Insights #1 transcription: Test'
-date: 2020-05-07
-tags: insights
-author: ebarnard, maxandersen, geoand
----
-
 
 **Emmanuel**: Quarkus Insights number one. Test.
 


### PR DESCRIPTION
This reverts commit 12b6e5a6b4ee072d776f6763a692480e91aba9fc.

Reverses #2690, which was fixing a problem that didn't exist. 
