### PR TITLE
Fix A2A contributor links: tsabau → tibisabau, unlink deleted luke-j-smith

### DIFF
--- a/_posts/2026-06-10-a2a-java-sdk-1-0-0-final-released.adoc
+++ b/_posts/2026-06-10-a2a-java-sdk-1-0-0-final-released.adoc
@@ -115,7 +115,7 @@ Here is a summary of the major changes. Each of our previous blog posts covers i
 
 The 1.0.0 series had 17 contributors across all pre-releases. Thank you all for your code, reviews, and feedback!
 
-https://github.com/brucearctor[@brucearctor], https://github.com/CharlieZhang1999[@CharlieZhang1999], https://github.com/dwieliczko[@dwieliczko], https://github.com/ehsavoie[@ehsavoie], https://github.com/HarshaRamesh11[@HarshaRamesh11], https://github.com/jmesnil[@jmesnil], https://github.com/kabir[@kabir], https://github.com/Lirons01[@Lirons01], https://github.com/LiZongbo[@LiZongbo], https://github.com/luke-j-smith[@luke-j-smith], https://github.com/maff[@maff], https://github.com/neo1027144-creator[@neo1027144-creator], https://github.com/pratik3558[@pratik3558], https://github.com/RainYuY[@RainYuY], https://github.com/sherryfox[@sherryfox], https://github.com/tsabau[@tsabau], https://github.com/yyy9942[@yyy9942]
+https://github.com/brucearctor[@brucearctor], https://github.com/CharlieZhang1999[@CharlieZhang1999], https://github.com/dwieliczko[@dwieliczko], https://github.com/ehsavoie[@ehsavoie], https://github.com/HarshaRamesh11[@HarshaRamesh11], https://github.com/jmesnil[@jmesnil], https://github.com/kabir[@kabir], https://github.com/Lirons01[@Lirons01], https://github.com/LiZongbo[@LiZongbo], @luke-j-smith, https://github.com/maff[@maff], https://github.com/neo1027144-creator[@neo1027144-creator], https://github.com/pratik3558[@pratik3558], https://github.com/RainYuY[@RainYuY], https://github.com/sherryfox[@sherryfox], https://github.com/tibisabau[@tibisabau], https://github.com/yyy9942[@yyy9942]
 
 == Resources
 


### PR DESCRIPTION
It looks like one user had a typo in their user name, and luke-j-smith shows in web archives as linking to a page for Luke Adams, but the user profile no longer exists.