### PR TITLE
Add page title sense check tests

### DIFF
--- a/src/test/java/io/quarkusio/SmokePageTest.java
+++ b/src/test/java/io/quarkusio/SmokePageTest.java
@@ -30,6 +30,31 @@ public class SmokePageTest extends BrowserTest {
                 "Expected 200 for " + path + " but got " + response.status());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/",
+            "/about/",
+            "/blog/",
+            "/guides/",
+            "/get-started/",
+            "/support/"
+    })
+    void criticalPageHasValidTitle(String path) {
+        page.navigate(baseUrl + path);
+        String title = page.title();
+        assertFalse(title == null || title.isBlank(),
+                "Page title should not be null or empty for " + path);
+        String lowerTitle = title.toLowerCase();
+        assertFalse(lowerTitle.contains("undefined"),
+                "Page title should not contain 'undefined' for " + path + ", got: " + title);
+        assertFalse(lowerTitle.contains("null"),
+                "Page title should not contain 'null' for " + path + ", got: " + title);
+        assertFalse(lowerTitle.contains("error"),
+                "Page title should not contain 'error' for " + path + ", got: " + title);
+        assertFalse(lowerTitle.contains("exception"),
+                "Page title should not contain 'Exception' for " + path + ", got: " + title);
+    }
+
     @Test
     void notFoundPageReturns404() {
         Response response = page.navigate(baseUrl + "/this-path-does-not-exist-xyz/");


### PR DESCRIPTION
This only tests a subset, but that's probably ok. If we think it's not, I could add it to the crawler as a validation. 