### PR TITLE
Trivial: Add in missing guard for starting the test server in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,8 @@ jobs:
 
       # Jekyll serve handles extensionless URLs (e.g. /guides/getting-started)
       # the same way GitHub Pages does; a plain HTTP server would 404 on them.
-      - name: Start test server
+      - name: Start Jekyll test server
+        if: steps.check_jekyll.outputs.jekyll_exists == 'true'
         run: |
           bundle exec jekyll serve --port 8090 --no-watch --skip-initial-build &
           timeout 30 bash -c 'until curl -s http://localhost:8090 > /dev/null 2>&1; do sleep 0.5; done'


### PR DESCRIPTION
Missed this when I added the other guards.