### PR TITLE
Add author page and blog content quality tests

### DIFF
--- a/src/test/java/io/quarkusio/AuthorPageTest.java
+++ b/src/test/java/io/quarkusio/AuthorPageTest.java
@@ -1,0 +1,41 @@
+package io.quarkusio;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AuthorPageTest extends BrowserTest {
+
+    @Test
+    void authorIndexPageListsAuthors() {
+        page.navigate(baseUrl + "/author/");
+        int authorCount = page.locator(".authors a[href*='/author/']").count();
+        assertTrue(authorCount >= 5,
+                "Expected at least 5 authors but found " + authorCount);
+    }
+
+    @Test
+    void authorPageShowsAuthorName() {
+        page.navigate(baseUrl + "/blog/");
+        var authorLink = page.locator(".byline a[href*='/author/']").first();
+        String authorName = authorLink.textContent().trim();
+        authorLink.click();
+
+        page.waitForURL("**/author/**");
+        var heading = page.locator(".byline").first();
+        assertTrue(heading.textContent().contains(authorName),
+                "Expected author page to show author name '" + authorName + "'");
+    }
+
+    @Test
+    void authorPageListsPosts() {
+        page.navigate(baseUrl + "/blog/");
+        var authorLink = page.locator(".byline a[href*='/author/']").first();
+        authorLink.click();
+
+        page.waitForURL("**/author/**");
+        int postCount = page.locator(".blog-list-item").count();
+        assertTrue(postCount >= 1,
+                "Expected at least 1 post on author page but found " + postCount);
+    }
+}

--- a/src/test/java/io/quarkusio/BlogPageTest.java
+++ b/src/test/java/io/quarkusio/BlogPageTest.java
@@ -102,6 +102,42 @@ public class BlogPageTest extends BrowserTest {
     }
 
     @Test
