### PR TITLE
Link checker selectiveness: run only on changed files on small PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,13 +118,83 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
 
+      - name: Determine link checker scope
+        id: link_scope
+        run: |
+          # If build infrastructure or the link checker itself changed, run a full check
+          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            INFRA_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- \
+              .github/workflows/build.yml \
+              pom.xml \
+              src/test/java/ 2>/dev/null || true)
+          else
+            INFRA_CHANGED="not-a-pr"
+          fi
+
+          if [ -n "$INFRA_CHANGED" ]; then
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "Infrastructure files changed, running full link check"
+            exit 0
+          fi
+
+          # Compare the built site to what is currently deployed on gh-pages
+          git fetch origin gh-pages 2>/dev/null || {
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "Could not fetch gh-pages, running full link check"
+            exit 0
+          }
+
+          git worktree add --detach /tmp/gh-pages origin/gh-pages 2>/dev/null || {
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "Could not check out gh-pages, running full link check"
+            exit 0
+          }
+
+          RSYNC_OUT=$(rsync -rcn --out-format='%n' \
+            --include='*/' --include='*.html' --exclude='*' \
+            _site/ /tmp/gh-pages/ 2>/dev/null) || {
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "Site comparison failed, running full link check"
+            git worktree remove /tmp/gh-pages 2>/dev/null || true
+            exit 0
+          }
+
+          CHANGED=$(echo "$RSYNC_OUT" | grep '\.html$' || true)
+
+          git worktree remove /tmp/gh-pages 2>/dev/null || true
+
+          if [ -z "$CHANGED" ]; then
+            echo "mode=skip" >> $GITHUB_OUTPUT
+            echo "No HTML files changed, skipping link crawl"
+            exit 0
+          fi
+
+          COUNT=$(echo "$CHANGED" | wc -l | tr -d ' ')
+          echo "$COUNT changed HTML file(s)"
+
+          if [ "$COUNT" -gt 15 ]; then
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "More than 15 files changed, running full link check"
+          else
+            PATHS=$(echo "$CHANGED" | sed 's|index\.html$||; s|^|/|' | tr '\n' ',' | sed 's/,$//')
+            echo "mode=partial" >> $GITHUB_OUTPUT
+            echo "paths=$PATHS" >> $GITHUB_OUTPUT
+            echo "Targeted check: $PATHS"
+          fi
+
       # Versioned guides (2.x-5.x) are excluded from this build by
       # _only_latest_guides_config.yml, so skip crawling those paths.
       - name: Run link crawler
-        run: >-
-          mvn -B test -Pe2e -Dtest.url=http://localhost:8090
-          -Dtest.crawl.check-external=false
-          -Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main/guides/doc-reference
+        if: steps.link_scope.outputs.mode != 'skip'
+        run: |
+          CHANGED_PATHS_ARG=""
+          if [ "${{ steps.link_scope.outputs.mode }}" = "partial" ]; then
+            CHANGED_PATHS_ARG="-Dtest.crawl.changed-paths=${{ steps.link_scope.outputs.paths }}"
+          fi
+          mvn -B test -Pe2e -Dtest.url=http://localhost:8090 \
+            -Dtest.crawl.check-external=false \
+            -Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main/guides/doc-reference \
+            $CHANGED_PATHS_ARG
         env:
           PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
 

