### PR TITLE
Use a variable for location of static assets in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,14 @@ jobs:
           if [ -f "Gemfile" ]; then
             echo "jekyll=true" >> $GITHUB_OUTPUT
             echo "site_dir=_site" >> $GITHUB_OUTPUT
+            echo "statics_dir=." >> $GITHUB_OUTPUT
           else
             echo "jekyll=false" >> $GITHUB_OUTPUT
           fi
           if [ -d "src/main" ]; then
             echo "roq=true" >> $GITHUB_OUTPUT
             echo "site_dir=target/roq" >> $GITHUB_OUTPUT
+            echo "statics_dir=public" >> $GITHUB_OUTPUT
           else
             echo "roq=false" >> $GITHUB_OUTPUT
           fi
@@ -212,8 +214,9 @@ jobs:
       - name: Reduce the size of the website to be compatible with surge
         run: |
           SITE_DIR="${{ steps.detect.outputs.site_dir }}"
-          find assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
-          find newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
+          STATICS_DIR="${{ steps.detect.outputs.statics_dir }}"
+          find "$STATICS_DIR"/assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
+          find "$STATICS_DIR"/newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
           rm -rf "$SITE_DIR"/assets/stickers
           rm -rf "$SITE_DIR"/assets/images/worldtour/2023
           rm -rf "$SITE_DIR"/assets/images/worldtour/2024

--- a/_sass/includes/image-pageheader.scss
+++ b/_sass/includes/image-pageheader.scss
@@ -1,5 +1,5 @@
 .image-header-centered {
-  background-image: url(/assets/images/1kcontributors/header_1kcontributors.png);
+  background-image: url($baseurl + '/assets/images/1kcontributors/header_1kcontributors.png');
   background-position: center center;
   background-repeat: no-repeat;
   background-color: $black;

--- a/_sass/layouts/documentation.scss
+++ b/_sass/layouts/documentation.scss
@@ -252,7 +252,7 @@ Styles for the documentation index page
     &.quarkiverse .origin:before {
       display: inline-flex;
       content: '';
-      background-image: url('/assets/images/quarkiverse_icon_default.svg');
+      background-image: url($baseurl + '/assets/images/quarkiverse_icon_default.svg');
       background-size: 25px 25px;
       height: 25px;
       width: 25px;


### PR DESCRIPTION
More adaptation of the build.yml to tolerate building both roq and jekyll (at the expense of extra verbosity, sadly). This is the version of build.yml that's successfully building the roq preview at https://quarkus-website-pr-2683-preview.surge.sh/ (with other code changes of course). 

As part of this change, I also homogenised the urls in background-images. Two were missing the $baseurl prefix. To be honest, I'm not totally sure if the prefix is adding anything, but we should do that research and make that decision at a site level, so in the meantime I've just gone for consistency. 

Note that the preview for *this* PR is https://quarkus-website-pr-2740-preview.surge.sh/ 