### PR TITLE
Fix dead links for amazon lambda and GCP

### DIFF
--- a/_posts/2019-10-30-quarkus-0-27-0-released.adoc
+++ b/_posts/2019-10-30-quarkus-0-27-0-released.adoc
@@ -22,7 +22,7 @@ We were hard at work to get the Amazon Lambda features on par with the Azure Fun
 
 And... we also added native support!
 
-Learn more about all this in our new guides for link:/guides/amazon-lambda[Amazon Lambda] and link:/guides/amazon-lambda-http[Amazon Lambda with Vert.x Web, Servlet, or RESTEasy].
+Learn more about all this in our new guides for link:/guides/amazon-lambda[Amazon Lambda] and link:/guides/aws-lambda-http[Amazon Lambda with Vert.x Web, Servlet, or RESTEasy].
 
 === Dev mode detects pom.xml changes
 

--- a/_posts/2020-04-27-quarkus-1-4-final-released.adoc
+++ b/_posts/2020-04-27-quarkus-1-4-final-released.adoc
@@ -59,7 +59,7 @@ We improved a lot on the function front (namely AWS Lambdas and Azure Functions)
 A blog post will soon explain everything you need to know about Funky but in the meantime, you can refer to the updated documentation:
 
  * link:/guides/amazon-lambda[Amazon Lambda]
- * link:/guides/amazon-lambda-http[Amazon Lambda with RESTEasy, Undertow, or Vert.x Web]
+ * link:/guides/aws-lambda-http[Amazon Lambda with RESTEasy, Undertow, or Vert.x Web]
  * link:/guides/azure-functions-http[Azure Functions (Serverless) with RESTEasy, Undertow, or Vert.x Web]
 
 === Improvements around mocking

--- a/_posts/2020-07-08-quarkus-1-6-0-final-released.adoc
+++ b/_posts/2020-07-08-quarkus-1-6-0-final-released.adoc
@@ -77,7 +77,7 @@ Of course, you can still configure it via `quarkus.http.limits.max-body-size`.
 
 Quarkus now support serverless on all the major cloud providers with the addition of the support for Google Cloud Functions.
 
-Eager to discover more about it, we have two new guides for you either if you want to link:/guides/gcp-functions[develop a simple function] or link:gcp-functions-http[use HTTP].
+Eager to discover more about it, we have two new guides for you either if you want to link:/guides/gcp-functions[develop a simple function] or link:/guides/gcp-functions-http[use HTTP].
 
 ==== Reactive IBM Db2 client
 


### PR DESCRIPTION
These are all in ancient blog posts.