### PR TITLE
Remove $baseurl template preprocessing from SCSS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,14 @@ jobs:
           if [ -f "Gemfile" ]; then
             echo "jekyll=true" >> $GITHUB_OUTPUT
             echo "site_dir=_site" >> $GITHUB_OUTPUT
+            echo "statics_dir=." >> $GITHUB_OUTPUT
           else
             echo "jekyll=false" >> $GITHUB_OUTPUT
           fi
           if [ -d "src/main" ]; then
             echo "roq=true" >> $GITHUB_OUTPUT
             echo "site_dir=target/roq" >> $GITHUB_OUTPUT
+            echo "statics_dir=public" >> $GITHUB_OUTPUT
           else
             echo "roq=false" >> $GITHUB_OUTPUT
           fi
@@ -212,8 +214,9 @@ jobs:
       - name: Reduce the size of the website to be compatible with surge
         run: |
           SITE_DIR="${{ steps.detect.outputs.site_dir }}"
-          find assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
-          find newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
+          STATICS_DIR="${{ steps.detect.outputs.statics_dir }}"
+          find "$STATICS_DIR"/assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
+          find "$STATICS_DIR"/newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
           rm -rf "$SITE_DIR"/assets/stickers
           rm -rf "$SITE_DIR"/assets/images/worldtour/2023
           rm -rf "$SITE_DIR"/assets/images/worldtour/2024

--- a/_sass/colormode.scss
+++ b/_sass/colormode.scss
@@ -114,19 +114,19 @@ html.dark {
 
     &:before {
       &.tutorial {
-        background: url($baseurl + '/assets/images/documentation/docsicon-tutorials-dark.svg') no-repeat !important; }
+        background: url('/assets/images/documentation/docsicon-tutorials-dark.svg') no-repeat !important; }
 
       &.guide, &.howto {
-        background: url($baseurl + '/assets/images/documentation/docsicon-guides-dark.svg') no-repeat !important; }
+        background: url('/assets/images/documentation/docsicon-guides-dark.svg') no-repeat !important; }
 
       &.concepts {
-        background: url($baseurl + '/assets/images/documentation/docsicon-concepts-dark.svg') no-repeat !important; }
+        background: url('/assets/images/documentation/docsicon-concepts-dark.svg') no-repeat !important; }
 
       &.pdf {
-        background: url($baseurl + '/assets/images/documentation/docsicon-pdf-dark.svg') no-repeat !important; }
+        background: url('/assets/images/documentation/docsicon-pdf-dark.svg') no-repeat !important; }
 
       &.reference {
-        background: url($baseurl + '/assets/images/documentation/docsicon-referencedocs-dark.svg') no-repeat !important; }
+        background: url('/assets/images/documentation/docsicon-referencedocs-dark.svg') no-repeat !important; }
     }
   }
 }

