### PR TITLE
Fix dead podman links

### DIFF
--- a/_versions/3.8/guides/podman.adoc
+++ b/_versions/3.8/guides/podman.adoc
@@ -22,14 +22,14 @@ The Homebrew package manager on Mac (*brew*) *should not be used to install Podm
 
 On Linux, Podman is integrated as part of the operating system, and installed through the system's packager manager. As with Mac, and Windows, Podman Desktop can also be installed to supplement the Podman CLI. However, on Linux, Podman Desktop acts as a client to the native Podman integration, and does not manage the underlying Podman installation.
 
-See https://podman-desktop.io/downloads/ for the latest version of Podman Desktop or pick the version that suits your operating system from the list below:
+See https://podman-desktop.io/downloads/ for the latest version of Podman Desktop or, for more detailed instructions, pick your operating system from the list below:
 
-- https://podman-desktop.io/macos/[MacOS]
-- https://podman-desktop.io/windows/[Windows]
-- https://podman-desktop.io/linux/[Linux]
+- https://podman-desktop.io/docs/installation/macos-install[MacOS]
+- https://podman-desktop.io/docs/installation/windows-install[Windows]
+- https://podman-desktop.io/docs/installation/linux-install[Linux]
 
 
-Additionally, if you are using Linux, see the Podman https://podman.io/docs/installation#installing-on-linux[Linux installation documentation] for instructions installing Podman to your specific Linux distribution.
+If you are using Linux, do see the Podman https://podman.io/docs/installation#installing-on-linux[Linux installation documentation] for instructions installing Podman to your specific Linux distribution.
 
 === Docker compatibility mode
 


### PR DESCRIPTION
Discovered while testing #2697.
Podman no longer have individual endpoints for platform installs, just one big landing page.