--- a/src/test/java/io/quarkusio/LinkCrawlerTest.java
+++ b/src/test/java/io/quarkusio/LinkCrawlerTest.java
@@ -59,6 +59,7 @@ public class LinkCrawlerTest extends BrowserTest {
         boolean checkInternal = Boolean.parseBoolean(System.getProperty("test.crawl.check-internal", "true"));
         boolean checkExternal = Boolean.parseBoolean(System.getProperty("test.crawl.check-external", "false"));
         List<String> excludePaths = parseExcludePaths(System.getProperty("test.crawl.exclude-paths", ""));
+        List<String> changedPaths = parseExcludePaths(System.getProperty("test.crawl.changed-paths", ""));
 
         Set<String> visited = ConcurrentHashMap.newKeySet();
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
@@ -67,7 +68,17 @@ public class LinkCrawlerTest extends BrowserTest {
         Set<String> checkedExternal = ConcurrentHashMap.newKeySet();
         AtomicInteger crawledCount = new AtomicInteger();
 
-        queue.add(normalize(baseUrl + "/"));
+        Set<String> seedUrls = ConcurrentHashMap.newKeySet();
+        if (!changedPaths.isEmpty()) {
+            System.out.println("Incremental mode: checking " + changedPaths.size() + " changed page(s)");
+            for (String path : changedPaths) {
+                String url = normalize(baseUrl + path);
+                seedUrls.add(url);
+                queue.add(url);
+            }
+        } else {
+            queue.add(normalize(baseUrl + "/"));
+        }
 
         ExecutorService executor = Executors.newFixedThreadPool(threads);
         for (int i = 0; i < threads; i++) {
@@ -81,7 +92,7 @@ public class LinkCrawlerTest extends BrowserTest {
                     p.setDefaultNavigationTimeout(30_000);
 
                     crawLoop(p, queue, visited, broken, foundOn, checkedExternal,
-                            crawledCount, maxPages, checkInternal, checkExternal, excludePaths);
+                            crawledCount, maxPages, checkInternal, checkExternal, excludePaths, seedUrls);
 
                     ctx.close();
                     br.close();
@@ -114,7 +125,9 @@ public class LinkCrawlerTest extends BrowserTest {
                            int maxPages,
                            boolean checkInternal,
                            boolean checkExternal,
-                           List<String> excludePaths) {
+                           List<String> excludePaths,
+                           Set<String> seedUrls) {
+        boolean incrementalMode = !seedUrls.isEmpty();
         int idlePolls = 0;
         while (idlePolls < 3) {
             if (crawledCount.get() >= maxPages) {
@@ -174,6 +187,13 @@ public class LinkCrawlerTest extends BrowserTest {
                 if (checkInternal) {
                     broken.put(currentUrl, new BrokenLink(status, response.statusText(), foundOn.get(currentUrl)));
                 }
+                continue;
+            }
+
+            // In incremental mode, only extract links from seed pages (the
+            // changed pages). Non-seed pages are visited only to verify their
+            // status — a depth-1 check from each changed page.
+            if (incrementalMode && !seedUrls.contains(currentUrl)) {
                 continue;
             }
 


### PR DESCRIPTION
This is the promised follow-on to #2685 to reduce the build-time impact. It only checks changed files for internal dead links. This does introduce a gap where if a file is moved, any files that reference that file wouldn't be checked, so build would be green. However, the external link checker (#2697) would pick that up on its scheduled runs and raise a defect. I think the trade-off is worth it for the improved build speed. 

If someone has a PR which is lagging way behind `main`, they'll also get a slow build, but I think we can live with that. 

Here's the logic:

- Compares the built `_site/` against the `gh-pages` branch (the deployed site) using `rsync` to find changed HTML files (using a git diff would pick up adoc changes instead, and we'd have to map from them to the html)
- When ≤15 HTML files changed and no infrastructure files (`build.yml`, `pom.xml`, `src/test/java/`) were modified, runs the link crawler only on the changed pages with a depth-1 check (verifies outbound links from those pages)
- Falls back to a full crawl when >15 files changed, infrastructure changed, or gh-pages comparison fails
- Skips the link crawl entirely when no HTML files changed

In this PR, we can always trigger the 'full' scenario so can only exercise the 'full' paths, but I've tried my best to test the others locally. I'll also keep an eye on PRs that go in after this merges to try to validate the scope detection is working as expected. 

## Attempts at testing it
- [x] Ran incremental mode against quarkus.io with 2 paths (`/blog/`, `/about/`) — crawled 217 pages (depth-1) vs thousands for a full crawl, 0 broken links
- [x] Tested scope determination script locally: Claude claims it correctly detects changed files, skips unchanged files, converts paths to URLs
- [x] Tested no-changes edge case: correctly produces mode=skip
