### PR TITLE
Add blog pagination navigation test

### DIFF
--- a/src/test/java/io/quarkusio/BlogPageTest.java
+++ b/src/test/java/io/quarkusio/BlogPageTest.java
@@ -21,4 +21,23 @@ public class BlogPageTest extends BrowserTest {
         assertTrue(linkCount > 0,
                 "Expected an 'Older Posts' link on the blog page");
     }
+
+    @Test
+    void blogPageTwoHasContentAndNavigationLinks() {
+        page.navigate(baseUrl + "/blog/");
+        page.locator("a:has-text('Older Posts')").first().click();
+        page.waitForLoadState();
+
+        int postCount = page.locator(".blog-list-item").count();
+        assertTrue(postCount >= 5,
+                "Expected at least 5 blog posts on page 2 but found " + postCount);
+
+        int olderCount = page.locator("a:has-text('Older Posts')").count();
+        assertTrue(olderCount > 0,
+                "Expected an 'Older Posts' link on page 2");
+
+        int newerCount = page.locator("a:has-text('Newer Posts')").count();
+        assertTrue(newerCount > 0,
+                "Expected a 'Newer Posts' link on page 2");
+    }
 }


### PR DESCRIPTION
The current tests makes sure we have an older posts link, but doesn't make sure following it leads somewhere useful, like a page 2. :) 