+    void multiAuthorPostShowsAllAuthors() {
+        page.navigate(baseUrl + BLOG_PATH);
+
+        String postHref = null;
+        int indexAuthorCount = 0;
+
+        while (postHref == null) {
+            var posts = page.locator(".blog-list-item");
+            int postCount = posts.count();
+            for (int i = 0; i < postCount; i++) {
+                var post = posts.nth(i);
+                int authorCount = post.locator(".byline a[href*='/author/']").count();
+                if (authorCount > 1) {
+                    postHref = post.locator(".post-title a").getAttribute("href");
+                    indexAuthorCount = authorCount;
+                    break;
+                }
+            }
+            if (postHref == null) {
+                var olderPosts = page.locator("a:has-text('Older Posts')");
+                assertFalse(olderPosts.count() == 0,
+                        "Could not find any multi-author blog post");
+                olderPosts.click();
+                page.waitForLoadState();
+            }
+        }
+
+        page.navigate(postHref.startsWith("http") ? postHref : baseUrl + postHref);
+        int postPageAuthorCount = page.locator(".byline a[href*='/author/']").count();
+        assertEquals(indexAuthorCount, postPageAuthorCount,
+                "Post page should show the same number of authors as the blog index");
+        assertTrue(postPageAuthorCount > 1,
+                "Expected multiple authors on post page but found " + postPageAuthorCount);
+    }
+
+    @Test
     void blogPostsDoNotContainUnrenderedMarkup() {
         page.navigate(baseUrl + BLOG_PATH);
         var postLinks = page.locator(".blog-list-item .post-title a");

--- a/src/test/java/io/quarkusio/BlogPageTest.java
+++ b/src/test/java/io/quarkusio/BlogPageTest.java
@@ -1,10 +1,16 @@
 package io.quarkusio;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import static io.quarkusio.UnrenderedMarkupDetector.findUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BlogPageTest extends BrowserTest {
+
+    private static final String BLOG_PATH = "/blog/";
+    private static final int POSTS_TO_CHECK = 3;
 
     @Test
     void blogPageTitleIsExact() {
@@ -14,7 +20,7 @@ public class BlogPageTest extends BrowserTest {
 
     @Test
     void blogPageHasAtLeastFivePosts() {
-        page.navigate(baseUrl + "/blog/");
+        page.navigate(baseUrl + BLOG_PATH);
         int postCount = page.locator(".blog-list-item").count();
         assertTrue(postCount >= 5,
                 "Expected at least 5 blog posts but found " + postCount);
@@ -22,7 +28,7 @@ public class BlogPageTest extends BrowserTest {
 
     @Test
     void blogPageHasOlderPostsLink() {
-        page.navigate(baseUrl + "/blog/");
+        page.navigate(baseUrl + BLOG_PATH);
         int linkCount = page.locator("a:has-text('Older Posts')").count();
         assertTrue(linkCount > 0,
                 "Expected an 'Older Posts' link on the blog page");
@@ -45,5 +51,75 @@ public class BlogPageTest extends BrowserTest {
         int newerCount = page.locator("a:has-text('Newer Posts')").count();
         assertTrue(newerCount > 0,
                 "Expected a 'Newer Posts' link on page 2");
+    }
+
+    @Test
+    void blogIndexAuthorLinkNavigatesToAuthorPage() {
+        page.navigate(baseUrl + BLOG_PATH);
+        var authorLink = page.locator(".byline a[href*='/author/']").first();
+        String authorName = authorLink.textContent().trim();
+        assertFalse(authorName.isEmpty(), "Expected author link to have text");
+
+        authorLink.click();
+        page.waitForURL("**/author/**");
+
+        var heading = page.locator(".byline").first();
+        assertTrue(heading.textContent().contains(authorName),
+                "Expected author page to contain author name '" + authorName + "'");
+    }
+
+    @Test
+    void blogPostAuthorLinkNavigatesToAuthorPage() {
+        page.navigate(baseUrl + BLOG_PATH);
+        var postLink = page.locator(".blog-list-item .post-title a").first();
+        postLink.click();
+
+        var authorLink = page.locator(".byline a[href*='/author/']").first();
+        String authorName = authorLink.textContent().trim();
+        assertFalse(authorName.isEmpty(), "Expected author link to have text");
+
+        authorLink.click();
+        page.waitForURL("**/author/**");
+
+        var heading = page.locator(".byline").first();
+        assertTrue(heading.textContent().contains(authorName),
+                "Expected author page to contain author name '" + authorName + "'");
+    }
+
+    @Test
+    void blogPostLinksUseBlogUrl() {
+        page.navigate(baseUrl + BLOG_PATH);
+        var postLinks = page.locator(".blog-list-item .post-title a");
+        int count = Math.min(postLinks.count(), POSTS_TO_CHECK);
+        assertTrue(count > 0, "Expected at least one blog post link");
+
+        for (int i = 0; i < count; i++) {
+            String href = postLinks.nth(i).getAttribute("href");
+            assertNotNull(href, "Post link should have an href");
+            assertTrue(href.contains(BLOG_PATH),
+                    "Blog post link should contain " + BLOG_PATH + ": " + href);
+        }
+    }
+
+    @Test
+    void blogPostsDoNotContainUnrenderedMarkup() {
+        page.navigate(baseUrl + BLOG_PATH);
+        var postLinks = page.locator(".blog-list-item .post-title a");
+        int count = Math.min(postLinks.count(), POSTS_TO_CHECK);
+        assertTrue(count > 0, "Expected at least one blog post link");
+
+        for (int i = 0; i < count; i++) {
+            String href = postLinks.nth(i).getAttribute("href");
+            String title = postLinks.nth(i).textContent().trim();
+
+            page.navigate(href.startsWith("http") ? href : baseUrl + href);
+
+            String bodyText = page.locator(".doc-content").first().textContent();
+            List<String> findings = findUnrenderedMarkup(bodyText);
+            assertTrue(findings.isEmpty(),
+                    () -> "\"" + title + "\" (" + href + ") contains unrendered markup: " + String.join("; ", findings));
+
+            page.navigate(baseUrl + BLOG_PATH);
+        }
     }
 }

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
@@ -1,0 +1,52 @@
+package io.quarkusio;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class UnrenderedMarkupDetector {
+
+    private record MarkupPattern(Pattern pattern, String description) {
+    }
+
+    private static final List<MarkupPattern> PATTERNS = List.of(
+            // AsciiDoc headings: == Heading or === Heading at start of line
+            new MarkupPattern(Pattern.compile("(?m)^={2,6}\\s+\\S"), "AsciiDoc heading"),
+            // AsciiDoc code block fence
+            new MarkupPattern(Pattern.compile("(?m)^----\\s*$"), "AsciiDoc code fence (----)"),
+            // AsciiDoc source block annotation
+            new MarkupPattern(Pattern.compile("\\[source,[a-z]+]"), "AsciiDoc [source,...] block"),
+            // AsciiDoc image macro
+            new MarkupPattern(Pattern.compile("image::[^\\[]+\\["), "AsciiDoc image:: macro"),
+            // AsciiDoc link syntax: https://url[link text]
+            new MarkupPattern(Pattern.compile("https?://[^\\s\\[]+\\[[^]]+]"), "AsciiDoc link (url[text])"),
+            // AsciiDoc admonition markers
+            new MarkupPattern(Pattern.compile("(?m)^\\[(NOTE|TIP|WARNING|IMPORTANT|CAUTION)]\\s*$"), "AsciiDoc admonition marker"),
+            // AsciiDoc attribute definition
+            new MarkupPattern(Pattern.compile("(?m)^:[a-zA-Z][a-zA-Z0-9_-]+:"), "AsciiDoc attribute definition"),
+
+            // Markdown headings: ## Heading or ### Heading
+            new MarkupPattern(Pattern.compile("(?m)^#{2,6}\\s+\\S"), "Markdown heading"),
+            // Markdown links: [text](url)
+            new MarkupPattern(Pattern.compile("\\[[^]]+]\\(https?://[^)]+\\)"), "Markdown link ([text](url))"),
+            // Markdown image: ![alt](url)
+            new MarkupPattern(Pattern.compile("!\\[[^]]*]\\("), "Markdown image (![alt](url))"),
+            // Markdown code fence
+            new MarkupPattern(Pattern.compile("(?m)^```[a-z]*\\s*$"), "Markdown code fence (```)")
+    );
+
+    public static List<String> findUnrenderedMarkup(String text) {
+        List<String> findings = new ArrayList<>();
+        for (MarkupPattern mp : PATTERNS) {
+            var matcher = mp.pattern.matcher(text);
+            if (matcher.find()) {
+                String match = matcher.group();
+                if (match.length() > 60) {
+                    match = match.substring(0, 57) + "...";
+                }
+                findings.add(mp.description + ": \"" + match + "\"");
+            }
+        }
+        return findings;
+    }
+}

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
@@ -1,0 +1,84 @@
+package io.quarkusio;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static io.quarkusio.UnrenderedMarkupDetector.findUnrenderedMarkup;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnrenderedMarkupDetectorTest {
+
+    @Test
+    void detectsAsciidocHeadings() {
+        assertDetects("== My Heading\nSome text", "AsciiDoc heading");
+        assertDetects("=== Sub Heading\ntext", "AsciiDoc heading");
+    }
+
+    @Test
+    void detectsAsciidocCodeFences() {
+        assertDetects("some text\n----\ncode\n----\n", "AsciiDoc code fence");
+    }
+
+    @Test
+    void detectsAsciidocSourceBlocks() {
+        assertDetects("before\n[source,java]\n----\ncode\n----", "AsciiDoc [source,...] block");
+    }
+
+    @Test
+    void detectsAsciidocImageMacros() {
+        assertDetects("see image::screenshot.png[A screenshot] for details", "AsciiDoc image:: macro");
+    }
+
+    @Test
+    void detectsAsciidocLinks() {
+        assertDetects("Visit https://example.com[Example Site] for more", "AsciiDoc link");
+    }
+
+    @Test
+    void detectsAsciidocAdmonitions() {
+        assertDetects("text\n[NOTE]\n====\nBe careful\n====", "AsciiDoc admonition");
+    }
+
+    @Test
+    void detectsAsciidocAttributes() {
+        assertDetects(":imagesdir: /assets/images\nSome text", "AsciiDoc attribute");
+    }
+
+    @Test
+    void detectsMarkdownHeadings() {
+        assertDetects("## My Heading\nSome text", "Markdown heading");
+        assertDetects("### Sub Heading\ntext", "Markdown heading");
+    }
+
+    @Test
+    void detectsMarkdownLinks() {
+        assertDetects("Click [here](https://example.com) to continue", "Markdown link");
+    }
+
+    @Test
+    void detectsMarkdownImages() {
+        assertDetects("See ![alt text](https://example.com/img.png)", "Markdown image");
+    }
+
+    @Test
+    void detectsMarkdownCodeFences() {
+        assertDetects("text\n```java\ncode\n```\n", "Markdown code fence");
+    }
+
+    @Test
+    void doesNotFlagCleanHtml() {
+        List<String> findings = findUnrenderedMarkup(
+                "This is a normal blog post with headings and paragraphs. "
+                        + "It mentions Java and Quarkus. "
+                        + "Visit our website for more details.");
+        assertTrue(findings.isEmpty(), "Clean HTML should produce no findings but got: " + findings);
+    }
+
+    private void assertDetects(String input, String expectedFragment) {
+        List<String> findings = findUnrenderedMarkup(input);
+        assertFalse(findings.isEmpty(), "Expected to detect markup in: " + input);
+        assertTrue(findings.stream().anyMatch(f -> f.contains(expectedFragment)),
+                "Expected finding containing '" + expectedFragment + "' but got: " + findings);
+    }
+}


### PR DESCRIPTION
More testing! 

- Add `AuthorPageTest` to verify the author index lists authors, and that navigating to an author page shows the correct name and posts
- Extend `BlogPageTest` with author link navigation from both the blog index and individual blog posts, URL path validation (ensures `/blog/` not `/posts/` which would be the default in some generators), and unrendered markup detection
- The markup detection is in a reusable `UnrenderedMarkupDetector` utility that checks for raw AsciiDoc and Markdown syntax (headings, code fences, link macros, image macros, admonitions, etc.) leaking into rendered pages. It was complex enough the test got its own test. :)
