### PR TITLE
Retry navigation once on timeout in link crawler

### DIFF
--- a/src/test/java/io/quarkusio/LinkCrawlerTest.java
+++ b/src/test/java/io/quarkusio/LinkCrawlerTest.java
@@ -78,7 +78,7 @@ public class LinkCrawlerTest extends BrowserTest {
                     BrowserContext ctx = br.newContext();
                     ctx.route("**/*.{css,png,jpg,jpeg,gif,svg,ico,woff,woff2,ttf,eot}", Route::abort);
                     Page p = ctx.newPage();
-                    p.setDefaultNavigationTimeout(30_000);
+                    p.setDefaultNavigationTimeout(60_000);
 
                     crawLoop(p, queue, visited, broken, foundOn, checkedExternal,
                             crawledCount, maxPages, checkInternal, checkExternal, excludePaths);
@@ -139,27 +139,14 @@ public class LinkCrawlerTest extends BrowserTest {
             }
             crawledCount.incrementAndGet();
 
-            Response response;
-            try {
-                response = p.navigate(currentUrl,
-                        new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
-            } catch (Exception e) {
+            Response response = navigateWithRetry(p, currentUrl);
+            if (response == null) {
                 try {
                     if (!currentUrl.equals(normalize(p.url()))) {
                         continue;
                     }
                 } catch (Exception ignored) {
                 }
-                if (checkInternal) {
-                    BrokenLink probe = probeWithHttp(currentUrl);
-                    if (probe != null) {
-                        broken.put(currentUrl, new BrokenLink(probe.status, probe.statusText, foundOn.get(currentUrl)));
-                    }
-                }
-                continue;
-            }
-
-            if (response == null) {
                 if (checkInternal) {
                     BrokenLink probe = probeWithHttp(currentUrl);
                     if (probe != null) {
@@ -220,6 +207,21 @@ public class LinkCrawlerTest extends BrowserTest {
                 }
             }
         }
+    }
+
+    private static Response navigateWithRetry(Page p, String url) {
+        for (int attempt = 0; attempt < 2; attempt++) {
+            try {
+                Response response = p.navigate(url,
+                        new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
+                return response;
+            } catch (Exception e) {
+                if (attempt == 0) {
+                    continue;
+                }
+            }
+        }
+        return null;
     }
 
     private ResolvedLink resolveLink(String currentPageUrl, String href) {


### PR DESCRIPTION
This is a fix for an intermittent issue we're seeing in tests, navigating to `security-ldap` (linked from /guides). This is a 75KB guide page (whoomp!). It times out intermittently under load; 8 concurrent Playwright
  threads rendering heavy AsciiDoc pages can exhaust the 30-second navigation timeout. 

Under concurrent load (8 Playwright threads rendering heavy AsciiDoc guide pages), individual page navigations can intermittently exceed the 30-second timeout. I've updated it to retry the navigation once before marking the link as broken, and I also bumped the timeout to 60s. Since we have multiple threads, that occasional wait on IO shouldn't delay things too much. 


