### PR TITLE
Remove dead Twitter profiles for phillipkruger and _Ladicek

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -234,7 +234,6 @@ phillipkruger:
   email: "phillip.kruger@redhat.com"
   emailhash: "c3e7539e1144f33342b9062ce5c0f728"
   job_title: "Engineer (Software)"
-  twitter: "phillipkruger"
   bio: "Works on SmallRye at Red Hat, Eclipse MicroProfile Committer"
 cescoffier:
   name: "Clement Escoffier"
@@ -466,7 +465,6 @@ lthon:
   email: "ladicek@gmail.com"
   emailhash: "238e8b2100a5366b226234b946026462"
   job_title: "Principal Software Engineer"
-  twitter: "_Ladicek"
   bio: "Books. Software. Imagination..."
 rtoyonag:
   name: "Robert Toyonaga"


### PR DESCRIPTION
@phillip-kruger and @Ladicek no longer have active twitter profiles, so we should remove those from their profile. 