### PR TITLE
Do not use forward reference for variable in scss

### DIFF
--- a/_sass/project-colors.scss
+++ b/_sass/project-colors.scss
@@ -8,6 +8,7 @@ $dark-blue-1: #205894;
 $orange: #F18F01;
 $green: #6AB443;
 $purple: #6622CC;
+$red: #FF004A;
 
 // Overwrites link colors in /core/colors.scss
 $link: #1259A5;
@@ -22,4 +23,3 @@ $cta-hover: $link-hover;
 $nav-cta-hover: #1259a5;
 
 $light-blue: #e4edf7;
-$red: #FF004A;


### PR DESCRIPTION
This scss compiles ok in Jekyll, but not in Roq. I assumed it was a Roq problem, but on closer inspection, I think it's that we're mildly violating the scss spec. Old Jekyll lets us get away with it, but more modern Jekyll wouldn't, and neither does Roq. 

> The file compiles in Jekyll but not in Dart Sass due to different compilation strategies:
> Jekyll (Ruby Sass/LibSass):
> * Uses a multi-pass compilation approach
> * First pass: Scans entire file and collects all variable definitions
> * Second pass: Resolves variable references
> * This allows forward references to work because all variables are known before resolution
> Dart Sass (Modern Standard):
> * Uses single-pass compilation (top-to-bottom)
> * Variables must be defined before use
> * More strict and follows the official SASS specification
> * This is the current standard and recommended implementation
> Why the change matters:
> * Ruby Sass was deprecated in 2019
> * LibSass (used by older Jekyll) is also deprecated
> * Dart Sass is now the primary, canonical implementation
> * Jekyll is transitioning to Dart Sass in newer versions
> Best practice: Define variables before using them to ensure compatibility with modern SASS compilers and future Jekyll versions. The forward reference works now but is technically non-standard and will break when Jekyll fully migrates to Dart Sass.
