### PR TITLE
Raise link checker scope threshold to 200 and log directory breakdown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,10 +179,11 @@ jobs:
 
           COUNT=$(echo "$CHANGED" | wc -l | tr -d ' ')
           echo "$COUNT changed HTML file(s)"
+          echo "$CHANGED" | sed 's|/[^/]*$||' | sort | uniq -c | sort -rn | head -20
 
-          if [ "$COUNT" -gt 15 ]; then
+          if [ "$COUNT" -gt 200 ]; then
             echo "mode=full" >> $GITHUB_OUTPUT
-            echo "More than 15 files changed, running full link check"
+            echo "More than 200 files changed, running full link check"
           else
             PATHS=$(echo "$CHANGED" | sed 's|index\.html$||; s|^|/|' | tr '\n' ',' | sed 's/,$//')
             echo "mode=partial" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Despite my 'fix', the link checker is still checking the whole site on all changes, even if they just add one blog. Slooooow. 

I can't figure out quite what's wrong, but I can do two things: 
- The previous threshold of 15 was too low because adding a single blog post changes ~70+ paginated listing pages. There's very little harm in listing those longer numbers of pages and passing them to the crawler, as long as it's not huuuuge. 
- Since I don't know why the delta is bigger than expected, I have added directory breakdown logging will help diagnose what's actually changing.

