### PR TITLE
Add java ecosystem to dependabot management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@
 
 version: 2
 updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Now that we have java code, we should turn on dependabot updates. 

I started looking at this because the surge preview action has a stale setup-java action, and I don't know why. I still don't know why, either!)