### PR TITLE
CI: add build report to job summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,28 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
 
+      - name: Test report
+        if: always()
+        run: |
+          {
+            echo "### Test Results"
+            echo ""
+            echo "| Suite | Tests | Passed | Failed | Skipped | Time |"
+            echo "|-------|------:|-------:|-------:|--------:|-----:|"
+            for f in target/surefire-reports/TEST-*.xml; do
+              [ -f "$f" ] || continue
+              suite=$(sed -n 's/.*name="\([^"]*\).*/\1/p' "$f" | head -1)
+              tests=$(sed -n 's/.*tests="\([^"]*\).*/\1/p' "$f" | head -1)
+              fail=$(sed -n 's/.*failures="\([^"]*\).*/\1/p' "$f" | head -1)
+              err=$(sed -n 's/.*errors="\([^"]*\).*/\1/p' "$f" | head -1)
+              skip=$(sed -n 's/.*skipped="\([^"]*\).*/\1/p' "$f" | head -1)
+              time=$(sed -n 's/.*time="\([^"]*\).*/\1/p' "$f" | head -1)
+              pass=$((tests - ${fail:-0} - ${err:-0} - ${skip:-0}))
+              icon=$( [ "${fail:-0}" -gt 0 ] || [ "${err:-0}" -gt 0 ] && echo ":x:" || echo ":white_check_mark:" )
+              echo "| ${icon} ${suite##*.} | $tests | $pass | $((${fail:-0} + ${err:-0})) | ${skip:-0} | ${time}s |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Store PR id
         run: echo ${{ github.event.number }} > ./_site/pr-id.txt
 


### PR DESCRIPTION
Now that we have tests, it's nice to get a summary of them in the CI status. I used the quarkusio/action-build-reporter to parse the Surefire XML test results and render them.
