### PR TITLE
Fix deploy failures caused by incorrect Roq guards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,17 +57,17 @@ jobs:
         if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: bundle exec jekyll build
 
-      - name: Check for Maven project
-        id: check_maven
+      - name: Check for Roq project
+        id: check_roq
         run: |
-          if [ -f "pom.xml" ]; then
-            echo "maven_exists=true" >> $GITHUB_OUTPUT
+          if [ -f "src/main" ]; then
+            echo "roq_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "maven_exists=false" >> $GITHUB_OUTPUT
+            echo "roq_exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up JDK
-        if: steps.check_maven.outputs.maven_exists == 'true'
+        if: steps.check_roq.outputs.roq_exists == 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
@@ -75,7 +75,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        if: steps.check_maven.outputs.maven_exists == 'true'
+        if: steps.check_roq.outputs.roq_exists == 'true'
         run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run
 
       - name: Upload Pages artifact


### PR DESCRIPTION
As part of my parallel-workstreams-merge-dance, PR #2684 updated build.yml to check for src/main (Roq project) instead of pom.xml, but I missed deploy.yml. It still assumed there were no e2e tests, which was a correct assumption when I wrote the PR, but not when it merged. The deploy problem doesn't show up in PRs, but it does show up in deploys from main. Oooops. 

The test-only pom.xml (for Playwright E2E tests) was triggering the Quarkus Maven build, which fails because there is no Quarkus plugin declared.

I'm also seeing fragility with the link checks that I didn't see on my initial PRs, which might make this CI red. (Why does it work like that? WIP, nice and green in CI, then post-merge, sea of red?!) I've cooked some fixes for the issues, but because there's two problems, neither branch is clean. Still working on piecing that together. 