--- a/_sass/includes/image-pageheader.scss
+++ b/_sass/includes/image-pageheader.scss
@@ -1,5 +1,5 @@
 .image-header-centered {
-  background-image: url($baseurl + '/assets/images/1kcontributors/header_1kcontributors.png');
+  background-image: url('/assets/images/1kcontributors/header_1kcontributors.png');
   background-position: center center;
   background-repeat: no-repeat;
   background-color: $black;

--- a/_sass/includes/image-pageheader.scss
+++ b/_sass/includes/image-pageheader.scss
@@ -1,5 +1,5 @@
 .image-header-centered {
-  background-image: url(/assets/images/1kcontributors/header_1kcontributors.png);
+  background-image: url($baseurl + '/assets/images/1kcontributors/header_1kcontributors.png');
   background-position: center center;
   background-repeat: no-repeat;
   background-color: $black;

--- a/_sass/includes/project-footer.scss
+++ b/_sass/includes/project-footer.scss
@@ -5,7 +5,7 @@
   a { color: $link-dark-bg; }
 
   @media screen and (min-width: 1024px) {
-    background-image: url($baseurl + '/assets/images/bg-footer.png');
+    background-image: url('/assets/images/bg-footer.png');
     background-repeat: no-repeat;
     background-size: cover;
     }

--- a/_sass/includes/spring-page.scss
+++ b/_sass/includes/spring-page.scss
@@ -2,7 +2,7 @@
     @extend .full-width-bg;
     @extend .component;
     @extend .alt-background;
-    background: url($baseurl + '/assets/images/spring/bg-titlespring.jpg') repeat-x !important;
+    background: url('/assets/images/spring/bg-titlespring.jpg') repeat-x !important;
     position: relative;
     padding-bottom: 3rem;
 

--- a/_sass/includes/whitecards.scss
+++ b/_sass/includes/whitecards.scss
@@ -192,7 +192,7 @@ grid-column: span 3;
 }
 
 .event-callout {
-  background-image: url($baseurl + '/assets/images/events/speakerbkg.png');
+  background-image: url('/assets/images/events/speakerbkg.png');
   background-repeat: no-repeat;
   background-size: cover;
   outline: 1px solid var(--card-outline);

--- a/_sass/layouts/documentation.scss
+++ b/_sass/layouts/documentation.scss
@@ -252,7 +252,7 @@ Styles for the documentation index page
     &.quarkiverse .origin:before {
       display: inline-flex;
       content: '';
-      background-image: url($baseurl + '/assets/images/quarkiverse_icon_default.svg');
+      background-image: url('/assets/images/quarkiverse_icon_default.svg');
       background-size: 25px 25px;
       height: 25px;
       width: 25px;
@@ -268,61 +268,61 @@ Styles for the documentation index page
   }
 
   .tutorialbkg {
-    background: url($baseurl + '/assets/images/documentation/docsicon-tutorials.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-tutorials.svg') no-repeat;
     background-size: 80px 80px;
 
     @media (prefers-color-scheme: dark) {
-    background: url($baseurl + '/assets/images/documentation/docsicon-tutorials-dark.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-tutorials-dark.svg') no-repeat;
     background-size: 80px 80px;
     }
   }
 
   .guidebkg {
-    background: url($baseurl + '/assets/images/documentation/docsicon-referencedocs.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-referencedocs.svg') no-repeat;
     background-size: 80px 80px;
 
     @media (prefers-color-scheme: dark) {
-    background: url($baseurl + '/assets/images/documentation/docsicon-referencedocs-dark.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-referencedocs-dark.svg') no-repeat;
     background-size: 80px 80px;
     }
   }
 
   .howtobkg {
-    background: url($baseurl + '/assets/images/documentation/docsicon-guides.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-guides.svg') no-repeat;
     background-size: 80px 80px;
 
     @media (prefers-color-scheme: dark) {
-    background: url($baseurl + '/assets/images/documentation/docsicon-guides-dark.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-guides-dark.svg') no-repeat;
     background-size: 80px 80px;
     }
   }
 
   .conceptsbkg {
-    background: url($baseurl + '/assets/images/documentation/docsicon-concepts.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-concepts.svg') no-repeat;
     background-size: 80px 80px;
 
     @media (prefers-color-scheme: dark) {
-    background: url($baseurl + '/assets/images/documentation/docsicon-concepts-dark.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-concepts-dark.svg') no-repeat;
     background-size: 80px 80px;
     }
   }
 
   .pdfbkg {
-    background: url($baseurl + '/assets/images/documentation/docsicon-pdf.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-pdf.svg') no-repeat;
     background-size: 80px 80px;
 
     @media (prefers-color-scheme: dark) {
-    background: url($baseurl + '/assets/images/documentation/docsicon-pdf-dark.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-pdf-dark.svg') no-repeat;
     background-size: 80px 80px;
     }
   }
 
   .referencebkg {
-    background: url($baseurl + '/assets/images/documentation/docsicon-referencedocs.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-referencedocs.svg') no-repeat;
     background-size: 80px 80px;
 
     @media (prefers-color-scheme: dark) {
-    background: url($baseurl + '/assets/images/documentation/docsicon-referencedocs-dark.svg') no-repeat;
+    background: url('/assets/images/documentation/docsicon-referencedocs-dark.svg') no-repeat;
     background-size: 80px 80px;
     }
   }

--- a/_sass/layouts/documentation.scss
+++ b/_sass/layouts/documentation.scss
@@ -252,7 +252,7 @@ Styles for the documentation index page
     &.quarkiverse .origin:before {
       display: inline-flex;
       content: '';
-      background-image: url('/assets/images/quarkiverse_icon_default.svg');
+      background-image: url($baseurl + '/assets/images/quarkiverse_icon_default.svg');
       background-size: 25px 25px;
       height: 25px;
       width: 25px;

--- a/_sass/layouts/guide.scss
+++ b/_sass/layouts/guide.scss
@@ -78,23 +78,23 @@ body.guides-configuration-reference div.guides-configuration-reference {
       margin-right: 0.7rem;
 
       &.tutorial {
-        background: url($baseurl + '/assets/images/documentation/docsicon-tutorials.svg') no-repeat;
+        background: url('/assets/images/documentation/docsicon-tutorials.svg') no-repeat;
       }
 
       &.guide, &.howto {
-        background: url($baseurl + '/assets/images/documentation/docsicon-guides.svg') no-repeat;
+        background: url('/assets/images/documentation/docsicon-guides.svg') no-repeat;
       }
 
       &.concepts {
-        background: url($baseurl + '/assets/images/documentation/docsicon-concepts.svg') no-repeat;
+        background: url('/assets/images/documentation/docsicon-concepts.svg') no-repeat;
       }
 
       &.pdf {
-        background: url($baseurl + '/assets/images/documentation/docsicon-pdf.svg') no-repeat;
+        background: url('/assets/images/documentation/docsicon-pdf.svg') no-repeat;
       }
 
       &.reference {
-        background: url($baseurl + '/assets/images/documentation/docsicon-referencedocs.svg') no-repeat;
+        background: url('/assets/images/documentation/docsicon-referencedocs.svg') no-repeat;
       }
     }
   }

--- a/_sass/layouts/home.scss
+++ b/_sass/layouts/home.scss
@@ -4,7 +4,7 @@
 
 .homepage {
 
-  background-image: url($baseurl + '/assets/images/bg-home-primary.png');
+  background-image: url('/assets/images/bg-home-primary.png');
   background-repeat: repeat-x;
   
   p {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -3,8 +3,6 @@
 # only Main files contain this front matter, not partials.
 ---
 
-$baseurl: "{{ site.baseurl }}";
-
 @import "core/global";
 @import "core/grid";
 @import "core/colors";


### PR DESCRIPTION
This is one of the first things where I've been unable to come up with a roq alternative for something done in Jekyll. Jekyll uses template processing to inject a value into a stylesheet, and then uses that injected value in a variable used elsewhere in css. The value is $baseurl, a path prefix. It would be useful if quarkus.io was hosted in a sub-path of another site, like commhaus.org/quarkus. But we don't have that requirement, and are unlikely to do so, so I think we can reduce complexity by just ditching the $baseurl. 

If we don't want to do that, the other option is to use a maven step or a `sed` in a CI step to edit the css and put in the blank path prefix for $baseurl, but that seems like a lot of complexity for very little gain. 

This PR:

- Removes the `$baseurl` SCSS variable that was injected via Jekyll Liquid preprocessing (`$baseurl: "{{ site.baseurl }}"`)
- Replaces all `url($baseurl + '/assets/...')` with plain `url('/assets/...')` across 8 SCSS files

Builds on #2740, so should be reviewed and merged after that one. .

We need check these pages on the preview to verify background images render correctly:
- [ ] **Homepage** (`/`) — hero section background image (`bg-home-primary.png`)
- [ ] **Guides index** (`/guides/`) — category icons (tutorials, how-to, concepts, reference, PDF) in both light and dark mode
- [ ] **A specific guide** (e.g. `/guides/getting-started`) — guide type icons in the breadcrumb area
- [ ] **Documentation index** (`/version/main/guides/`) — same category icons + quarkiverse icon on quarkiverse extensions
- [ ] **Footer** (any page) — footer background image (`bg-footer.png`), visible on wide screens (≥1024px)
- [ ] **Spring page** (`/spring/`) — title background image
- [ ] **Events page** (`/events/`) — speaker callout card background
- [ ] **1k Contributors page** — page header background image – only I'm not sure this page has a url anymore

