### PR TITLE
Add test for partial variable scoping via CSP meta tag

### DIFF
--- a/src/test/java/io/quarkusio/PartialVariableScopingTest.java
+++ b/src/test/java/io/quarkusio/PartialVariableScopingTest.java
@@ -1,0 +1,26 @@
+package io.quarkusio;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PartialVariableScopingTest extends BrowserTest {
+
+    @Test
+    void contentSecurityPolicyHasDirectives() {
+        page.navigate(baseUrl + "/");
+        String csp = page.locator("meta[http-equiv='Content-Security-Policy']").getAttribute("content");
+        assertNotNull(csp, "Expected a Content-Security-Policy meta tag");
+        assertTrue(csp.contains("script-src"),
+                "CSP should contain a script-src directive but was: " + csp);
+    }
+
+    @Test
+    void contentSecurityPolicyIsNotEmpty() {
+        page.navigate(baseUrl + "/");
+        String csp = page.locator("meta[http-equiv='Content-Security-Policy']").getAttribute("content");
+        assertNotNull(csp, "Expected a Content-Security-Policy meta tag");
+        assertTrue(csp.trim().length() > 20,
+                "CSP meta tag appears to be empty or truncated: " + csp);
+    }
+}


### PR DESCRIPTION
This is a bit of a niche thing, but we'd never think to check it manually, and it could break. Verify the Content-Security-Policy meta tag contains directives, catching cases where partial variable scoping silently swallows values via or-empty workarounds.

