### PR TITLE
Wild experiment for better navigation

### DIFF
--- a/_data/versioned/main/index/categories.yaml
+++ b/_data/versioned/main/index/categories.yaml
@@ -1,0 +1,3601 @@
+# Generated file. Do not edit
+---
+categories:
+- id: getting-started
+  title: Getting Started
+  description: Introduction to Quarkus and getting started guides
+  guides:
+  - filename: getting-started.adoc
+    title: Creating Your First Application
+    summary: "Build a REST API with live reload, dependency injection, and tests, in under 15 minutes."
+    url: /guides/getting-started
+    type: tutorial
+    categories: getting-started
+    topics:
+    - getting-started
+  - filename: getting-started-dev-services.adoc
+    id: getting-started-dev-services-tutorial
+    title: Your second Quarkus application
+    summary: Discover some of the features that make developing with Quarkus a joyful experience.
+    url: /guides/getting-started-dev-services
+    type: tutorial
+    categories: getting-started
+    topics:
+    - getting-started
+    - dev-services
+  - filename: tooling.adoc
+    title: Using our Tooling
+    summary: Explore the Quarkus developer toolchain which makes Quarkus development so fast and enjoyable.
+    url: /guides/tooling
+    type: tutorial
+    categories: getting-started
+    topics:
+    - tooling
+  - filename: ide-tooling.adoc
+    title: Quarkus Tools in your favorite IDE
+    summary: Learn more about Quarkus integrations in IDEs.
+    url: /guides/ide-tooling
+    type: tutorial
+    categories: getting-started
+    topics:
+    - ide
+    - tooling
+- id: packaging
+  title: Packaging
+  description: "Application packaging, containers, native images, and build optimization"
+  subcategories:
+  - id: packaging-jars
+    title: JARs
+    guides:
+    - filename: aot.adoc
+      title: Ahead-of-Time (AOT) Caching
+      summary: This guide explains how to use Leyden AOT caching with Quarkus for dramatically faster startup times on JDK 24+.
+      url: /guides/aot
+      type: guide
+      topics:
+      - aot
+      - leyden
+      - startup
+      - performance
+    - filename: jar-tree-shaking.adoc
+      title: Tree-shaking JAR dependencies
+      summary: This guide explains how to reduce JAR size by removing unreachable classes from runtime dependencies.
+      url: /guides/jar-tree-shaking
+      type: guide
+      topics:
+      - packaging
+      - jar
+      - tree-shaking
+      - optimization
+    - filename: jlink.adoc
+      id: jlink
+      title: JLink packaging
+      summary: The jlink extension produces a custom Java runtime image containing only the modules needed to run the application.
+      url: /guides/jlink
+      type: reference
+      status: experimental
+      topics:
+      - jlink
+      - packaging
+      - modules
+      - modularity
+      extensions:
+      - io.quarkus:quarkus-jlink
+    - filename: reaugmentation.adoc
+      title: Re-augment a Quarkus Application
+      summary: Use mutable jars to rebuild your application with different build time configurations.
+      url: /guides/reaugmentation
+      type: guide
+      topics:
+      - mutable-jars
+      - tooling
+  - id: packaging-native
+    title: Native
+    guides:
+    - filename: building-native-image.adoc
+      title: Building a Native Executable
+      summary: Build native executables with GraalVM or Mandrel.
+      url: /guides/building-native-image
+      type: guide
+      topics:
+      - native
+      - graalvm
+      - mandrel
+    - filename: native-reference.adoc
+      id: native-reference
+      title: Native Reference Guide
+      summary: "This guide is a companion to the Building a Native Executable, Using SSL With Native Images, and Writing Native Applications, guides."
+      url: /guides/native-reference
+      type: reference
+      topics:
+      - native
+    - filename: writing-native-applications-tips.adoc
+      title: Tips for writing native applications
+      summary: This guide is a collection of tips to help you solve the problems you encounter when compiling applications to native executable.
+      url: /guides/writing-native-applications-tips
+      type: guide
+      topics:
+      - native
+      - extensions
+    - filename: native-and-ssl.adoc
+      title: Using SSL With Native Executables
+      summary: "In this guide, we will discuss how you can get your native images to support SSL, as native images don't support it out of the box."
+      url: /guides/native-and-ssl
+      type: guide
+      topics:
+      - native
+      - ssl
+    - filename: upx.adoc
+      title: Compressing native executables using UPX
+      summary: Ultimate Packer for eXecutables (UPX) is a compression tool reducing the size of executables.
+      url: /guides/upx
+      type: guide
+      topics:
+      - tooling
+      - native
+      - compression
+      - upx
+  - id: packaging-containers
+    title: Containers
+    guides:
+    - filename: container-image.adoc
+      title: Container Images
+      summary: "Learn how to build and push container images with Jib, OpenShift, Docker, or Podman as part of the Quarkus build."
+      url: /guides/container-image
+      type: guide
+      topics:
+      - devops
+      - cloud
+      extensions:
+      - io.quarkus:quarkus-container-image-openshift
+      - io.quarkus:quarkus-container-image-jib
+      - io.quarkus:quarkus-container-image-docker
+      - io.quarkus:quarkus-container-image-podman
+      - io.quarkus:quarkus-container-image-buildpack
+    - filename: quarkus-runtime-base-image.adoc
+      title: Quarkus Base Runtime Image
+      summary: "To ease the containerization of native executables, Quarkus provides a base image providing the requirements to run these executables."
+      url: /guides/quarkus-runtime-base-image
+      type: guide
+      topics:
+      - docker
+      - podman
+      - images
+  - id: packaging-release
+    title: Release & Distribution
+    guides:
+    - filename: cyclonedx.adoc
+      id: cyclonedx
+      title: Generating and Using CycloneDX SBOMs
+      summary: This guide explains how to generate and use SBOMs for Quarkus applications in the CycloneDX format.
+      url: /guides/cyclonedx
+      type: guide
+      topics:
+      - sbom
+      extensions:
+      - io.quarkus:quarkus-cyclonedx
+    - filename: jreleaser.adoc
+      title: Packaging And Releasing With JReleaser
+      summary: This guide covers packaging and releasing CLI applications using the JReleaser tool.
+      url: /guides/jreleaser
+      type: guide
+      topics:
+      - tooling
+- id: core
+  title: Core
+  description: Core Quarkus concepts and features
+  subcategories:
+  - id: core-cdi
+    title: CDI & Dependency Injection
+    guides:
+    - filename: cdi.adoc
+      title: Introduction to Contexts and Dependency Injection (CDI)
+      summary: "Quarkus DI solution is based on the [Jakarta Contexts and Dependency Injection 4.1](https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1.html) specification."
+      url: /guides/cdi
+      type: guide
+      keywords: qualifier event interceptor observer arc
+      topics:
+      - cdi
+      - arc
+      - injection
+      - interceptor
+      - observer
+      extensions:
+      - io.quarkus:quarkus-arc
+    - filename: cdi-reference.adoc
+      title: Contexts and Dependency Injection
+      summary: Go more in depth into the Quarkus implementation of CDI.
+      url: /guides/cdi-reference
+      type: reference
+      keywords: arc
+      topics:
+      - cdi
+      - arc
+      - injection
+      - interceptor
+      - observer
+      extensions:
+      - io.quarkus:quarkus-arc
+    - filename: lifecycle.adoc
+      title: Application Initialization and Termination
+      summary: You often need to execute custom actions when the application starts and clean up everything when the application stops.
+      url: /guides/lifecycle
+      type: guide
+      keywords: lifecycle event
+      topics:
+      - lifecycle
+      - observers
+      extensions:
+      - io.quarkus:quarkus-arc
+  - id: core-dev-services
+    title: Dev Services
+    guides:
+    - filename: dev-services.adoc
+      title: Dev Services Overview
+      summary: An introduction to Dev Services and a list of all extensions that support Dev Services and their configuration options.
+      url: /guides/dev-services
+      type: guide
+      topics:
+      - dev-services
+      - dev-mode
+      - testing
+    - filename: compose-dev-services.adoc
+      title: Compose Dev Services
+      summary: Configure custom Dev Services using Docker or Podman Compose.
+      url: /guides/compose-dev-services
+      type: guide
+      topics:
+      - dev-services
+      - dev-mode
+      - testing
+      - compose
+    - filename: podman.adoc
+      title: Using Podman with Quarkus
+      summary: "Podman is an open-source, daemonless, and rootless container engine for developing, managing, and running OCI Containers on Linux, Windows and Mac."
+      url: /guides/podman
+      type: guide
+      topics:
+      - podman
+      - devops
+      - tooling
+  - id: core-config
+    title: Configuration
+    guides:
+    - filename: config.adoc
+      title: Configuring Your Application
+      summary: Hardcoded values in your code is a no go (even if we all did it at some point ;-)).
+      url: /guides/config
+      type: guide
+      topics:
+      - configuration
+    - filename: config-yaml.adoc
+      id: config-yaml
+      title: YAML configuration
+      summary: "Optionally, use application.yaml instead of application.properties to configure your application."
+      url: /guides/config-yaml
+      type: howto
+      topics:
+      - configuration
+      extensions:
+      - io.quarkus:quarkus-config-yaml
+    - filename: config-mappings.adoc
+      title: Mapping configuration to objects
+      summary: Group multiple configuration properties into an object.
+      url: /guides/config-mappings
+      type: guide
+      topics:
+      - configuration
+    - filename: config-reference.adoc
+      title: Configuration Reference Guide
+      summary: Learn more about how to configure your Quarkus applications.
+      url: /guides/config-reference
+      type: reference
+      topics:
+      - configuration
+    - filename: config-extending-support.adoc
+      title: Extending Configuration Support
+      summary: Extend and customize the Configuration.
+      url: /guides/config-extending-support
+      type: guide
+      topics:
+      - configuration
+    - filename: all-config.adoc
+      title: All configuration options
+      summary: List all the configuration properties per extensions
+      url: /guides/all-config
+      type: guide
+  - id: core-vertx
+    title: Vert.x
+    guides:
+    - filename: vertx.adoc
+      title: Using Eclipse Vert.x API from a Quarkus Application
+      summary: This guide explains how to use Vert.x in Quarkus to build reactive applications.
+      url: /guides/vertx
+      type: guide
+      keywords: vertx event verticle
+    - filename: vertx-reference.adoc
+      title: Vert.x Reference Guide
+      summary: This reference guide provides advanced details about the usage and the configuration of the Vert.x instance used by Quarkus.
+      url: /guides/vertx-reference
+      type: reference
+      keywords: vertx event verticle
+  - id: core-testing
+    title: Testing
+    guides:
+    - filename: getting-started-testing.adoc
+      id: testing
+      title: Testing Your Application
+      summary: "This guide covers testing in JVM mode, native mode, and injection of resources into tests"
+      url: /guides/getting-started-testing
+      type: guide
+      topics:
+      - getting-started
+      - testing
+      - tooling
+    - filename: continuous-testing.adoc
+      title: Continuous Testing
+      summary: Get early test feedback with Continuous Testing.
+      url: /guides/continuous-testing
+      type: guide
+      topics:
+      - testing
+      - dev-ui
+      - tooling
+      - dev-mode
+    - filename: testing-components.adoc
+      title: Testing components
+      summary: "This reference guide covers the `QuarkusComponentTestExtension`, a JUnit extension to ease the testing of components and mocking of their dependencies."
+      url: /guides/testing-components
+      type: guide
+      keywords: testing
+      topics:
+      - testing
+      - tooling
+    - filename: tests-with-coverage.adoc
+      title: Measuring the coverage of your tests
+      summary: This guide explains how to measure the test coverage of your Quarkus application.
+      url: /guides/tests-with-coverage
+      type: guide
+      topics:
+      - tooling
+      - testing
+      - coverage
+      - jacoco
+      extensions:
+      - io.quarkus:quarkus-jacoco
+- id: web
+  title: Web
+  description: Web application development
+  subcategories:
+  - id: web-http
+    title: HTTP
+    guides:
+    - filename: web.adoc
+      title: Quarkus for the Web
+      summary: Learn more about creating all kinds of Web applications with Quarkus.
+      url: /guides/web
+      type: guide
+      topics:
+      - http
+      - web
+      - renarde
+      - full-stack
+      - qute
+      - quinoa
+      - web-bundler
+      - mvc
+      - ssr
+      - nodejs
+      - npm
+      - javascript
+      - css
+      - jsf
+      - faces
+      extensions:
+      - io.quarkiverse.qute.web:quarkus-qute-web
+      - io.quarkiverse.renarde:quarkus-renarde
+      - io.quarkiverse.web-bundler:quarkus-web-bundler
+      - io.quarkiverse.quinoa:quarkus-quinoa
+    - filename: http-reference.adoc
+      title: HTTP Reference
+      summary: Learn more about configuring Quarkus' Vert.x based HTTP layer - and Undertow if you are using servlets.
+      url: /guides/http-reference
+      type: reference
+      topics:
+      - http
+      - web
+      - webjars
+      - mvnpm
+      - vertx
+      - servlet
+      - undertow
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+    - filename: reactive-routes.adoc
+      title: Using Reactive Routes
+      summary: This guide demonstrates how to use reactive routes.
+      url: /guides/reactive-routes
+      type: guide
+      topics:
+      - http
+      - web
+      - routing
+      extensions:
+      - io.quarkus:quarkus-reactive-routes
+  - id: web-rest
+    title: REST
+    guides:
+    - filename: rest.adoc
+      title: Writing REST Services with Quarkus REST (formerly RESTEasy Reactive)
+      summary: Discover how to develop highly scalable reactive REST services with Jakarta REST and Quarkus REST.
+      url: /guides/rest
+      type: guide
+      topics:
+      - rest
+      - resteasy-reactive
+      - virtual-threads
+      extensions:
+      - io.quarkus:quarkus-rest
+      - io.quarkus:quarkus-rest-jackson
+      - io.quarkus:quarkus-rest-jsonb
+      - io.quarkus:quarkus-rest-client
+      - io.quarkus:quarkus-rest-client-jackson
+      - io.quarkus:quarkus-rest-client-jsonb
+    - filename: rest-client.adoc
+      title: Using the REST Client
+      summary: This guide explains how to use the REST Client.
+      url: /guides/rest-client
+      type: guide
+      topics:
+      - rest
+      - rest-client
+      - resteasy-reactive
+      extensions:
+      - io.quarkus:quarkus-rest-client
+      - io.quarkus:quarkus-rest-client-jackson
+      - io.quarkus:quarkus-rest-client-jsonb
+    - filename: rest-json.adoc
+      title: Writing JSON REST Services
+      summary: JSON is now the lingua franca between microservices.
+      url: /guides/rest-json
+      type: guide
+      topics:
+      - rest
+      - json
+      - resteasy-reactive
+      extensions:
+      - io.quarkus:quarkus-rest-jackson
+      - io.quarkus:quarkus-rest-jsonb
+      - io.quarkus:quarkus-rest
+    - filename: openapi-swaggerui.adoc
+      title: Using OpenAPI and Swagger UI
+      summary: This guide explains how to use the OpenAPI extension to generate an OpenAPI descriptor and get a Swagger UI frontend to test your REST endpoints.
+      url: /guides/openapi-swaggerui
+      type: guide
+      topics:
+      - rest
+      - openapi
+      - swagger-ui
+      - dev-ui
+      extensions:
+      - io.quarkus:quarkus-smallrye-openapi
+    - filename: resteasy.adoc
+      title: RESTEasy Classic
+      url: /guides/resteasy
+      type: guide
+      topics:
+      - rest
+      - resteasy-classic
+      extensions:
+      - io.quarkus:quarkus-resteasy
+      - io.quarkus:quarkus-resteasy-jackson
+      - io.quarkus:quarkus-resteasy-jsonb
+    - filename: resteasy-client.adoc
+      title: Using the legacy REST Client
+      summary: This guide explains how to use the RESTEasy Classic REST Client in order to interact with REST APIs (JSON and other) with very little effort.
+      url: /guides/resteasy-client
+      type: guide
+      topics:
+      - rest
+      - rest-client
+      - resteasy-client
+      - resteasy-classic
+      extensions:
+      - io.quarkus:quarkus-resteasy-client
+      - io.quarkus:quarkus-resteasy-client-jackson
+      - io.quarkus:quarkus-resteasy-client-jsonb
+      - io.quarkus:quarkus-resteasy-client-jaxb
+    - filename: resteasy-client-multipart.adoc
+      title: Using the legacy REST Client with Multipart
+      summary: "This guide explains how to use the RESTEasy Classic REST Client to send multipart REST requests, typically to upload documents."
+      url: /guides/resteasy-client-multipart
+      type: guide
+      topics:
+      - rest
+      - rest-client
+      - resteasy-client
+      - multipart
+      - resteasy-classic
+      extensions:
+      - io.quarkus:quarkus-resteasy-client
+      - io.quarkus:quarkus-resteasy-multipart
+    - filename: rest-data-panache.adoc
+      title: Generating Jakarta REST resources with Panache
+      summary: Hibernate ORM REST Data with Panache simplifies the creation of CRUD applications based on Jakarta REST and Hibernate ORM.
+      url: /guides/rest-data-panache
+      type: guide
+      topics:
+      - rest
+      - hibernate-orm
+      - panache
+      - mongodb
+      - sql
+      - jdbc
+      - nosql
+      extensions:
+      - io.quarkus:quarkus-hibernate-orm-rest-data-panache
+      - io.quarkus:quarkus-hibernate-reactive-rest-data-panache
+      - io.quarkus:quarkus-mongodb-rest-data-panache
+    - filename: rest-virtual-threads.adoc
+      id: rest-virtual-threads
+      title: Use virtual threads in REST applications
+      summary: How to use virtual threads in a REST application
+      url: /guides/rest-virtual-threads
+      type: howto
+      topics:
+      - rest
+      - resteasy-reactive
+      - virtual-threads
+      extensions:
+      - io.quarkus:quarkus-rest
+      - io.quarkus:quarkus-rest-jackson
+      - io.quarkus:quarkus-rest-jsonb
+      - io.quarkus:quarkus-rest-client
+      - io.quarkus:quarkus-rest-client-jackson
+      - io.quarkus:quarkus-rest-client-jsonb
+    - filename: rest-migration.adoc
+      title: Migrating to Quarkus REST (formerly RESTEasy Reactive)
+      summary: "Migrating from RESTEasy Classic to Quarkus REST (formerly RESTEasy Reactive) is straightforward in most cases, however there are a few cases that require some attention."
+      url: /guides/rest-migration
+      type: guide
+      topics:
+      - rest
+      - rest-client
+      - resteasy-reactive
+      extensions:
+      - io.quarkus:quarkus-rest
+      - io.quarkus:quarkus-rest-jackson
+      - io.quarkus:quarkus-rest-jsonb
+      - io.quarkus:quarkus-rest-client
+      - io.quarkus:quarkus-rest-client-jackson
+      - io.quarkus:quarkus-rest-client-jsonb
+  - id: web-graphql
+    title: GraphQL
+    guides:
+    - filename: smallrye-graphql.adoc
+      title: SmallRye GraphQL
+      summary: This guide explains how to leverage SmallRye GraphQL to implement GraphQL services.
+      url: /guides/smallrye-graphql
+      type: guide
+      topics:
+      - graphql
+      extensions:
+      - io.quarkus:quarkus-smallrye-graphql
+    - filename: smallrye-graphql-client.adoc
+      title: SmallRye GraphQL Client
+      summary: This guide explains how to leverage SmallRye GraphQL Client to consume GraphQL services.
+      url: /guides/smallrye-graphql-client
+      type: guide
+      topics:
+      - graphql
+      extensions:
+      - io.quarkus:quarkus-smallrye-graphql-client
+  - id: web-websockets
+    title: WebSockets
+    guides:
+    - filename: websockets-next-tutorial.adoc
+      title: Getting started with WebSockets Next
+      summary: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications.
+      url: /guides/websockets-next-tutorial
+      type: tutorial
+      topics:
+      - web
+      - websockets
+      extensions:
+      - io.quarkus:quarkus-websockets-next
+    - filename: websockets-next-reference.adoc
+      id: websockets-next-reference-guide
+      title: WebSockets Next reference guide
+      summary: The quarkus-websockets-next extension provides a modern declarative API to define WebSocket server and client endpoints.
+      url: /guides/websockets-next-reference
+      type: reference
+      topics:
+      - web
+      - websockets
+      extensions:
+      - io.quarkus:quarkus-websockets-next
+    - filename: websockets.adoc
+      title: Using WebSockets with Undertow
+      summary: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications.
+      url: /guides/websockets
+      type: guide
+      topics:
+      - web
+      - websockets
+      extensions:
+      - io.quarkus:quarkus-websockets
+      - io.quarkus:quarkus-websockets-client
+  - id: web-frontend
+    title: Frontend
+    guides:
+    - filename: web-dependency-locator.adoc
+      title: Web dependency locator
+      summary: Learn more about how to use the web dependency locator
+      url: /guides/web-dependency-locator
+      type: guide
+      topics:
+      - http
+      - web
+      - webjars
+      - mvnpm
+      - vertx
+      - servlet
+      - undertow
+      extensions:
+      - io.quarkus:quarkus-web-dependency-locator
+- id: data
+  title: Data
+  description: Data persistence and management
+  subcategories:
+  - id: data-datasources
+    title: Datasources
+    guides:
+    - filename: datasource.adoc
+      id: datasources
+      title: Configure data sources in Quarkus
+      summary: Use a unified configuration model to define data sources for Java Database Connectivity (JDBC) and Reactive drivers.
+      url: /guides/datasource
+      type: reference
+      topics:
+      - data
+      - database
+      - datasource
+      - sql
+      - jdbc
+      - reactive
+      extensions:
+      - io.quarkus:quarkus-agroal
+      - io.quarkus:quarkus-reactive-mysql-client
+      - io.quarkus:quarkus-reactive-oracle-client
+      - io.quarkus:quarkus-reactive-pg-client
+      - io.quarkus:quarkus-reactive-db2-client
+      - io.quarkus:quarkus-reactive-mssql-client
+      - io.quarkus:quarkus-jdbc-db2
+      - io.quarkus:quarkus-jdbc-h2
+      - io.quarkus:quarkus-jdbc-mariadb
+      - io.quarkus:quarkus-jdbc-mssql
+      - io.quarkus:quarkus-jdbc-mysql
+      - io.quarkus:quarkus-jdbc-oracle
+      - io.quarkus:quarkus-jdbc-postgresql
+    - filename: reactive-sql-clients.adoc
+      title: Reactive SQL Clients
+      summary: This guide covers how to use the Reactive SQL Clients in Quarkus.
+      url: /guides/reactive-sql-clients
+      type: guide
+      topics:
+      - data
+      - database
+      - reactive
+      - sql
+      extensions:
+      - io.quarkus:quarkus-reactive-mysql-client
+      - io.quarkus:quarkus-reactive-oracle-client
+      - io.quarkus:quarkus-reactive-pg-client
+      - io.quarkus:quarkus-reactive-db2-client
+      - io.quarkus:quarkus-reactive-mssql-client
+    - filename: databases-dev-services.adoc
+      title: Dev Services for Databases
+      summary: "When testing or running in dev mode Quarkus can provide you with a zero-config database out of the box, a feature we refer to as Dev Services."
+      url: /guides/databases-dev-services
+      type: guide
+      topics:
+      - dev-services
+      - data
+      - database
+      - datasource
+      - dev-mode
+      - testing
+      extensions:
+      - io.quarkus:quarkus-agroal
+      - io.quarkus:quarkus-reactive-mysql-client
+      - io.quarkus:quarkus-reactive-oracle-client
+      - io.quarkus:quarkus-reactive-pg-client
+      - io.quarkus:quarkus-jdbc-db2
+      - io.quarkus:quarkus-jdbc-h2
+      - io.quarkus:quarkus-jdbc-mariadb
+      - io.quarkus:quarkus-jdbc-mssql
+      - io.quarkus:quarkus-jdbc-mysql
+      - io.quarkus:quarkus-jdbc-oracle
+      - io.quarkus:quarkus-jdbc-postgresql
+  - id: data-orm
+    title: ORM & Hibernate
+    guides:
+    - filename: hibernate-orm.adoc
+      title: Using Hibernate ORM and Jakarta Persistence
+      summary: Hibernate ORM is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper.
+      url: /guides/hibernate-orm
+      type: guide
+      topics:
+      - data
+      - hibernate-orm
+      - sql
+      - jdbc
+      extensions:
+      - io.quarkus:quarkus-hibernate-orm
+    - filename: quarkus-data-hibernate.adoc
+      title: Simplified Hibernate with Quarkus Data Hibernate
+      summary: Hibernate is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper.
+      url: /guides/quarkus-data-hibernate
+      type: guide
+      status: experimental
+      topics:
+      - data
+      - hibernate-orm
+      - hibernate-reactive
+      - panache
+      - sql
+      - jdbc
+      extensions:
+      - io.quarkus:quarkus-data-hibernate
+      - io.quarkus:quarkus-hibernate-orm
+      - io.quarkus:quarkus-hibernate-reactive
+    - filename: hibernate-orm-panache.adoc
+      title: Simplified Hibernate ORM with Panache
+      summary: Hibernate ORM is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper.
+      url: /guides/hibernate-orm-panache
+      type: guide
+      topics:
+      - data
+      - hibernate-orm
+      - panache
+      - sql
+      - jdbc
+      extensions:
+      - io.quarkus:quarkus-hibernate-orm-panache
+      - io.quarkus:quarkus-hibernate-orm
+    - filename: hibernate-orm-panache-kotlin.adoc
+      title: Simplified Hibernate ORM with Panache and Kotlin
+      summary: This explains the specifics of using Hibernate ORM with Panache in a Kotlin project.
+      url: /guides/hibernate-orm-panache-kotlin
+      type: guide
+      topics:
+      - data
+      - hibernate-orm
+      - panache
+      - kotlin
+      - sql
+      - jdbc
+      extensions:
+      - io.quarkus:quarkus-hibernate-orm-panache-kotlin
+      - io.quarkus:quarkus-hibernate-orm-panache
+      - io.quarkus:quarkus-hibernate-orm
+    - filename: hibernate-reactive.adoc
+      title: Using Hibernate Reactive
+      summary: "Hibernate Reactive is a reactive API for Hibernate ORM, supporting non-blocking database drivers and a reactive style of interaction with the database."
+      url: /guides/hibernate-reactive
+      type: guide
+      status: preview
+      topics:
+      - data
+      - hibernate-reactive
+      - sql
+      extensions:
+      - io.quarkus:quarkus-hibernate-reactive-panache
+      - io.quarkus:quarkus-hibernate-reactive
+    - filename: hibernate-reactive-panache.adoc
+      title: Simplified Hibernate Reactive with Panache
+      summary: Simplified reactive ORM layer based on Hibernate Reactive.
+      url: /guides/hibernate-reactive-panache
+      type: guide
+      topics:
+      - data
+      - hibernate-reactive
+      - panache
+      - sql
+      extensions:
+      - io.quarkus:quarkus-hibernate-reactive-panache
+      - io.quarkus:quarkus-hibernate-reactive
+    - hibernate-panache-next.adoc
+    - filename: hibernate-search-orm-elasticsearch.adoc
+      title: Use Hibernate Search with Hibernate ORM and Elasticsearch/OpenSearch
+      summary: Hibernate Search with Hibernate ORM allows you to index your entities in an Elasticsearch/OpenSearch cluster and easily offer full text search in all your Hibernate ORM-based applications.
+      url: /guides/hibernate-search-orm-elasticsearch
+      type: guide
+      keywords: elasticsearch opensearch hibernate orm search
+      topics:
+      - data
+      - hibernate-search
+      - elasticsearch
+      - opensearch
+      - search
+      - nosql
+      - hibernate-orm
+      extensions:
+      - io.quarkus:quarkus-hibernate-search-orm-elasticsearch
+    - filename: hibernate-search-standalone-elasticsearch.adoc
+      title: Use Hibernate Search in Standalone mode with Elasticsearch/OpenSearch
+      summary: "Hibernate Search Standalone allows you to index your entities in an Elasticsearch/OpenSearch cluster and easily offer full text search in all your applications, even without Hibernate ORM."
+      url: /guides/hibernate-search-standalone-elasticsearch
+      type: guide
+      keywords: elasticsearch opensearch hibernate search
+      topics:
+      - data
+      - hibernate-search
+      - elasticsearch
+      - opensearch
+      - search
+      - nosql
+      extensions:
+      - io.quarkus:quarkus-hibernate-search-standalone-elasticsearch
+    - filename: blaze-persistence.adoc
+      title: Using Blaze-Persistence
+      summary: This guide explains how to use Blaze-Persistence to simplify your data and DTO layers.
+      url: /guides/blaze-persistence
+      type: guide
+  - id: data-transactions
+    title: Transactions
+    guides:
+    - filename: transaction.adoc
+      title: Using transactions in Quarkus
+      summary: "The quarkus-narayana-jta extension provides a Transaction Manager that coordinates and expose transactions to your applications as described in the Jakarta Transactions specification, formerly known as Java Transaction API (JTA)."
+      url: /guides/transaction
+      type: reference
+      topics:
+      - data
+      - jpa
+      - jta
+      - transactions
+      - narayana
+      extensions:
+      - io.quarkus:quarkus-narayana-jta
+    - filename: software-transactional-memory.adoc
+      title: Using Software Transactional Memory in Quarkus
+      summary: This guides covers the usage of Software Transactional Memory (STM).
+      url: /guides/software-transactional-memory
+      type: guide
+      status: preview
+      topics:
+      - narayana
+      - stm
+      - transactions
+      extensions:
+      - io.quarkus:quarkus-narayana-stm
+    - filename: lra.adoc
+      title: Narayana LRA Participant Support
+      summary: This guides covers the usage of LRA to coordinate activities across services.
+      url: /guides/lra
+      type: guide
+      topics:
+      - data
+      - lra
+      - narayana
+      extensions:
+      - io.quarkus:quarkus-narayana-lra
+    - filename: lra-dev-services.adoc
+      title: Dev Services for LRA
+      summary: Start the Narayana LRA coordinator automatically in dev and test modes.
+      url: /guides/lra-dev-services
+      type: guide
+      topics:
+      - data
+      - lra
+      - narayana
+      extensions:
+      - io.quarkus:quarkus-narayana-lra
+  - id: data-validation
+    title: Validation
+    guides:
+    - filename: validation.adoc
+      title: Validation with Hibernate Validator
+      summary: This guide covers how to use Hibernate Validator/Bean Validation in your REST services.
+      url: /guides/validation
+      type: guide
+      topics:
+      - bean-validation
+      - hibernate-validator
+      - validation
+      - validator
+      - constraints
+      extensions:
+      - io.quarkus:quarkus-hibernate-validator
+  - id: data-nosql
+    title: NoSQL
+    guides:
+    - filename: mongodb.adoc
+      title: Using the MongoDB Client
+      summary: This guide covers how to use MongoDB in Quarkus.
+      url: /guides/mongodb
+      type: guide
+      topics:
+      - data
+      - mongodb
+      - nosql
+      extensions:
+      - io.quarkus:quarkus-mongodb-client
+    - filename: mongodb-panache.adoc
+      title: Simplified MongoDB with Panache
+      summary: This guide covers the usage of MongoDB using active records and repositories.
+      url: /guides/mongodb-panache
+      type: guide
+      topics:
+      - data
+      - mongodb
+      - nosql
+      - panache
+      - kotlin
+      extensions:
+      - io.quarkus:quarkus-mongodb-panache
+      - io.quarkus:quarkus-mongodb-client
+    - filename: mongodb-panache-kotlin.adoc
+      title: Simplified MongoDB with Panache and Kotlin
+      summary: This guide covers the usage of MongoDB using active records and repositories in a Kotlin project.
+      url: /guides/mongodb-panache-kotlin
+      type: guide
+      topics:
+      - data
+      - mongodb
+      - nosql
+      - panache
+      - kotlin
+      extensions:
+      - io.quarkus:quarkus-mongodb-panache-kotlin
+      - io.quarkus:quarkus-mongodb-panache
+      - io.quarkus:quarkus-mongodb-client
+    - filename: mongodb-dev-services.adoc
+      title: Dev Services for MongoDB
+      summary: Quarkus supports a feature called Dev Services that allows you to create various datasources without any config.
+      url: /guides/mongodb-dev-services
+      type: guide
+    - filename: redis.adoc
+      title: Using the Redis Client
+      summary: This guide covers how to use a Redis datastore in Quarkus.
+      url: /guides/redis
+      type: guide
+      status: stable
+      topics:
+      - data
+      - redis
+      - nosql
+      extensions:
+      - io.quarkus:quarkus-redis-client
+    - filename: redis-reference.adoc
+      title: Redis Extension Reference Guide
+      summary: "Redis is an in-memory data store used as a database, cache, streaming engine, and message broker."
+      url: /guides/redis-reference
+      type: reference
+      status: stable
+      topics:
+      - data
+      - redis
+      - nosql
+      extensions:
+      - io.quarkus:quarkus-redis-client
+    - filename: redis-dev-services.adoc
+      title: Dev Services for Redis
+      summary: Start Redis automatically in dev and test modes.
+      url: /guides/redis-dev-services
+      type: guide
+      status: stable
+      topics:
+      - data
+      - redis
+      - nosql
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-redis-client
+    - filename: elasticsearch.adoc
+      title: Connecting to an Elasticsearch cluster
+      summary: This guide covers how to interact with an Elasticsearch cluster using the low level REST client or the Elasticsearch Java client.
+      url: /guides/elasticsearch
+      type: guide
+      topics:
+      - data
+      - search
+      - elasticsearch
+      - nosql
+      extensions:
+      - io.quarkus:quarkus-elasticsearch-java-client
+      - io.quarkus:quarkus-elasticsearch-rest-client
+    - filename: elasticsearch-dev-services.adoc
+      title: Dev Services for Elasticsearch
+      summary: Start Elasticsearch automatically in dev and test modes
+      url: /guides/elasticsearch-dev-services
+      type: guide
+      topics:
+      - data
+      - search
+      - elasticsearch
+      - nosql
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-elasticsearch-java-client
+      - io.quarkus:quarkus-elasticsearch-rest-client
+      - io.quarkus:quarkus-hibernate-search-orm-elasticsearch
+    - filename: cassandra.adoc
+      title: Using the Cassandra Client
+      summary: This guide covers how to use the Apache Cassandra NoSQL database in Quarkus.
+      url: /guides/cassandra
+      type: guide
+      topics:
+      - data
+      - cassandra
+  - id: data-caching
+    title: Caching
+    guides:
+    - filename: cache.adoc
+      title: Application Data Caching
+      summary: This guide explains how to cache expensive method calls of your CDI beans using simple annotations.
+      url: /guides/cache
+      type: guide
+      topics:
+      - cache
+      - data
+      extensions:
+      - io.quarkus:quarkus-cache
+    - filename: cache-redis-reference.adoc
+      title: Redis Cache
+      summary: Use Redis as the Quarkus cache backend
+      url: /guides/cache-redis-reference
+      type: reference
+      status: preview
+      topics:
+      - redis
+      - cache
+      - data
+      extensions:
+      - io.quarkus:quarkus-redis-cache
+      - io.quarkus:quarkus-redis-client
+    - filename: cache-infinispan-reference.adoc
+      title: Infinispan Cache
+      summary: Use Infinispan as the Quarkus cache backend
+      url: /guides/cache-infinispan-reference
+      type: reference
+      status: preview
+      topics:
+      - infinispan
+      - cache
+      - data
+      extensions:
+      - io.quarkus:quarkus-infinispan-cache
+      - io.quarkus:quarkus-infinispan-client
+    - filename: infinispan-client.adoc
+      title: Using the Infinispan Client
+      summary: This guide covers how to use Infinispan with Quarkus.
+      url: /guides/infinispan-client
+      type: guide
+      topics:
+      - data
+      - infinispan
+      extensions:
+      - io.quarkus:quarkus-infinispan-client
+    - filename: infinispan-client-reference.adoc
+      title: Infinispan Client Extension Reference Guide
+      summary: "Infinispan is an in memory distributed data store and cache server that offers flexible deployment options and robust capabilities for storing, managing, and processing data."
+      url: /guides/infinispan-client-reference
+      type: reference
+      topics:
+      - data
+      - infinispan
+      extensions:
+      - io.quarkus:quarkus-infinispan-client
+    - filename: infinispan-dev-services.adoc
+      title: Dev Services for Infinispan
+      summary: Start Infinispan automatically in dev and test modes.
+      url: /guides/infinispan-dev-services
+      type: guide
+      topics:
+      - dev-services
+      - data
+      - infinispan
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-infinispan-client
+  - id: data-migration
+    title: Database Migration
+    guides:
+    - filename: flyway.adoc
+      title: Using Flyway
+      summary: This guide covers how to use the Flyway extension to manage your schema migrations.
+      url: /guides/flyway
+      type: guide
+      topics:
+      - flyway
+      - data
+      - schema-migration
+      - database
+      extensions:
+      - io.quarkus:quarkus-flyway
+    - filename: liquibase.adoc
+      title: Using Liquibase
+      summary: This guide covers how to use the Liquibase extension to manage your schema migrations.
+      url: /guides/liquibase
+      type: guide
+      topics:
+      - data
+      - schema-migration
+      - liquibase
+      extensions:
+      - io.quarkus:quarkus-liquibase
+    - filename: liquibase-mongodb.adoc
+      title: Using Liquibase MongoDB
+      summary: "Liquibase is an open source tool for database schema change management, it allows managing MongoDB databases via it&#8217;s MongoDB Extension."
+      url: /guides/liquibase-mongodb
+      type: guide
+      topics:
+      - data
+      - schema-migration
+      - liquibase
+      - mongodb
+      extensions:
+      - io.quarkus:quarkus-liquibase-mongodb
+- id: messaging
+  title: Messaging
+  description: Asynchronous messaging and event streaming
+  subcategories:
+  - id: messaging-core
+    title: Messaging Core
+    guides:
+    - filename: messaging.adoc
+      title: Quarkus Messaging Extensions
+      summary: "Event-driven messaging systems have become the backbone of most modern applications, enabling the building of message-driven microservices or complex data streaming pipelines."
+      url: /guides/messaging
+      type: guide
+      topics:
+      - messaging
+      - reactive-messaging
+      extensions:
+      - io.quarkus:quarkus-messaging
+    - filename: messaging-virtual-threads.adoc
+      title: Quarkus Virtual Thread support with Reactive Messaging
+      summary: This guide explains how to benefit from Java virtual threads when writing message processing applications in Quarkus.
+      url: /guides/messaging-virtual-threads
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - reactive-messaging
+      - virtual-threads
+      extensions:
+      - io.quarkus:quarkus-messaging-kafka
+  - id: messaging-events
+    title: Events
+    guides:
+    - filename: signals.adoc
+      title: Quarkus Signals
+      summary: Learn more about how application components can interact in a loosely coupled fashion
+      url: /guides/signals
+      type: guide
+      status: experimental
+      topics:
+      - events
+      - signals
+      - messages
+      extensions:
+      - io.quarkus:quarkus-signals
+    - filename: reactive-event-bus.adoc
+      title: Using the event bus
+      summary: This guide explains how different beans can interact using the event bus.
+      url: /guides/reactive-event-bus
+      type: guide
+      keywords: vertx vert.x
+      topics:
+      - messaging
+      - event-bus
+      - vert.x
+      extensions:
+      - io.quarkus:quarkus-vertx
+  - id: messaging-jms
+    title: JMS
+    guides:
+    - filename: jms.adoc
+      title: Using JMS
+      summary: "This guide demonstrates how your Quarkus application can use JMS messaging with AMQP 1.0 using Apache Qpid JMS, or using Apache ActiveMQ Artemis JMS."
+      url: /guides/jms
+      type: guide
+      status: preview
+      topics:
+      - messaging
+      - jms
+      - artemis
+      - qpid
+      - activemq
+      extensions:
+      - org.amqphub.quarkus:quarkus-qpid-jms
+      - io.quarkiverse.artemis:quarkus-artemis-jms
+  - id: messaging-kafka
+    title: Kafka
+    guides:
+    - filename: kafka-getting-started.adoc
+      title: Getting Started with Quarkus Messaging and Apache Kafka
+      summary: Build two applications that communicate via Apache Kafka using Quarkus Messaging.
+      url: /guides/kafka-getting-started
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - reactive-messaging
+      extensions:
+      - io.quarkus:quarkus-messaging-kafka
+    - filename: kafka.adoc
+      title: Apache Kafka Reference Guide
+      summary: This reference guide provides an in-depth look on Apache Kafka and Quarkus Messaging extensions.
+      url: /guides/kafka
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - reactive-messaging
+      extensions:
+      - io.quarkus:quarkus-messaging-kafka
+    - filename: kafka-dev-services.adoc
+      title: Dev Services for Kafka
+      summary: Start Apache Kafka automatically in dev and test modes.
+      url: /guides/kafka-dev-services
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-kafka-client
+      - io.quarkus:quarkus-messaging-kafka
+    - filename: kafka-streams.adoc
+      title: Using Apache Kafka Streams
+      summary: This guide demonstrates how your Quarkus application can utilize the Apache Kafka Streams API to implement stream processing applications based on Apache Kafka.
+      url: /guides/kafka-streams
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - kafka-streams
+      extensions:
+      - io.quarkus:quarkus-kafka-streams
+    - filename: kafka-schema-registry-avro.adoc
+      title: Using Apache Kafka with Schema Registry and Avro
+      summary: "Use Apache Kafka, Avro serialized records, and connect to a schema registry."
+      url: /guides/kafka-schema-registry-avro
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - apicurio
+      - registry
+      extensions:
+      - io.quarkus:quarkus-apicurio-registry-avro
+      - io.quarkus:quarkus-messaging-kafka
+    - filename: kafka-schema-registry-json-schema.adoc
+      title: Using Apache Kafka with Schema Registry and JSON Schema
+      summary: "Use Apache Kafka, Json Schema serialized records, and connect to a schema registry."
+      url: /guides/kafka-schema-registry-json-schema
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - apicurio
+      - registry
+      extensions:
+      - io.quarkus:quarkus-apicurio-registry-json-schema
+      - io.quarkus:quarkus-messaging-kafka
+    - filename: kafka-dev-ui.adoc
+      title: Kafka Dev UI
+      summary: Dev UI extension for Apache Kafka for development purposes.
+      url: /guides/kafka-dev-ui
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - dev-ui
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-kafka-client
+      - io.quarkus:quarkus-messaging-kafka
+    - filename: apicurio-registry-dev-services.adoc
+      title: Dev Services for Apicurio Registry
+      summary: Start Apicurio Registry automatically in dev and test modes.
+      url: /guides/apicurio-registry-dev-services
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - apicurio
+      - registry
+      - dev-services
+      - dev-mode
+      - testing
+      extensions:
+      - io.quarkus:quarkus-apicurio-registry-avro
+      - io.quarkus:quarkus-messaging-kafka
+  - id: messaging-amqp
+    title: AMQP
+    guides:
+    - filename: amqp.adoc
+      title: Getting Started to Quarkus Messaging with AMQP 1.0
+      summary: This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with AMQP.
+      url: /guides/amqp
+      type: guide
+      topics:
+      - messaging
+      - amqp
+      extensions:
+      - io.quarkus:quarkus-messaging-amqp
+    - filename: amqp-reference.adoc
+      title: Reactive Messaging AMQP 1.0 Connector Reference Documentation
+      summary: This guide is the companion from the Getting Started with AMQP 1.0.
+      url: /guides/amqp-reference
+      type: reference
+      topics:
+      - messaging
+      - amqp
+      extensions:
+      - io.quarkus:quarkus-messaging-amqp
+    - filename: amqp-dev-services.adoc
+      title: Dev Services for AMQP
+      summary: Start AMQP automatically in dev and test modes.
+      url: /guides/amqp-dev-services
+      type: guide
+      topics:
+      - messaging
+      - amqp
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-messaging-amqp
+  - id: messaging-pulsar
+    title: Pulsar
+    guides:
+    - filename: pulsar-getting-started.adoc
+      title: Getting Started to Quarkus Messaging with Apache Pulsar
+      summary: This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with Apache Pulsar.
+      url: /guides/pulsar-getting-started
+      type: guide
+      topics:
+      - messaging
+      - reactive-messaging
+      - pulsar
+      extensions:
+      - io.quarkus:quarkus-messaging-pulsar
+    - filename: pulsar.adoc
+      title: Apache Pulsar Reference Guide
+      summary: This reference guide provides an in-depth look on Apache Pulsar and the Quarkus Messaging extensions.
+      url: /guides/pulsar
+      type: guide
+      topics:
+      - messaging
+      - reactive-messaging
+      - pulsar
+      extensions:
+      - io.quarkus:quarkus-messaging-pulsar
+    - filename: pulsar-dev-services.adoc
+      title: Dev Services for Pulsar
+      summary: With Quarkus Messaging Pulsar extension (quarkus-messaging-pulsar) Dev Services for Pulsar automatically starts a Pulsar broker in dev mode and when running tests.
+      url: /guides/pulsar-dev-services
+      type: guide
+      topics:
+      - messaging
+      - reactive-messaging
+      - pulsar
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-messaging-pulsar
+  - id: messaging-rabbitmq
+    title: RabbitMQ
+    guides:
+    - filename: rabbitmq.adoc
+      title: Getting Started to Quarkus Messaging with RabbitMQ
+      summary: This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with RabbitMQ.
+      url: /guides/rabbitmq
+      type: guide
+      status: preview
+      topics:
+      - messaging
+      - reactive-messaging
+      - rabbitmq
+      extensions:
+      - io.quarkus:quarkus-messaging-rabbitmq
+    - filename: rabbitmq-reference.adoc
+      title: Reactive Messaging RabbitMQ Connector Reference Documentation
+      summary: This guide is the companion from the Getting Started with RabbitMQ.
+      url: /guides/rabbitmq-reference
+      type: reference
+      status: preview
+      topics:
+      - messaging
+      - reactive-messaging
+      - rabbitmq
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-messaging-rabbitmq
+    - filename: rabbitmq-dev-services.adoc
+      title: Dev Services for RabbitMQ
+      summary: Dev Services for RabbitMQ automatically starts a RabbitMQ broker in dev mode and when running tests.
+      url: /guides/rabbitmq-dev-services
+      type: guide
+      topics:
+      - messaging
+      - reactive-messaging
+      - rabbitmq
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-messaging-rabbitmq
+- id: security
+  title: Security
+  description: "Security, authentication, and authorization"
+  subcategories:
+  - id: security-core
+    title: Security Core
+    guides:
+    - filename: security-overview.adoc
+      id: security-overview
+      title: Quarkus Security overview
+      summary: "Quarkus Security is a framework that provides the architecture, multiple authentication and authorization mechanisms, and other tools to build secure and production-quality Java applications."
+      url: /guides/security-overview
+      type: concepts
+      topics:
+      - security
+    - filename: security-architecture.adoc
+      id: security-architecture
+      title: Quarkus Security architecture
+      summary: The Quarkus Security architecture provides several built-in authentication mechanisms and is highly customizable.
+      url: /guides/security-architecture
+      type: concepts
+      topics:
+      - security
+    - filename: security-getting-started-tutorial.adoc
+      id: security-getting-started-tutorial
+      title: Getting started with security by using Basic authentication and Jakarta Persistence
+      summary: "Get started with Quarkus Security by securing your Quarkus application endpoints with the built-in Quarkus Basic authentication and the Jakarta Persistence identity provider, enabling role-based access control."
+      url: /guides/security-getting-started-tutorial
+      type: tutorial
+      topics:
+      - security
+      - authentication
+      - basic-authentication
+      - http
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+      - io.quarkus:quarkus-elytron-security-jdbc
+      - io.quarkus:quarkus-elytron-security-ldap
+      - io.quarkus:quarkus-security-jpa-reactive
+    - filename: security-customization.adoc
+      title: Security Tips and Tricks
+      url: /guides/security-customization
+      type: guide
+      topics:
+      - security
+      extensions:
+      - io.quarkus:quarkus-security
+    - filename: security-authorize-web-endpoints-reference.adoc
+      id: security-authorize-web-endpoints-reference
+      title: Authorization of web endpoints
+      summary: Quarkus incorporates a pluggable web security layer.
+      url: /guides/security-authorize-web-endpoints-reference
+      type: reference
+      topics:
+      - security
+      - authorization
+      - http
+      - rest
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+      - io.quarkus:quarkus-rest
+      - io.quarkus:quarkus-resteasy
+    - filename: security-proactive-authentication.adoc
+      id: security-proactive-authentication
+      title: Proactive authentication
+      summary: "Learn how to manage proactive authentication in Quarkus, including customizing settings and handling exceptions."
+      url: /guides/security-proactive-authentication
+      type: concepts
+      topics:
+      - security
+      - authentication
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+    - filename: security-cors.adoc
+      id: security-cors
+      title: Cross-Origin Resource Sharing (CORS)
+      summary: "Enable and configure CORS in Quarkus to specify allowed origins, methods, and headers, guiding browsers in handling cross-origin requests safely."
+      url: /guides/security-cors
+      type: reference
+      keywords: "cors, http, configuration, security, headers"
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+    - filename: security-csrf-prevention.adoc
+      title: Cross-Site Request Forgery Prevention
+      summary: Cross-Site Request Forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated.
+      url: /guides/security-csrf-prevention
+      type: guide
+      topics:
+      - security
+      - csrf
+      - http
+      extensions:
+      - io.quarkus:quarkus-rest-csrf
+    - filename: security-properties.adoc
+      title: Using Security with .properties File
+      summary: Quarkus provides support for properties file-based authentication intended for development and testing purposes.
+      url: /guides/security-properties
+      type: guide
+    - filename: security-testing.adoc
+      title: Security Testing
+      summary: This document describes how to test Quarkus Security.
+      url: /guides/security-testing
+      type: guide
+      topics:
+      - security
+      - testing
+      extensions:
+      - io.quarkus:quarkus-test-security
+    - filename: config-secrets.adoc
+      title: Secrets in Configuration
+      summary: "Use encrypted configuration values to protect sensitive passwords, secrets, tokens and keys."
+      url: /guides/config-secrets
+      type: guide
+    - filename: credentials-provider.adoc
+      title: Using a Credentials Provider
+      summary: This guides explains how to use the Vault credentials provider or implement your own custom one.
+      url: /guides/credentials-provider
+      type: guide
+      status: preview
+      topics:
+      - security
+      - credentials
+    - filename: native-and-ssl.adoc
+      title: Using SSL With Native Executables
+      summary: "In this guide, we will discuss how you can get your native images to support SSL, as native images don't support it out of the box."
+      url: /guides/native-and-ssl
+      type: guide
+      topics:
+      - native
+      - ssl
+    - filename: security-vulnerability-detection.adoc
+      id: security-vulnerability-detection
+      title: Security vulnerability detection and reporting in Quarkus
+      summary: Most of the Quarkus tags are registered in the US National Vulnerability Database (NVD) in Common Platform Enumeration (CPE) name format.
+      url: /guides/security-vulnerability-detection
+      type: concepts
+      topics:
+      - security
+      - vulnerability
+  - id: security-authentication
+    title: Authentication
+    guides:
+    - filename: security-authentication-mechanisms.adoc
+      id: security-authentication-mechanisms
+      title: Authentication mechanisms in Quarkus
+      summary: "The Quarkus Security framework supports multiple authentication mechanisms, which you can use to secure your applications."
+      url: /guides/security-authentication-mechanisms
+      type: concepts
+      topics:
+      - security
+      - authentication
+    - filename: security-basic-authentication.adoc
+      id: security-basic-authentication
+      title: Basic authentication
+      summary: HTTP Basic authentication is one of the least resource-demanding techniques that enforce access controls to web resources.
+      url: /guides/security-basic-authentication
+      type: concepts
+      topics:
+      - security
+      - authentication
+      - basic-authentication
+      - http
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+      - io.quarkus:quarkus-elytron-security-jdbc
+      - io.quarkus:quarkus-elytron-security-ldap
+      - io.quarkus:quarkus-security-jpa-reactive
+    - filename: security-basic-authentication-howto.adoc
+      id: security-basic-authentication-howto
+      title: Enable Basic authentication
+      summary: Enable Basic authentication for your Quarkus project and allow users to authenticate with a username and password.
+      url: /guides/security-basic-authentication-howto
+      type: howto
+      topics:
+      - security
+      - authentication
+      - basic-authentication
+      - http
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+      - io.quarkus:quarkus-elytron-security-jdbc
+      - io.quarkus:quarkus-elytron-security-ldap
+      - io.quarkus:quarkus-security-jpa-reactive
+    - filename: security-jwt.adoc
+      id: security-jwt
+      title: Using JWT RBAC
+      summary: This guide explains how your application can use SmallRye JWT to provide secured access to the Jakarta REST endpoints.
+      url: /guides/security-jwt
+      type: guide
+      topics:
+      - security
+      - jwt
+      extensions:
+      - io.quarkus:quarkus-smallrye-jwt
+    - filename: security-jwt-build.adoc
+      id: security-jwt-build
+      title: "Build, sign, and encrypt JSON Web Tokens"
+      summary: "JSON Web Token (JWT) is defined by the RFC 7519 specification as a compact, URL-safe means of representing claims."
+      url: /guides/security-jwt-build
+      type: guide
+      topics:
+      - security
+      - jwt
+      extensions:
+      - io.quarkus:quarkus-smallrye-jwt-build
+    - filename: security-oauth2.adoc
+      title: Using OAuth2 RBAC
+      summary: This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the Jakarta REST endpoints.
+      url: /guides/security-oauth2
+      type: guide
+      keywords: oauth
+      topics:
+      - security
+      - oauth2
+      - identity-providers
+      extensions:
+      - io.quarkus:quarkus-elytron-security-oauth2
+    - filename: security-webauthn.adoc
+      id: security-webauthn
+      title: Using Security with WebAuthn
+      summary: This guide demonstrates how your Quarkus application can use WebAuthn authentication instead of passwords.
+      url: /guides/security-webauthn
+      type: guide
+      status: experimental
+      topics:
+      - security
+      - webauthn
+      - authorization
+      extensions:
+      - io.quarkus:quarkus-security-webauthn
+  - id: security-oidc
+    title: OIDC & OpenID Connect
+    guides:
+    - filename: security-oidc-code-flow-authentication.adoc
+      id: security-oidc-code-flow-authentication
+      title: OpenID Connect authorization code flow mechanism for protecting web applications
+      summary: "To protect your web applications, you can use the industry-standard OpenID Connect (OIDC) Authorization Code Flow mechanism provided by the Quarkus OIDC extension."
+      url: /guides/security-oidc-code-flow-authentication
+      type: concepts
+      topics:
+      - security
+      - oidc
+      - keycloak
+      - authentication
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-oidc-code-flow-authentication-tutorial.adoc
+      id: security-oidc-code-flow-authentication-tutorial
+      title: Protect a web application by using OpenID Connect (OIDC) authorization code flow
+      summary: "Discover how to secure application HTTP endpoints by using the Quarkus OpenID Connect (OIDC) authorization code flow mechanism with the Quarkus OIDC extension, providing robust authentication and authorization."
+      url: /guides/security-oidc-code-flow-authentication-tutorial
+      type: tutorial
+      topics:
+      - security
+      - oidc
+      - keycloak
+      - authorization
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-oidc-bearer-token-authentication.adoc
+      id: security-oidc-bearer-token-authentication
+      title: OpenID Connect (OIDC) Bearer token authentication
+      summary: Secure HTTP access to Jakarta REST (formerly known as JAX-RS) endpoints in your application with Bearer token authentication by using the Quarkus OpenID Connect (OIDC) extension.
+      url: /guides/security-oidc-bearer-token-authentication
+      type: concepts
+      topics:
+      - security
+      - oidc
+      - bearer-token
+      - keycloak
+      - authentication
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-oidc-bearer-token-authentication-tutorial.adoc
+      id: security-oidc-bearer-token-authentication-tutorial
+      title: Protect a service application by using OpenID Connect (OIDC) Bearer token authentication
+      summary: Use the Quarkus OpenID Connect (OIDC) extension to secure a Jakarta REST application with Bearer token authentication.
+      url: /guides/security-oidc-bearer-token-authentication-tutorial
+      type: tutorial
+      topics:
+      - security
+      - oidc
+      - bearer-token
+      - keycloak
+      - authentication
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-oidc-auth0-tutorial.adoc
+      id: security-oidc-auth0-tutorial
+      title: Protect a Quarkus web application by using an Auth0 OpenID Connect provider
+      summary: "Quarkus Security provides comprehensive OpenId Connect (OIDC) and OAuth2 support with its quarkus-oidc extension, supporting both Authorization code flow and Bearer token authentication mechanisms."
+      url: /guides/security-oidc-auth0-tutorial
+      type: tutorial
+      keywords: "oidc, sso, auth0"
+    - filename: security-oidc-configuration-properties-reference.adoc
+      id: security-oidc-configuration-properties-reference
+      title: OpenID Connect (OIDC) configuration properties
+      summary: "As a Quarkus developer, you configure the Quarkus OpenID Connect (OIDC) extension by setting the following properties in the src/main/resources/application.properties file."
+      url: /guides/security-oidc-configuration-properties-reference
+      type: reference
+      topics:
+      - security
+      - oidc
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-oidc-expanded-configuration.adoc
+      id: security-oidc-expanded-configuration
+      title: Quarkus OpenId Connect (OIDC) Expanded Configuration Reference
+      summary: "Quarkus OIDC quarkus-oidc extension provides a comprehensive, highly adaptable and configurable OIDC and OAuth2 adapter implementation."
+      url: /guides/security-oidc-expanded-configuration
+      type: concepts
+      topics:
+      - security
+    - filename: security-openid-connect-providers.adoc
+      id: security-openid-connect-providers
+      title: Configuring Well-Known OpenID Connect Providers
+      summary: This document explains how to configure well-known social OIDC and OAuth2 providers.
+      url: /guides/security-openid-connect-providers
+      type: concepts
+      keywords: oidc github twitter google facebook mastodon microsoft apple spotify twitch linkedin strava
+      topics:
+      - security
+      - oidc
+      - github
+      - twitter
+      - google
+      - facebook
+      - mastodon
+      - microsoft
+      - apple
+      - spotify
+      - twitch
+      - linkedin
+      - strava
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-openid-connect-client.adoc
+      id: security-openid-connect-client
+      title: OpenID Connect client and token propagation quickstart
+      summary: "Learn how to use OpenID Connect (OIDC) and OAuth2 clients with filters to get, refresh, and propagate access tokens in your applications."
+      url: /guides/security-openid-connect-client
+      type: tutorial
+      topics:
+      - security
+      - oidc
+      - client
+      extensions:
+      - io.quarkus:quarkus-oidc-client
+    - filename: security-openid-connect-client-reference.adoc
+      id: security-openid-connect-client-reference
+      title: OpenID Connect (OIDC) and OAuth2 client and filters
+      summary: "You can use Quarkus extensions for OpenID Connect and OAuth 2.0 access token management, focusing on acquiring, refreshing, and propagating tokens."
+      url: /guides/security-openid-connect-client-reference
+      type: reference
+      topics:
+      - security
+      - oidc
+      - client
+      extensions:
+      - io.quarkus:quarkus-oidc-client
+    - filename: security-openid-connect-client-registration.adoc
+      title: OpenID Connect (OIDC) and OAuth2 dynamic client registration
+      summary: "Typically, you have to register an OIDC client (application) manually in your OIDC provider&#8217;s dashboard."
+      url: /guides/security-openid-connect-client-registration
+      type: reference
+      status: experimental
+      topics:
+      - security
+      - oidc
+      - client
+      extensions:
+      - io.quarkus:quarkus-oidc-client-registration
+    - filename: security-openid-connect-multitenancy.adoc
+      id: security-openid-connect-multitenancy
+      title: Using OpenID Connect (OIDC) multitenancy
+      summary: This guide demonstrates how your OpenID Connect (OIDC) application can support multitenancy to serve multiple tenants from a single application.
+      url: /guides/security-openid-connect-multitenancy
+      type: howto
+      keywords: sso oidc oauth2 security
+      topics:
+      - security
+      - oidc
+      - multitenancy
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-openid-connect-dev-services.adoc
+      title: Dev Services and Dev UI for OpenID Connect (OIDC)
+      summary: You can use Dev Services for Keycloak and the Dev UI for the OpenID Connect (OIDC) Keycloak provider and adapt these services for other OpenID Connect providers.
+      url: /guides/security-openid-connect-dev-services
+      type: howto
+      keywords: sso oidc security keycloak
+      topics:
+      - security
+      - oidc
+      - keycloak
+      - dev-services
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-oidc
+    - filename: security-vertx-oidc-to-quarkus-oidc-migration.adoc
+      id: security-vertx-oidc-to-quarkus-oidc-migration
+      title: Migrate from Vert.x OIDC to Quarkus OIDC
+      summary: Learn how to migrate your Vert.x OIDC application to Quarkus and choose to either retain Vert.x OIDC or replace it with Quarkus OIDC.
+      url: /guides/security-vertx-oidc-to-quarkus-oidc-migration
+      type: tutorial
+      topics:
+      - security
+      - oidc
+      - vertx
+      extensions:
+      - io.quarkus:quarkus-oidc
+  - id: security-identity
+    title: Identity Providers
+    guides:
+    - filename: security-identity-providers.adoc
+      id: security-identity-providers
+      title: Identity providers
+      summary: "In the Quarkus Security framework, identity providers play a crucial role in authentication and authorization by verifying user identities."
+      url: /guides/security-identity-providers
+      type: concepts
+      topics:
+      - security
+      - identity-providers
+      extensions:
+      - io.quarkus:quarkus-elytron-security-jdbc
+      - io.quarkus:quarkus-elytron-security-ldap
+      - io.quarkus:quarkus-security-jpa-reactive
+    - filename: security-jpa.adoc
+      id: security-jpa
+      title: Quarkus Security with Jakarta Persistence
+      summary: You can configure your application to use Jakarta Persistence to store users' identities.
+      url: /guides/security-jpa
+      type: howto
+      topics:
+      - security
+      - identity-providers
+      - sql
+      - database
+      - jpa
+      - jdbc
+      extensions:
+      - io.quarkus:quarkus-security-jpa-reactive
+    - filename: security-jdbc.adoc
+      title: Using Security with JDBC
+      summary: This guide demonstrates how your Quarkus application can use a database to store your user identities.
+      url: /guides/security-jdbc
+      type: guide
+      topics:
+      - security
+      - identity-providers
+      - jdbc
+      - sql
+      - database
+      extensions:
+      - io.quarkus:quarkus-elytron-security-jdbc
+    - filename: security-ldap.adoc
+      title: Using Security with an LDAP Realm
+      summary: This guide demonstrates how your Quarkus application can use a LDAP directory to store your user identities.
+      url: /guides/security-ldap
+      type: guide
+      topics:
+      - security
+      - identity-providers
+      - ldap
+      extensions:
+      - io.quarkus:quarkus-elytron-security-ldap
+    - filename: security-keycloak-authorization.adoc
+      id: security-keycloak-authorization
+      title: Using OpenID Connect (OIDC) and Keycloak to centralize authorization
+      summary: Learn how to enable bearer token authorization in your Quarkus application by using Keycloak Authorization Services for secure access to protected resources.
+      url: /guides/security-keycloak-authorization
+      type: howto
+      keywords: "sso, oidc, security, keycloak"
+      topics:
+      - security
+      - authentication
+      - authorization
+      - keycloak
+      - sso
+      - oidc
+      extensions:
+      - io.quarkus:quarkus-oidc
+      - io.quarkus:quarkus-keycloak-authorization
+    - filename: security-keycloak-admin-client.adoc
+      title: Using Keycloak Admin Client
+      summary: The Quarkus Keycloak Admin Client and its reactive twin support Keycloak Admin Client which can be used to configure a running Keycloak server.
+      url: /guides/security-keycloak-admin-client
+      type: guide
+      keywords: sso oidc security keycloak
+      topics:
+      - security
+      - authentication
+      - authorization
+      - keycloak
+      - sso
+      extensions:
+      - io.quarkus:quarkus-keycloak-admin-rest-client
+      - io.quarkus:quarkus-keycloak-admin-resteasy-client
+- id: execution-model
+  title: Execution Model
+  description: "Virtual threads, reactive programming, and context propagation"
+  subcategories:
+  - id: execution-model-virtual-threads
+    title: Virtual Threads
+    guides:
+    - filename: virtual-threads.adoc
+      id: virtual-threads
+      title: Virtual Thread support reference
+      summary: This guide explains how to benefit from Java 21+ virtual threads in Quarkus application.
+      url: /guides/virtual-threads
+      type: reference
+      topics:
+      - virtual-threads
+    - filename: rest-virtual-threads.adoc
+      id: rest-virtual-threads
+      title: Use virtual threads in REST applications
+      summary: How to use virtual threads in a REST application
+      url: /guides/rest-virtual-threads
+      type: howto
+      topics:
+      - rest
+      - resteasy-reactive
+      - virtual-threads
+      extensions:
+      - io.quarkus:quarkus-rest
+      - io.quarkus:quarkus-rest-jackson
+      - io.quarkus:quarkus-rest-jsonb
+      - io.quarkus:quarkus-rest-client
+      - io.quarkus:quarkus-rest-client-jackson
+      - io.quarkus:quarkus-rest-client-jsonb
+    - filename: grpc-virtual-threads.adoc
+      title: Quarkus Virtual Thread support for gRPC services
+      summary: This guide explains how to benefit from Java virtual threads when implementing a gRPC service.
+      url: /guides/grpc-virtual-threads
+      type: guide
+      topics:
+      - grpc
+      - virtual-threads
+      extensions:
+      - io.quarkus:quarkus-grpc
+    - filename: messaging-virtual-threads.adoc
+      title: Quarkus Virtual Thread support with Reactive Messaging
+      summary: This guide explains how to benefit from Java virtual threads when writing message processing applications in Quarkus.
+      url: /guides/messaging-virtual-threads
+      type: guide
+      topics:
+      - messaging
+      - kafka
+      - reactive-messaging
+      - virtual-threads
+      extensions:
+      - io.quarkus:quarkus-messaging-kafka
+  - id: execution-model-reactive
+    title: Reactive
+    guides:
+    - filename: getting-started-reactive.adoc
+      title: Getting Started With Reactive
+      summary: Learn more about developing reactive applications with Quarkus.
+      url: /guides/getting-started-reactive
+      type: guide
+      topics:
+      - getting-started
+      - reactive
+    - filename: mutiny-primer.adoc
+      title: Mutiny - Async for mere mortals
+      summary: "Mutiny is an intuitive, reactive programming library."
+      url: /guides/mutiny-primer
+      type: guide
+      topics:
+      - mutiny
+      - reactive
+      extensions:
+      - io.quarkus:quarkus-mutiny
+    - filename: quarkus-reactive-architecture.adoc
+      title: Quarkus Reactive Architecture
+      summary: Learn more about Quarkus reactive architecture.
+      url: /guides/quarkus-reactive-architecture
+      type: guide
+      categories: architecture
+      topics:
+      - internals
+      - reactive
+    - filename: reactive-routes.adoc
+      title: Using Reactive Routes
+      summary: This guide demonstrates how to use reactive routes.
+      url: /guides/reactive-routes
+      type: guide
+      topics:
+      - http
+      - web
+      - routing
+      extensions:
+      - io.quarkus:quarkus-reactive-routes
+    - filename: reactive-sql-clients.adoc
+      title: Reactive SQL Clients
+      summary: This guide covers how to use the Reactive SQL Clients in Quarkus.
+      url: /guides/reactive-sql-clients
+      type: guide
+      topics:
+      - data
+      - database
+      - reactive
+      - sql
+      extensions:
+      - io.quarkus:quarkus-reactive-mysql-client
+      - io.quarkus:quarkus-reactive-oracle-client
+      - io.quarkus:quarkus-reactive-pg-client
+      - io.quarkus:quarkus-reactive-db2-client
+      - io.quarkus:quarkus-reactive-mssql-client
+    - filename: hibernate-reactive.adoc
+      title: Using Hibernate Reactive
+      summary: "Hibernate Reactive is a reactive API for Hibernate ORM, supporting non-blocking database drivers and a reactive style of interaction with the database."
+      url: /guides/hibernate-reactive
+      type: guide
+      status: preview
+      topics:
+      - data
+      - hibernate-reactive
+      - sql
+      extensions:
+      - io.quarkus:quarkus-hibernate-reactive-panache
+      - io.quarkus:quarkus-hibernate-reactive
+    - filename: hibernate-reactive-panache.adoc
+      title: Simplified Hibernate Reactive with Panache
+      summary: Simplified reactive ORM layer based on Hibernate Reactive.
+      url: /guides/hibernate-reactive-panache
+      type: guide
+      topics:
+      - data
+      - hibernate-reactive
+      - panache
+      - sql
+      extensions:
+      - io.quarkus:quarkus-hibernate-reactive-panache
+      - io.quarkus:quarkus-hibernate-reactive
+    - filename: reactive-event-bus.adoc
+      title: Using the event bus
+      summary: This guide explains how different beans can interact using the event bus.
+      url: /guides/reactive-event-bus
+      type: guide
+      keywords: vertx vert.x
+      topics:
+      - messaging
+      - event-bus
+      - vert.x
+      extensions:
+      - io.quarkus:quarkus-vertx
+  - id: execution-model-context
+    title: Context Propagation
+    guides:
+    - filename: context-propagation.adoc
+      title: Context Propagation in Quarkus
+      summary: Learn more about how you can pass contextual information with SmallRye Context Propagation.
+      url: /guides/context-propagation
+      type: guide
+      topics:
+      - context-propagation
+    - filename: duplicated-context.adoc
+      id: duplicated-context
+      title: "Duplicated context, context locals, asynchronous processing and propagation"
+      summary: "When using a traditional, blocking, and synchronous framework, processing of each request is performed in a dedicated thread."
+      url: /guides/duplicated-context
+      type: concepts
+      topics:
+      - internals
+      - extensions
+- id: cloud
+  title: Cloud
+  description: Cloud platforms and deployment
+  subcategories:
+  - id: cloud-deployment
+    title: Deployment
+    guides:
+    - filename: deploying-to-kubernetes.adoc
+      id: deploy-kubernetes
+      title: Kubernetes extension
+      summary: This guide covers how to deploy a native application on Kubernetes.
+      url: /guides/deploying-to-kubernetes
+      type: guide
+      topics:
+      - devops
+      - kubernetes
+      - cloud
+      - deployment
+      extensions:
+      - io.quarkus:quarkus-kubernetes
+    - filename: deploying-to-openshift.adoc
+      id: deploying-to-openshift
+      title: Deploying Quarkus applications to OpenShift
+      summary: This guide describes the deployment of Quarkus applications to OpenShift.
+      url: /guides/deploying-to-openshift
+      type: guide
+      topics:
+      - devops
+      - kubernetes
+      - openshift
+      - cloud
+      - deployment
+      extensions:
+      - io.quarkus:quarkus-openshift
+    - filename: deploying-to-openshift-howto.adoc
+      id: deploying-to-openshift-howto
+      title: Deploying Quarkus applications to OpenShift in a single step
+      summary: This guide describes how to build and deploy a Quarkus application to OpenShift in a single step.
+      url: /guides/deploying-to-openshift-howto
+      type: howto
+      topics:
+      - devops
+      - kubernetes
+      - openshift
+      - cloud
+      - deployment
+      extensions:
+      - io.quarkus:quarkus-openshift
+    - filename: deploying-to-openshift-s2i-howto.adoc
+      id: deploying-to-openshift-s2i-howto
+      title: Using S2I to deploy Quarkus applications to OpenShift
+      summary: This guide describes how to build and deploy a Quarkus application on OpenShift by using Source-to-Image (S2I).
+      url: /guides/deploying-to-openshift-s2i-howto
+      type: howto
+      topics:
+      - devops
+      - kubernetes
+      - openshift
+      - cloud
+      - deployment
+      extensions:
+      - io.quarkus:quarkus-openshift
+    - filename: deploying-to-openshift-docker-howto.adoc
+      id: deploying-to-openshift-docker-howto
+      title: Deploying Quarkus Java applications to OpenShift by using a Docker build strategy
+      summary: This guide describes how to build and deploy a Quarkus application on OpenShift by using the Docker build strategy.
+      url: /guides/deploying-to-openshift-docker-howto
+      type: howto
+      topics:
+      - devops
+      - kubernetes
+      - openshift
+      - cloud
+      - deployment
+      extensions:
+      - io.quarkus:quarkus-openshift
+    - filename: deploying-to-openshift-native-howto.adoc
+      id: deploying-to-openshift-native-howto
+      title: Deploying Quarkus applications compiled to native executables
+      summary: This guide describes how to deploy a Quarkus application to OpenShift compiled to native executables.
+      url: /guides/deploying-to-openshift-native-howto
+      type: howto
+      topics:
+      - devops
+      - kubernetes
+      - openshift
+      - cloud
+      - deployment
+      extensions:
+      - io.quarkus:quarkus-openshift
+    - filename: deploying-to-azure-cloud.adoc
+      title: Deploying to Microsoft Azure Cloud
+      summary: Deploy a Quarkus application to the Microsoft Azure cloud platform.
+      url: /guides/deploying-to-azure-cloud
+      type: guide
+      topics:
+      - devops
+      - azure
+      - cloud
+      - deployment
+    - filename: deploying-to-google-cloud.adoc
+      title: Deploying to Google Cloud Platform (GCP)
+      summary: This guide explains how to deploy a Quarkus application to Google Cloud.
+      url: /guides/deploying-to-google-cloud
+      type: guide
+      topics:
+      - devops
+      - google
+      - gcp
+      - cloud
+      - deployment
+    - filename: deploying-to-heroku.adoc
+      title: Deploying to Heroku
+      summary: Deploy your Quarkus applications on Heroku.
+      url: /guides/deploying-to-heroku
+      type: guide
+      topics:
+      - devops
+      - heroku
+      - cloud
+      - deployment
+      - docker
+      - podman
+    - filename: ansible.adoc
+      title: Automate Quarkus deployment with Ansible
+      summary: Build and deploy your Quarkus App using Ansible
+      url: /guides/ansible
+      type: guide
+      topics:
+      - ansible
+      - devops
+  - id: cloud-functions
+    title: Serverless Functions
+    guides:
+    - filename: aws-lambda.adoc
+      title: AWS Lambda
+      summary: This guide explains how you can deploy Quarkus-based AWS Lambdas.
+      url: /guides/aws-lambda
+      type: guide
+      topics:
+      - aws
+      - lambda
+      - serverless
+      - function
+      - cloud
+      extensions:
+      - io.quarkus:quarkus-amazon-lambda
+    - filename: aws-lambda-http.adoc
+      title: "AWS Lambda with Quarkus REST, Undertow, or Reactive Routes"
+      summary: "This guide explains how you can deploy Vert.x Web, Servlet, or RESTEasy microservices as an AWS Lambda."
+      url: /guides/aws-lambda-http
+      type: guide
+      status: preview
+      topics:
+      - aws
+      - lambda
+      - serverless
+      - function
+      - cloud
+      extensions:
+      - io.quarkus:quarkus-amazon-lambda
+      - io.quarkus:quarkus-amazon-lambda-http
+    - filename: aws-lambda-snapstart.adoc
+      title: AWS Lambda SnapStart Configuration
+      summary: This document explains how to optimize your AWS Lambda application for SnapStart
+      url: /guides/aws-lambda-snapstart
+      type: guide
+      topics:
+      - aws
+      - lambda
+      - serverless
+      - function
+      - snapstart
+      - cloud
+    - filename: gcp-functions.adoc
+      title: Google Cloud Functions (Serverless)
+      summary: This guide explains how you can deploy Quarkus-based Google Cloud Functions.
+      url: /guides/gcp-functions
+      type: guide
+      status: preview
+      topics:
+      - google
+      - gcp
+      - serverless
+      - function
+      - cloud
+      extensions:
+      - io.quarkus:quarkus-google-cloud-functions
+    - filename: gcp-functions-http.adoc
+      title: "Google Cloud Functions (Serverless) with Quarkus REST, Undertow, or Reactive Routes"
+      summary: "This guide explains how you can deploy Vert.x Web, Servlet, or RESTEasy microservices as a Google Cloud Function."
+      url: /guides/gcp-functions-http
+      type: guide
+      status: preview
+      topics:
+      - google
+      - gcp
+      - serverless
+      - function
+      - cloud
+      extensions:
+      - io.quarkus:quarkus-google-cloud-functions-http
+    - filename: azure-functions.adoc
+      title: Azure Functions
+      summary: Integrate Quarkus with the Microsoft Azure functions that you have written.
+      url: /guides/azure-functions
+      type: guide
+      status: preview
+      topics:
+      - azure
+      - serverless
+      - function
+      - cloud
+      extensions:
+      - io.quarkus:quarkus-azure-functions
+    - filename: azure-functions-http.adoc
+      title: "Azure Functions with Quarkus REST, Undertow, or Reactive Routes"
+      summary: "Deploy Vert.x Web, Servlet, or RESTEasy microservices as a Microsoft Azure Function."
+      url: /guides/azure-functions-http
+      type: guide
+      status: preview
+      topics:
+      - azure
+      - serverless
+      - function
+      - cloud
+      extensions:
+      - io.quarkus:quarkus-azure-functions-http
+    - filename: funqy.adoc
+      title: Funqy
+      summary: "This guide explains basics of the Funqy framework, a simple portable cross-provider cloud function API."
+      url: /guides/funqy
+      type: guide
+      status: preview
+      topics:
+      - serverless
+      - function
+      - cloud
+      - funqy
+    - filename: funqy-http.adoc
+      title: Funqy HTTP Binding (Standalone)
+      summary: This guide explains Funqy's HTTP binding.
+      url: /guides/funqy-http
+      type: guide
+      status: preview
+      topics:
+      - serverless
+      - function
+      - cloud
+      - funqy
+      extensions:
+      - io.quarkus:quarkus-funqy-http
+    - filename: funqy-aws-lambda.adoc
+      title: Funqy AWS Lambda Binding
+      summary: This guide explains Funqy's AWS Lambda binding.
+      url: /guides/funqy-aws-lambda
+      type: guide
+      status: preview
+      topics:
+      - aws
+      - lambda
+      - serverless
+      - function
+      - cloud
+      - funqy
+      extensions:
+      - io.quarkus:quarkus-funqy-amazon-lambda
+    - filename: funqy-aws-lambda-http.adoc
+      title: Funqy HTTP Binding with AWS Lambda 
+      summary: This guide explains Funqy's AWS Lambda HTTP binding.
+      url: /guides/funqy-aws-lambda-http
+      type: guide
+      status: preview
+      topics:
+      - aws
+      - lambda
+      - serverless
+      - function
+      - cloud
+      - funqy
+      extensions:
+      - io.quarkus:quarkus-funqy-http
+      - io.quarkus:quarkus-amazon-lambda-http
+    - filename: funqy-gcp-functions.adoc
+      title: Funqy Google Cloud Functions
+      summary: This guide explains Funqy's Google Cloud Platform Functions binding.
+      url: /guides/funqy-gcp-functions
+      type: guide
+      status: preview
+      topics:
+      - google
+      - gcp
+      - serverless
+      - function
+      - cloud
+      - funqy
+      extensions:
+      - io.quarkus:quarkus-funqy-http
+      - io.quarkus:quarkus-funqy-google-cloud-functions
+    - filename: funqy-gcp-functions-http.adoc
+      title: Funqy HTTP Binding with Google Cloud Functions
+      summary: This guide explains Funqy's Google Cloud Platform Functions HTTP binding.
+      url: /guides/funqy-gcp-functions-http
+      type: guide
+      status: preview
+      topics:
+      - google
+      - gcp
+      - serverless
+      - function
+      - cloud
+      - funqy
+      extensions:
+      - io.quarkus:quarkus-funqy-http
+      - io.quarkus:quarkus-google-cloud-functions-http
+    - filename: funqy-azure-functions-http.adoc
+      title: Funqy HTTP Binding with Azure Functions
+      summary: Use Funqy HTTP binding with Microsoft Azure Functions to deploy your serverless Quarkus applications.
+      url: /guides/funqy-azure-functions-http
+      type: guide
+      status: preview
+      topics:
+      - azure
+      - serverless
+      - function
+      - cloud
+      - funqy
+      extensions:
+      - io.quarkus:quarkus-azure-functions-http
+    - filename: funqy-knative-events.adoc
+      title: Funqy Knative Events Binding
+      summary: This guide explains Funqy's Knative Events binding.
+      url: /guides/funqy-knative-events
+      type: guide
+      topics:
+      - serverless
+      - function
+      - cloud
+      - funqy
+      extensions:
+      - io.quarkus:quarkus-funqy-knative-events
+  - id: cloud-kubernetes
+    title: Kubernetes
+    guides:
+    - filename: kubernetes-client.adoc
+      title: Kubernetes Client
+      summary: This guide demonstrates how to use the Fabric8 Kubernetes client to interact with your Kubernetes cluster.
+      url: /guides/kubernetes-client
+      type: guide
+      topics:
+      - kubernetes
+      - openshift
+      - kubernetes-client
+      extensions:
+      - io.quarkus:quarkus-kubernetes-client
+    - filename: kubernetes-config.adoc
+      title: Kubernetes Config
+      summary: Use ConfigMaps as a configuration source for your Quarkus applications.
+      url: /guides/kubernetes-config
+      type: guide
+      topics:
+      - kubernetes
+      - openshift
+      - configuration
+      - configmap
+      extensions:
+      - io.quarkus:quarkus-kubernetes-config
+    - filename: kubernetes-dev-services.adoc
+      title: Dev Services for Kubernetes
+      summary: Start a Kubernetes API server automatically in dev and test modes.
+      url: /guides/kubernetes-dev-services
+      type: guide
+      topics:
+      - dev-services
+      - kubernetes
+      - testing
+      - dev-mode
+      extensions:
+      - io.quarkus:quarkus-kubernetes-client
+    - filename: init-tasks.adoc
+      title: Initialization tasks
+      summary: This reference guide explains how to configure initialization tasks
+      url: /guides/init-tasks
+      type: guide
+      topics:
+      - init
+      - kubernetes
+      - openshift
+      - liquibase
+      - flyway
+      extensions:
+      - io.quarkus:quarkus-kubernetes
+      - io.quarkus:quarkus-openshift
+      - io.quarkus:quarkus-flyway
+      - io.quarkus:quarkus-liquibase
+  - id: cloud-service-discovery
+    title: Service Discovery
+    guides:
+    - filename: stork.adoc
+      title: Getting Started with SmallRye Stork
+      summary: The essence of distributed systems resides in the interaction between services.
+      url: /guides/stork
+      type: guide
+      status: preview
+      topics:
+      - service-discovery
+      - load-balancing
+      - stork
+      extensions:
+      - io.quarkus:quarkus-smallrye-stork
+    - filename: stork-kubernetes.adoc
+      title: Using Stork with Kubernetes
+      summary: This guide explains how to use Stork with Kubernetes for service discovery and load balancing.
+      url: /guides/stork-kubernetes
+      type: guide
+      status: preview
+      topics:
+      - service-discovery
+      - load-balancing
+      - stork
+      - kubernetes
+      extensions:
+      - io.quarkus:quarkus-kubernetes
+      - io.quarkus:quarkus-smallrye-stork
+    - filename: stork-reference.adoc
+      title: Stork Reference Guide
+      summary: This guide is the companion from the Stork Getting Started Guide.
+      url: /guides/stork-reference
+      type: reference
+      status: preview
+      topics:
+      - service-discovery
+      - load-balancing
+      - stork
+      extensions:
+      - io.quarkus:quarkus-smallrye-stork
+    - filename: stork-registration.adoc
+      title: Automatic service registration with SmallRye Stork for Quarkus
+      summary: "This guide explains how to enable automatic registration and deregistration of a Quarkus application using SmallRye Stork and Consul, with minimal or no configuration."
+      url: /guides/stork-registration
+      type: guide
+      status: preview
+      topics:
+      - service-discovery
+      - consul
+      extensions:
+      - io.quarkus:quarkus-smallrye-stork
+    - filename: stork-manual-service-registration.adoc
+      title: Implementing a Custom Stork Service Registrar
+      summary: This guide explains how to implement a custom service registrar for SmallRye Stork and use it to programmatically register service instances at startup.
+      url: /guides/stork-manual-service-registration
+      type: guide
+      status: preview
+      topics:
+      - service-discovery
+      - service-registration
+      - stork
+      extensions:
+      - io.quarkus:quarkus-smallrye-stork
+- id: operations
+  title: Operations
+  description: "Production operations, observability, resilience, and monitoring"
+  guides: null
+  subcategories:
+  - id: operations-management
+    title: Management
+    guides:
+    - filename: management-interface-reference.adoc
+      title: Management interface reference
+      summary: Management interface configuration
+      url: /guides/management-interface-reference
+      type: reference
+      topics:
+      - management
+      - observability
+      extensions:
+      - io.quarkus:quarkus-vertx-http
+    - filename: tls-registry-reference.adoc
+      id: tls-registry-reference
+      title: TLS registry reference
+      summary: TLS registry configuration and usage
+      url: /guides/tls-registry-reference
+      type: reference
+      topics:
+      - TLS
+      - http
+      - SSL
+      - HTTPS
+      - security
+      - network
+      extensions:
+      - io.quarkus:quarkus-tls-registry
+    - filename: proxy-registry.adoc
+      title: Using Proxy Registry
+      summary: This guide explains how to use the Proxy Registry in your Quarkus application.
+      url: /guides/proxy-registry
+      type: guide
+      status: preview
+      topics:
+      - security
+      - proxy
+      - http
+      extensions:
+      - io.quarkus:quarkus-proxy-registry
+  - id: operations-health
+    title: Health
+    guides:
+    - filename: smallrye-health.adoc
+      title: SmallRye Health
+      summary: This guide demonstrates how your Quarkus application can utilize the SmallRye Health extension.
+      url: /guides/smallrye-health
+      type: guide
+      topics:
+      - health
+      - observability
+      extensions:
+      - io.quarkus:quarkus-smallrye-health
+    - filename: info.adoc
+      title: Application Info Endpoint
+      summary: "Expose build, git, Java, and OS information via the /q/info endpoint."
+      url: /guides/info
+      type: guide
+      topics:
+      - info
+      - observability
+      extensions:
+      - io.quarkus:quarkus-info
+  - id: operations-logging
+    title: Logging
+    guides:
+    - filename: logging.adoc
+      id: logging
+      title: Logging configuration
+      summary: "Read about the use of logging API in Quarkus, configuring logging output, and using logging adapters to unify the output from other logging APIs."
+      url: /guides/logging
+      type: reference
+      topics:
+      - logging
+      - observability
+    - filename: centralized-log-management.adoc
+      title: "Centralized log management (Graylog, Logstash, Fluentd)"
+      summary: "This guide explains how to centralize your logs with Graylog, Logstash or Fluentd."
+      url: /guides/centralized-log-management
+      type: guide
+      topics:
+      - observability
+      - logging
+      extensions:
+      - io.quarkus:quarkus-logging-gelf
+      - io.quarkus:quarkus-opentelemetry
+    - filename: opentelemetry-logging.adoc
+      title: Using OpenTelemetry Logging
+      summary: This guide explains how your Quarkus application can utilize OpenTelemetry Logging to provide centralised logging for interactive web applications.
+      url: /guides/opentelemetry-logging
+      type: guide
+      status: preview
+      topics:
+      - observability
+      - opentelemetry
+      - logging
+      extensions:
+      - io.quarkus:quarkus-opentelemetry
+  - id: operations-metrics
+    title: Metrics and Telemetry
+    guides:
+    - filename: telemetry-micrometer.adoc
+      id: telemetry-micrometer
+      title: Micrometer Metrics
+      summary: "Use Micrometer to collect metrics produced by Quarkus, its extensions, and your application."
+      url: /guides/telemetry-micrometer
+      type: reference
+      topics:
+      - observability
+      - micrometer
+      extensions:
+      - io.quarkus:quarkus-micrometer
+    - filename: telemetry-micrometer-tutorial.adoc
+      id: telemetry-micrometer-tutorial
+      title: Collect metrics using Micrometer
+      summary: "Create an application that uses the Micrometer metrics library to collect runtime, extension and application metrics and expose them as a Prometheus (OpenMetrics) endpoint."
+      url: /guides/telemetry-micrometer-tutorial
+      type: tutorial
+      topics:
+      - observability
+      - micrometer
+      - prometheus
+      extensions:
+      - io.quarkus:quarkus-micrometer-registry-prometheus
+      - io.quarkus:quarkus-micrometer
+    - filename: observability.adoc
+      title: Observability in Quarkus
+      summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide observability for interactive web applications.
+      url: /guides/observability
+      type: reference
+      topics:
+      - observability
+      - opentelemetry
+      - micrometer
+      - jfr
+      - logging
+      - metrics
+      - tracing
+      - monitoring
+      - devservice
+      extensions:
+      - io.quarkus:quarkus-opentelemetry
+      - io.quarkus:quarkus-micrometer
+      - io.quarkus:quarkus-jfr
+    - filename: opentelemetry.adoc
+      title: Using OpenTelemetry
+      summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide observability for interactive web applications.
+      url: /guides/opentelemetry
+      type: reference
+      topics:
+      - observability
+      - opentelemetry
+      extensions:
+      - io.quarkus:quarkus-opentelemetry
+    - filename: opentelemetry-tracing.adoc
+      title: Using OpenTelemetry Tracing
+      summary: This guide explains how your Quarkus application can utilize OpenTelemetry Tracing to provide distributed tracing for interactive web applications.
+      url: /guides/opentelemetry-tracing
+      type: guide
+      topics:
+      - observability
+      - opentelemetry
+      - tracing
+      extensions:
+      - io.quarkus:quarkus-opentelemetry
+    - filename: opentelemetry-metrics.adoc
+      title: Using OpenTelemetry Metrics
+      summary: This guide explains how your Quarkus application can utilize OpenTelemetry to provide metrics for interactive web applications.
+      url: /guides/opentelemetry-metrics
+      type: guide
+      status: preview
+      topics:
+      - observability
+      - opentelemetry
+      - metrics
+      extensions:
+      - io.quarkus:quarkus-opentelemetry
+    - filename: telemetry-micrometer-to-opentelemetry.adoc
+      id: telemetry-micrometer-opentelemetry
+      title: Micrometer and OpenTelemetry extension
+      summary: Guide to send Micrometer data to OpenTelemetry.
+      url: /guides/telemetry-micrometer-to-opentelemetry
+      type: reference
+      status: preview
+      topics:
+      - observability
+      - opentelemetry
+      - metrics
+      - micrometer
+      - tracing
+      - logs
+      extensions:
+      - io.quarkus:quarkus-micrometer-opentelemetry
+    - filename: telemetry-opentracing-to-otel-tutorial.adoc
+      id: telemetry-opentracing-to-otel-tutorial
+      title: Migrate from OpenTracing to OpenTelemetry tracing
+      summary: Migrate an application from OpenTracing to OpenTelemetry tracing in Quarkus 3.x.
+      url: /guides/telemetry-opentracing-to-otel-tutorial
+      type: tutorial
+      topics:
+      - observability
+      - opentracing
+      - opentelemetry
+      - tracing
+      - migration
+      extensions:
+      - io.quarkus:quarkus-smallrye-opentracing
+      - io.quarkus:quarkus-opentelemetry
+    - filename: jfr.adoc
+      id: jfr
+      title: Using JDK Flight Recorder
+      summary: This guide explains how JDK Flight Recorder (JFR) can be extended to provide additional insight into your Quarkus application.
+      url: /guides/jfr
+      type: guide
+      topics:
+      - observability
+      - jfr
+      extensions:
+      - io.quarkus:quarkus-jfr
+    - filename: observability-devservices.adoc
+      title: Observability Dev Services
+      summary: Entry point for Observability DevServices
+      url: /guides/observability-devservices
+      type: guide
+      topics:
+      - observability
+      - grafana
+      - lgtm
+      - prometheus
+      - victoriametrics
+      - jaeger
+      - otel
+      - otlp
+      extensions:
+      - io.quarkus:quarkus-observability-devservices
+    - filename: observability-devservices-lgtm.adoc
+      title: Observability Dev Services with Grafana OTel LGTM
+      summary: Instructions on how to use Grafana Otel LGTM
+      url: /guides/observability-devservices-lgtm
+      type: guide
+      topics:
+      - observability
+      - grafana
+      - lgtm
+      - otlp
+      - opentelemetry
+      - devservices
+      - micrometer
+      extensions:
+      - io.quarkus:quarkus-observability-devservices
+  - id: operations-resilience
+    title: Resilience
+    guides:
+    - filename: smallrye-fault-tolerance.adoc
+      title: SmallRye Fault Tolerance
+      summary: This guide demonstrates how your Quarkus application can utilize the SmallRye Fault Tolerance specification through the SmallRye Fault Tolerance extension.
+      url: /guides/smallrye-fault-tolerance
+      type: guide
+      topics:
+      - fault-tolerance
+      - resiliency
+      extensions:
+      - io.quarkus:quarkus-smallrye-fault-tolerance
+    - filename: load-shedding-reference.adoc
+      title: Load Shedding reference guide
+      summary: Load shedding is the practice of detecting service overload and rejecting requests.
+      url: /guides/load-shedding-reference
+      type: reference
+      status: experimental
+      topics:
+      - web
+      - load-shedding
+      extensions:
+      - io.quarkus:quarkus-load-shedding
+- id: serialization
+  title: Serialization
+  description: Data serialization and RPC
+  subcategories:
+  - id: serialization-json
+    title: JSON
+    guides:
+    - filename: rest-json.adoc
+      title: Writing JSON REST Services
+      summary: JSON is now the lingua franca between microservices.
+      url: /guides/rest-json
+      type: guide
+      topics:
+      - rest
+      - json
+      - resteasy-reactive
+      extensions:
+      - io.quarkus:quarkus-rest-jackson
+      - io.quarkus:quarkus-rest-jsonb
+      - io.quarkus:quarkus-rest
+  - id: serialization-grpc
+    title: gRPC
+    guides:
+    - filename: grpc.adoc
+      title: gRPC
+      summary: Entry point for everything gRPC.
+      url: /guides/grpc
+      type: guide
+      topics:
+      - grpc
+      extensions:
+      - io.quarkus:quarkus-grpc
+      - io.quarkus:quarkus-grpc-xds
+    - filename: grpc-getting-started.adoc
+      title: Getting Started with gRPC
+      summary: This guide explains how to start using gRPC in your Quarkus application.
+      url: /guides/grpc-getting-started
+      type: guide
+      topics:
+      - grpc
+      extensions:
+      - io.quarkus:quarkus-grpc
+    - filename: grpc-service-implementation.adoc
+      title: Implementing a gRPC Service
+      summary: This guide explains how to implement gRPC services in your Quarkus application.
+      url: /guides/grpc-service-implementation
+      type: guide
+      topics:
+      - grpc
+      extensions:
+      - io.quarkus:quarkus-grpc
+    - filename: grpc-service-consumption.adoc
+      title: Consuming a gRPC Service
+      summary: This guide explains how to consume gRPC services in your Quarkus application.
+      url: /guides/grpc-service-consumption
+      type: guide
+      topics:
+      - grpc
+      extensions:
+      - io.quarkus:quarkus-grpc
+    - filename: grpc-cli.adoc
+      title: Using gRPC CLI
+      summary: This page explains how to use gRPC CLI.
+      url: /guides/grpc-cli
+      type: guide
+      topics:
+      - grpc
+      - cli
+      extensions:
+      - io.quarkus:quarkus-grpc-cli
+    - filename: grpc-reference.adoc
+      title: gRPC reference guide
+      summary: Learn how to configure gRPC server and clients.
+      url: /guides/grpc-reference
+      type: reference
+      topics:
+      - grpc
+      extensions:
+      - io.quarkus:quarkus-grpc
+    - filename: grpc-generation-reference.adoc
+      title: gRPC code generation reference guide
+      summary: Learn how to configure gRPC code generation.
+      url: /guides/grpc-generation-reference
+      type: reference
+      topics:
+      - grpc
+      extensions:
+      - io.quarkus:quarkus-grpc
+    - filename: grpc-kubernetes.adoc
+      title: Deploying your gRPC Service in Kubernetes
+      summary: This guide explains how to deploy your gRPC services in Quarkus to Kubernetes.
+      url: /guides/grpc-kubernetes
+      type: guide
+      topics:
+      - grpc
+      - kubernetes
+      extensions:
+      - io.quarkus:quarkus-grpc
+      - io.quarkus:quarkus-kubernetes
+    - filename: grpc-xds.adoc
+      title: Using xDS gRPC
+      summary: This page explains how to enable xDS gRPC usage in your Quarkus application.
+      url: /guides/grpc-xds
+      type: guide
+      topics:
+      - grpc
+      - xds
+      extensions:
+      - io.quarkus:quarkus-grpc-xds
+    - filename: grpc-virtual-threads.adoc
+      title: Quarkus Virtual Thread support for gRPC services
+      summary: This guide explains how to benefit from Java virtual threads when implementing a gRPC service.
+      url: /guides/grpc-virtual-threads
+      type: guide
+      topics:
+      - grpc
+      - virtual-threads
+      extensions:
+      - io.quarkus:quarkus-grpc
+- id: command-line
+  title: Command Line
+  description: Command-line applications and tools
+  guides:
+  - filename: command-mode-reference.adoc
+    title: Command Mode Applications
+    summary: This reference guide explains how to develop command line applications with Quarkus.
+    url: /guides/command-mode-reference
+    type: reference
+    categories: command-line
+    topics:
+    - command-line
+    - cli
+  - filename: picocli.adoc
+    title: Command Mode with Picocli
+    summary: Simplify command line applications creation with the Picocli extension.
+    url: /guides/picocli
+    type: guide
+    categories: command-line
+    topics:
+    - command-line
+    - cli
+    - picocli
+    extensions:
+    - io.quarkus:quarkus-picocli
+  - filename: aesh.adoc
+    title: Command Mode with Aesh
+    summary: Develop command line applications with the Aesh extension.
+    url: /guides/aesh
+    type: guide
+    categories: command-line
+    topics:
+    - command-line
+    - cli
+    - aesh
+    - ssh
+    - websocket
+    - terminal
+    extensions:
+    - io.quarkus:quarkus-aesh
+    - io.quarkus:quarkus-aesh-websocket
+    - io.quarkus:quarkus-aesh-ssh
+  - filename: scripting.adoc
+    title: Scripting with Quarkus
+    summary: Easy Quarkus-based scripting with jbang.
+    url: /guides/scripting
+    type: guide
+    status: preview
+    categories: command-line
+    topics:
+    - scripting
+    - jbang
+- id: miscellaneous
+  title: Miscellaneous
+  description: "Other topics (mailer, scheduler, templating, etc.)"
+  subcategories:
+  - id: miscellaneous-templating
+    title: Templating
+    guides:
+    - filename: qute.adoc
+      title: Qute Templating Engine
+      summary: Learn more about how you can use templating in your applications with the Qute template engine.
+      url: /guides/qute
+      type: guide
+      topics:
+      - templating
+      - qute
+      extensions:
+      - io.quarkus:quarkus-qute
+      - io.quarkus:quarkus-resteasy-qute
+      - io.quarkus:quarkus-rest-qute
+    - filename: qute-reference.adoc
+      title: Qute Reference Guide
+      summary: Learn everything you need to know about the Qute template engine.
+      url: /guides/qute-reference
+      type: reference
+      topics:
+      - templating
+      - qute
+      extensions:
+      - io.quarkus:quarkus-qute
+      - io.quarkus:quarkus-resteasy-qute
+      - io.quarkus:quarkus-rest-qute
+  - id: miscellaneous-scheduling
+    title: Scheduling
+    guides:
+    - filename: scheduler.adoc
+      title: Scheduling Periodic Tasks
+      summary: Modern applications often need to run specific tasks periodically.
+      url: /guides/scheduler
+      type: guide
+      topics:
+      - scheduling
+      - cronjob
+      extensions:
+      - io.quarkus:quarkus-scheduler
+    - filename: scheduler-reference.adoc
+      title: Scheduler Reference Guide
+      summary: Learn more about the Scheduler extension.
+      url: /guides/scheduler-reference
+      type: reference
+      topics:
+      - scheduling
+      - cronjob
+      extensions:
+      - io.quarkus:quarkus-scheduler
+    - filename: quartz.adoc
+      title: Scheduling Periodic Tasks with Quartz
+      summary: You need clustering support for your scheduled tasks? This guide explains how to use the Quartz extension for that.
+      url: /guides/quartz
+      type: guide
+      topics:
+      - scheduling
+      - cronjob
+      - quartz
+      extensions:
+      - io.quarkus:quarkus-quartz
+  - id: miscellaneous-mail
+    title: Mail
+    guides:
+    - filename: mailer.adoc
+      title: Sending emails using SMTP
+      summary: Learn more about how you can send email from a Quarkus application with our reactive email client.
+      url: /guides/mailer
+      type: guide
+      topics:
+      - mail
+      - mailer
+      extensions:
+      - io.quarkus:quarkus-mailer
+    - filename: mailer-reference.adoc
+      title: Mailer Reference Guide
+      summary: This reference guide explains in more details the configuration and usage of the Quarkus Mailer.
+      url: /guides/mailer-reference
+      type: reference
+      topics:
+      - mail
+      - mailer
+      extensions:
+      - io.quarkus:quarkus-mailer
+- id: tooling
+  title: Tooling
+  description: "Development tools, build tools, and IDE support"
+  guides:
+  - filename: cli-tooling.adoc
+    id: cli-tooling
+    title: Building Quarkus apps with Quarkus Command Line Interface (CLI)
+    summary: "Use the Quarkus CLI to create, build, run, and manage extensions for Quarkus projects."
+    url: /guides/cli-tooling
+    type: guide
+    categories: tooling
+    topics:
+    - cli
+    - tooling
+  - filename: maven-tooling.adoc
+    id: maven-tooling
+    title: Quarkus and Maven
+    summary: Develop and build your Quarkus application with Maven
+    url: /guides/maven-tooling
+    type: guide
+    categories: tooling
+    topics:
+    - maven
+    - tooling
+  - filename: quarkus-maven-plugin.adoc
+    title: Quarkus Maven Plugin
+    summary: "The Quarkus Maven Plugin builds the Quarkus applications, and provides helpers to launch dev mode or build native executables."
+    url: /guides/quarkus-maven-plugin
+    type: reference
+    categories: tooling
+    topics:
+    - maven
+    - tooling
+  - filename: gradle-tooling.adoc
+    id: gradle-tooling
+    title: Quarkus and Gradle
+    summary: Develop and build your Quarkus application with Gradle
+    url: /guides/gradle-tooling
+    type: guide
+    categories: tooling
+    topics:
+    - gradle
+    - tooling
+  - filename: build-analytics.adoc
+    title: Build analytics
+    summary: This guide presents what build analytics is and how to configure it.
+    url: /guides/build-analytics
+    type: guide
+    categories: tooling
+  - filename: update-quarkus.adoc
+    id: update-quarkus
+    title: Update projects to the latest Quarkus version
+    summary: Learn how to upgrade your projects to the latest version of Quarkus
+    url: /guides/update-quarkus
+    type: howto
+    categories: tooling
+    topics:
+    - tooling
+- id: compatibility
+  title: Spring Compatibility
+  description: Spring framework compatibility layer
+  guides:
+  - filename: spring-di.adoc
+    title: Quarkus Extension for Spring DI API
+    summary: "While you are encouraged to use CDI annotations for injection, Quarkus provides a compatibility layer for Spring dependency injection in the form of the spring-di extension."
+    url: /guides/spring-di
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - cdi
+    - injection
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-di
+  - filename: spring-web.adoc
+    title: Quarkus Extension for Spring Web API
+    summary: "While you are encouraged to use Jakarta REST annotations for defining REST endpoints, Quarkus provides a compatibility layer for Spring Web in the form of the spring-web extension."
+    url: /guides/spring-web
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - rest
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-web
+  - filename: spring-data-jpa.adoc
+    title: Extension for Spring Data API
+    summary: "While you are encouraged to use Hibernate ORM with Panache for your data layer, Quarkus provides a compatibility layer for Spring Data JPA in the form of the spring-data-jpa extension."
+    url: /guides/spring-data-jpa
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - data
+    - hibernate-orm
+    - jpa
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-data-jpa
+  - filename: spring-tx.adoc
+    title: Quarkus Extension for Spring Transaction API
+    summary: "While you are encouraged to use Jakarta @Transactional directly, Quarkus provides a compatibility layer for Spring @Transactional in the form of the spring-tx extension."
+    url: /guides/spring-tx
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - transactions
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-tx
+  - filename: spring-boot-properties.adoc
+    title: Accessing application properties with Spring Boot properties API
+    summary: Use Spring Boot's @ConfigurationProperties in place of MicroProfile Config annotations
+    url: /guides/spring-boot-properties
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - configuration
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-boot-properties
+  - filename: spring-security.adoc
+    title: Quarkus Extension for Spring Security API
+    summary: "While you are encouraged to use the Quarkus Security layer to secure your applications, Quarkus provides a compatibility layer for Spring Security in the form of the spring-security extension."
+    url: /guides/spring-security
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - security
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-security
+  - filename: spring-cache.adoc
+    title: Quarkus Extension for Spring Cache API
+    summary: "While you are encouraged to use the Cache extension for your application-level caching, Quarkus provides a compatibility layer for Spring Cache in the form of the spring-cache extension."
+    url: /guides/spring-cache
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - cache
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-cache
+  - filename: spring-scheduled.adoc
+    title: Quarkus Extension for Spring Scheduling API
+    summary: "While you are encouraged to use the Scheduler or Quartz extensions to schedule tasks, Quarkus provides a compatibility layer for Spring Scheduled in the form of the spring-scheduled extension."
+    url: /guides/spring-scheduled
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - scheduling
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-scheduled
+  - filename: spring-data-rest.adoc
+    title: Extension for Spring Data REST
+    summary: Spring Data REST simplifies the creation of CRUD applications based on our Spring Data compatibility layer.
+    url: /guides/spring-data-rest
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - data
+    - hibernate-orm
+    - jpa
+    - rest
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-data-rest
+  - filename: spring-cloud-config-client.adoc
+    title: Reading properties from Spring Cloud Config Server
+    summary: Quarkus provides a compatibility layer for Spring Cloud Config in the form of the spring-cloud-config-client extension.
+    url: /guides/spring-cloud-config-client
+    type: guide
+    categories: compatibility
+    topics:
+    - spring
+    - cloud
+    - configuration
+    - compatibility
+    extensions:
+    - io.quarkus:quarkus-spring-cloud-config-client
+- id: integration
+  title: Integration
+  description: Integration with other frameworks and tools
+  guides:
+  - filename: camel.adoc
+    title: Apache Camel on Quarkus
+    summary: This guide covers the systems integration with Apache Camel
+    url: /guides/camel
+    type: guide
+    categories: integration
+    topics:
+    - camel
+    - integration
+- id: alt-languages
+  title: Alternative Languages
+  description: Using Quarkus with alternative JVM languages (Kotlin)
+  guides:
+  - filename: kotlin.adoc
+    title: Using Kotlin
+    summary: This guide explains how to use Kotlin.
+    url: /guides/kotlin
+    type: guide
+    categories: alt-languages
+    topics:
+    - kotlin
+    extensions:
+    - io.quarkus:quarkus-kotlin
+- id: architecture
+  title: Architecture
+  description: Architectural concepts and patterns
+  guides:
+  - filename: quarkus-reactive-architecture.adoc
+    title: Quarkus Reactive Architecture
+    summary: Learn more about Quarkus reactive architecture.
+    url: /guides/quarkus-reactive-architecture
+    type: guide
+    categories: architecture
+    topics:
+    - internals
+    - reactive
+  - filename: platform.adoc
+    title: Platform
+    summary: Learn more about what we call a Platform in the Quarkus world.
+    url: /guides/platform
+    type: guide
+    categories: architecture
+    topics:
+    - internals
+    - platform
+  - filename: class-loading-reference.adoc
+    title: Class Loading Reference
+    summary: Learn more about Quarkus class loading infrastructure.
+    url: /guides/class-loading-reference
+    type: reference
+    categories: architecture
+    topics:
+    - internals
+    - extensions
+  - filename: modularity.adoc
+    id: modularity
+    title: Quarkus modularity
+    summary: Quarkus modularity builds on JPMS to produce a complete and enhanced module graph for the application at build time.
+    url: /guides/modularity
+    type: concepts
+    status: experimental
+    categories: architecture
+    topics:
+    - modularity
+    - jpms
+    - modules
+    - extensions
+  - filename: modularity-reference.adoc
+    id: modularity-reference
+    title: Modularity SPI reference
+    summary: Reference for the build items that Quarkus extensions use to participate in Quarkus modularity.
+    url: /guides/modularity-reference
+    type: reference
+    status: experimental
+    categories: architecture
+    topics:
+    - modularity
+    - jpms
+    - modules
+    - extensions
+    - spi
+  - filename: dev-mode-differences.adoc
+    title: How dev mode differs from a production application
+    summary: How dev mode differs from a production application
+    url: /guides/dev-mode-differences
+    type: guide
+    categories: architecture
+    topics:
+    - internals
+    - dev-mode
+  - filename: extension-registry-user.adoc
+    title: Quarkus Extension Registry
+    summary: Learn more about the notion of extension registry and how you can use your own.
+    url: /guides/extension-registry-user
+    type: guide
+    categories: architecture
+    topics:
+    - internals
+    - extensions
+  - filename: performance-measure.adoc
+    title: Measuring Performance
+    summary: This guide explains how to best measure the footprint of a Quarkus application.
+    url: /guides/performance-measure
+    type: guide
+    categories: architecture
+    topics:
+    - internals
+    - performance
+- id: writing-extensions
+  title: Writing Extensions
+  description: Creating Quarkus extensions
+  guides:
+  - filename: writing-extensions.adoc
+    title: Writing Your Own Extension
+    summary: Quarkus extensions optimize your applications by pushing as much work as possible to the build operation.
+    url: /guides/writing-extensions
+    type: guide
+    categories: writing-extensions
+    topics:
+    - extensions
+  - filename: building-my-first-extension.adoc
+    title: Building my first extension
+    summary: Learn step by step how to build a simple extension.
+    url: /guides/building-my-first-extension
+    type: guide
+    categories: writing-extensions
+    topics:
+    - extensions
+  - filename: extension-metadata.adoc
+    title: Quarkus Extension Metadata
+    summary: Quarkus extensions are distributed as Maven JAR artifacts that application and other libraries may depend on.
+    url: /guides/extension-metadata
+    type: guide
+    categories: writing-extensions
+    topics:
+    - extensions
+    - codestarts
+  - filename: capabilities.adoc
+    title: Extension Capabilities
+    summary: How capabilities are implemented and used in Quarkus.
+    url: /guides/capabilities
+    type: guide
+    categories: writing-extensions
+    topics:
+    - extensions
+  - filename: cdi-integration.adoc
+    title: CDI Integration Guide
+    summary: Learn how to integrate your extension with Quarkus' CDI container.
+    url: /guides/cdi-integration
+    type: guide
+    categories: writing-extensions
+    topics:
+    - cdi
+    - arc
+    - injection
+    extensions:
+    - io.quarkus:quarkus-arc
+  - filename: conditional-extension-dependencies.adoc
+    title: Conditional Extension Dependencies
+    summary: Trigger the inclusion on additional extensions based on certain conditions.
+    url: /guides/conditional-extension-dependencies
+    type: guide
+    categories: writing-extensions
+    topics:
+    - extensions
+  - filename: all-builditems.adoc
+    title: Build Items
+    summary: Explore all the BuildItems you can consume/produce in your extensions.
+    url: /guides/all-builditems
+    type: guide
+    categories: writing-extensions
+  - filename: dev-ui.adoc
+    title: Dev UI
+    summary: Learn more about Dev UI
+    url: /guides/dev-ui
+    type: guide
+    categories: writing-extensions
+    topics:
+    - dev-ui
+    - testing
+  - filename: extension-codestart.adoc
+    title: Extension codestart
+    summary: Provide users with initial code for extensions when generating Quarkus applications on code.quarkus.io and all the Quarkus tooling.
+    url: /guides/extension-codestart
+    type: guide
+    categories: writing-extensions
+    topics:
+    - extensions
+    - codestarts
+  - filename: extension-writing-dev-service.adoc
+    id: extension-writing-dev-service
+    title: Writing a Dev Service
+    summary: Learn how to develop a Dev Service for your extension in order to replace an external service in development mode.
+    url: /guides/extension-writing-dev-service
+    type: howto
+    categories: writing-extensions
+    topics:
+    - extensions
+  - filename: dev-mcp.adoc
+    title: Dev MCP
+    summary: Learn more about Dev MCP
+    url: /guides/dev-mcp
+    type: guide
+    categories: writing-extensions
+    topics:
+    - dev-mcp
+    - dev-ui
+  - filename: agent-mcp.adoc
+    title: Agent MCP
+    summary: Learn more about the Quarkus Agent MCP server for AI coding agents
+    url: /guides/agent-mcp
+    type: guide
+    categories: writing-extensions
+    topics:
+    - agent-mcp
+    - mcp
+    - ai-agents
+  - filename: assistant.adoc
+    title: Dev Assistant
+    summary: Learn more about the Dev Assistant
+    url: /guides/assistant
+    type: guide
+    categories: writing-extensions
+    topics:
+    - dev-ui
+    - assistant
+    - extension
+  - filename: extension-maturity-matrix.adoc
+    id: extension-maturity-matrix
+    title: A maturity matrix for Quarkus extensions
+    summary: "Quarkus extensions can do a lot, or a little."
+    url: /guides/extension-maturity-matrix
+    type: concepts
+    categories: writing-extensions
+    topics:
+    - extensions
+  - filename: extension-faq.adoc
+    id: extensions-faq
+    title: Frequently asked questions about writing extensions
+    url: /guides/extension-faq
+    type: howto
+    categories: writing-extensions
+- id: contributing
+  title: Contributing
+  description: Contributing to Quarkus documentation
+  guides:
+  - filename: doc-contribute-docs-howto.adoc
+    id: doc-contribute-howto
+    title: Contribute to Quarkus documentation
+    summary: "Contribute to the documentation by using the recommended diataxis content types, steps, workflow, and style guidance to ensure the content successfully renders on the Quarkus website portal."
+    url: /guides/doc-contribute-docs-howto
+    type: howto
+    categories: contributing
+    topics:
+    - internals
+    - documentation
+  - filename: doc-concept.adoc
+    id: doc-concept
+    title: Quarkus documentation content types
+    summary: "Quarkus documentation is structured into four distinct content types: concepts, how-tos, tutorials, and references."
+    url: /guides/doc-concept
+    type: concepts
+    categories: contributing
+    topics:
+    - internals
+    - documentation
+  - filename: doc-reference.adoc
+    id: doc-reference
+    title: Quarkus style and content guidelines
+    summary: Guidelines are provided to help you to contribute clear and consistent content that is also sourced in the required diataxis structure and composition of Quarkus documentation.
+    url: /guides/doc-reference
+    type: reference
+    categories: contributing
+    topics:
+    - internals
+    - documentation
+  - filename: doc-create-tutorial.adoc
+    id: doc-create-tutorial
+    title: Creating a tutorial
+    summary: "Create a new tutorial that guides users through creating, running, and testing a Quarkus application that uses annotations from an imaginary extension."
+    url: /guides/doc-create-tutorial
+    type: tutorial
+    categories: contributing
+    topics:
+    - internals
+    - documentation
+- id: rule-engine
+  title: Rule Engine
+  description: Business rules with Drools
+  guides:
+  - filename: drools.adoc
+    title: Defining and executing business rules with Drools
+    summary: Drools is the most used rule engine implementation in the Java ecosystem.
+    url: /guides/drools
+    type: guide
+    topics:
+    - drools
+    - rules
+    - rule engine
+    extensions:
+    - org.drools:drools-quarkus

--- a/_includes/guide-metadata-bar.html
+++ b/_includes/guide-metadata-bar.html
@@ -1,0 +1,154 @@
+{% assign current_filename = include.current_filename %}
+{% assign docversion = include.docversion %}
+{% assign docversion_index = docversion | replace: '.', '-' %}
+{% assign cat_data = site.data.versioned[docversion_index].index.categories.categories %}
+
+{% unless cat_data %}{% break %}{% endunless %}
+
+{% assign guide_cat_labels = "" | split: "," %}
+{% assign guide_cat_ids = "" | split: "," %}
+{% assign guide_topics = nil %}
+
+{% for cat in cat_data %}
+  {% if cat.subcategories %}
+    {% for sub in cat.subcategories %}
+      {% for g in sub.guides %}
+        {% if g.filename == current_filename %}
+          {% assign cat_label = cat.title | append: " › " | append: sub.title %}
+          {% assign guide_cat_labels = guide_cat_labels | push: cat_label %}
+          {% assign guide_cat_ids = guide_cat_ids | push: sub.id %}
+          {% if g.topics %}
+            {% assign guide_topics = g.topics %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  {% else %}
+    {% for g in cat.guides %}
+      {% if g.filename == current_filename %}
+        {% assign guide_cat_labels = guide_cat_labels | push: cat.title %}
+        {% assign guide_cat_ids = guide_cat_ids | push: cat.id %}
+        {% if g.topics %}
+          {% assign guide_topics = g.topics %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+
+{% if guide_cat_labels.size > 0 or guide_topics %}
+<div class="guide-metadata-bar">
+  {% for cat_label in guide_cat_labels %}
+    {% assign cat_id = guide_cat_ids[forloop.index0] %}
+    {% assign panel_guides = "" | split: "," %}
+    {% for cat in cat_data %}
+      {% if cat.subcategories %}
+        {% for sub in cat.subcategories %}
+          {% if sub.id == cat_id %}
+            {% for g in sub.guides %}
+              {% if g.title and g.url and g.filename != current_filename %}
+                {% assign panel_guides = panel_guides | push: g %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      {% else %}
+        {% if cat.id == cat_id %}
+          {% for g in cat.guides %}
+            {% if g.title and g.url and g.filename != current_filename %}
+              {% assign panel_guides = panel_guides | push: g %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    {% assign panel_guides = panel_guides | sort: "title" %}
+    {% if panel_guides.size > 0 %}
+      <span class="guide-meta-dropdown">
+        <button class="guide-meta-label guide-meta-category" onclick="toggleMetaDropdown(event, 'meta-cat-{{ cat_id }}')">{{ cat_label }}</button>
+        <div class="guide-meta-panel" id="meta-cat-{{ cat_id }}">
+          <div class="guide-meta-panel-header">{{ cat_label }}</div>
+          <ul>
+            {% for g in panel_guides %}
+              {% if docversion == 'latest' %}
+                {% assign gurl = site.baseurl | append: g.url %}
+              {% else %}
+                {% assign gurl = site.baseurl | append: '/version/' | append: docversion | append: g.url %}
+              {% endif %}
+              <li><a href="{{ gurl }}">{{ g.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+      </span>
+    {% else %}
+      <button class="guide-meta-label guide-meta-category guide-meta-noclick" disabled>{{ cat_label }}</button>
+    {% endif %}
+  {% endfor %}
+  {% if guide_topics %}
+    {% for topic in guide_topics %}
+      {% assign topic_id = topic | slugify %}
+      {% assign topic_guides = "" | split: "," %}
+      {% for cat in cat_data %}
+        {% if cat.subcategories %}
+          {% for sub in cat.subcategories %}
+            {% for g in sub.guides %}
+              {% if g.topics contains topic and g.title and g.url and g.filename != current_filename %}
+                {% assign topic_guides = topic_guides | push: g %}
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        {% else %}
+          {% for g in cat.guides %}
+            {% if g.topics contains topic and g.title and g.url and g.filename != current_filename %}
+              {% assign topic_guides = topic_guides | push: g %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+      {% assign topic_guides = topic_guides | sort: "title" %}
+      {% if topic_guides.size > 0 %}
+        <span class="guide-meta-dropdown">
+          <button class="guide-meta-label guide-meta-topic" onclick="toggleMetaDropdown(event, 'meta-topic-{{ topic_id }}')">{{ topic }}</button>
+          <div class="guide-meta-panel" id="meta-topic-{{ topic_id }}">
+            <div class="guide-meta-panel-header">{{ topic }}</div>
+            <ul>
+              {% for g in topic_guides %}
+                {% if docversion == 'latest' %}
+                  {% assign gurl = site.baseurl | append: g.url %}
+                {% else %}
+                  {% assign gurl = site.baseurl | append: '/version/' | append: docversion | append: g.url %}
+                {% endif %}
+                <li><a href="{{ gurl }}">{{ g.title }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+        </span>
+      {% else %}
+        <button class="guide-meta-label guide-meta-topic guide-meta-noclick" disabled>{{ topic }}</button>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+</div>
+
+<script>
+function toggleMetaDropdown(event, id) {
+  event.stopPropagation();
+  var panel = document.getElementById(id);
+  var wasOpen = panel.classList.contains('open');
+  closeAllMetaDropdowns();
+  if (!wasOpen) {
+    panel.classList.add('open');
+  }
+}
+function closeAllMetaDropdowns() {
+  document.querySelectorAll('.guide-meta-panel.open').forEach(function(p) {
+    p.classList.remove('open');
+  });
+}
+document.addEventListener('click', function(e) {
+  if (!e.target.closest('.guide-meta-dropdown')) {
+    closeAllMetaDropdowns();
+  }
+});
+</script>
+{% endif %}

--- a/_includes/guide-nav-sidebar.html
+++ b/_includes/guide-nav-sidebar.html
@@ -1,0 +1,79 @@
+{% assign docversion = include.docversion %}
+{% assign current_filename = include.current_filename %}
+{% assign docversion_index = docversion | replace: '.', '-' %}
+{% assign cat_data = site.data.versioned[docversion_index].index.categories.categories %}
+
+{% unless cat_data %}{% break %}{% endunless %}
+
+<nav class="guide-nav-sidebar">
+  {% for cat in cat_data %}
+    {% assign cat_has_current = false %}
+    {% if cat.subcategories %}
+      {% for sub in cat.subcategories %}
+        {% for g in sub.guides %}
+          {% if g.filename == current_filename %}
+            {% assign cat_has_current = true %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    {% else %}
+      {% for g in cat.guides %}
+        {% if g.filename == current_filename %}
+          {% assign cat_has_current = true %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    <details class="guide-nav-cat" {% if cat_has_current %}open{% endif %}>
+      <summary>{{ cat.title }}</summary>
+
+      {% if cat.subcategories %}
+        {% for sub in cat.subcategories %}
+          {% assign sub_has_current = false %}
+          {% for g in sub.guides %}
+            {% if g.filename == current_filename %}
+              {% assign sub_has_current = true %}
+            {% endif %}
+          {% endfor %}
+
+          <details class="guide-nav-subcat" {% if sub_has_current %}open{% endif %}>
+            <summary>{{ sub.title }}</summary>
+            <ul>
+              {% for g in sub.guides %}
+                {% if g.title %}
+                  {% if g.url %}
+                    {% if docversion == 'latest' %}
+                      {% assign guide_url = site.baseurl | append: g.url %}
+                    {% else %}
+                      {% assign guide_url = site.baseurl | append: '/version/' | append: docversion | append: g.url %}
+                    {% endif %}
+                    <li {% if g.filename == current_filename %}class="active"{% endif %}>
+                      <a href="{{ guide_url }}">{{ g.title }}</a>
+                    </li>
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+            </ul>
+          </details>
+        {% endfor %}
+      {% else %}
+        <ul>
+          {% for g in cat.guides %}
+            {% if g.title %}
+              {% if g.url %}
+                {% if docversion == 'latest' %}
+                  {% assign guide_url = site.baseurl | append: g.url %}
+                {% else %}
+                  {% assign guide_url = site.baseurl | append: '/version/' | append: docversion | append: g.url %}
+                {% endif %}
+                <li {% if g.filename == current_filename %}class="active"{% endif %}>
+                  <a href="{{ guide_url }}">{{ g.title }}</a>
+                </li>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </details>
+  {% endfor %}
+</nav>

--- a/_includes/index-categories-guides.html
+++ b/_includes/index-categories-guides.html
@@ -1,0 +1,27 @@
+<ul class="guide-list">
+  {% for g in include.guides %}
+    {% if g.title %}
+      {% assign is_external = g.url | slice: 0, 4 %}
+      {% if is_external == "http" %}
+        {% assign guide_url = g.url %}
+      {% elsif include.docversion == 'latest' %}
+        {% assign guide_url = site.baseurl | append: g.url %}
+      {% else %}
+        {% assign guide_url = site.baseurl | append: '/version/' | append: include.docversion | append: g.url %}
+      {% endif %}
+      <li>
+        <qs-guide type="{{ g.type | escape }}"
+                  title="{{ g.title | escape }}"
+                  url="{{ guide_url }}"
+                  summary="{{ g.summary | escape }}"
+                  keywords="{{ g.keywords | escape }}"
+                  categories="{{ g.categories | escape }}"
+                  origin="{{ g.origin | escape }}"
+        >
+          <a href="{{ guide_url }}">{{ g.title }}</a>
+          {% if g.summary %}<span class="guide-summary">{{ g.summary }}</span>{% endif %}
+        </qs-guide>
+      </li>
+    {% endif %}
+  {% endfor %}
+</ul>

--- a/_includes/index-categories.html
+++ b/_includes/index-categories.html
@@ -1,0 +1,80 @@
+{% assign docversion = include.docversion %}
+{% assign docversion_index = docversion | replace: '.', '-' %}
+{% assign cat_data = site.data.versioned[docversion_index].index.categories.categories %}
+
+<div id="guides-app">
+  <qs-form server="{{ site.search.host }}"
+           quarkus-version="{{ docversion }}"
+           language="{{ site.language }}"
+           initial-timeout="{{ site.search.initial-timeout }}"
+           more-timeout="{{ site.search.more-timeout }}"
+           min-chars="{{ site.search.min-chars }}"
+  >
+    <section class="full-width-version-bg flexfilterbar">
+      <div class="flexcontainer">
+        <div class="flexlabel">
+          <label>{{site.data.index-docs.texts.by_version}}</label>
+        </div>
+        <div class="pulldown version">
+          <select id="guidesindex-version-dropdown">
+            {% for version in site.data.versions.documentation %}
+            <option value="{{ version }}" {% if docversion== version %}selected{% endif %}>{% if version ==
+              'latest' %}{{ site.data.versions.quarkus.version | replace_regex: "\.[0-9+]\.Final", "" }} -
+              {% endif %}{{ version | capitalize }}{% if version == 'main' %} - SNAPSHOT{% endif %}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="search">
+          <input name="q" type="search" placeholder="{{site.data.index-docs.texts.filter_by_keyword}}" autocomplete="off"/>
+        </div>
+      </div>
+    </section>
+  </qs-form>
+
+  <div>
+    <h1 class="title">{{ page.title }}</h1>
+  </div>
+
+  <qs-target origins-with-relative-urls="quarkus">
+    <div class="categories-index">
+      <nav class="categories-toc">
+        <h3>Categories</h3>
+        <ul>
+          {% for cat in cat_data %}
+          <li>
+            <a href="#cat-{{ cat.id }}">{{ cat.title }}</a>
+            {% if cat.subcategories %}
+            <ul>
+              {% for sub in cat.subcategories %}
+              <li><a href="#cat-{{ sub.id }}">{{ sub.title }}</a></li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+      </nav>
+
+      <div class="categories-content" id="all-docs">
+        {% for cat in cat_data %}
+        <section class="category-section" id="cat-{{ cat.id }}">
+          <h2>{{ cat.title }}</h2>
+          {% if cat.description %}<p class="category-desc">{{ cat.description }}</p>{% endif %}
+
+          {% if cat.subcategories %}
+            {% for sub in cat.subcategories %}
+            <div class="subcategory-section" id="cat-{{ sub.id }}">
+              <h3>{{ sub.title }}</h3>
+              {% include index-categories-guides.html guides=sub.guides docversion=docversion %}
+            </div>
+            {% endfor %}
+          {% else %}
+            {% include index-categories-guides.html guides=cat.guides docversion=docversion %}
+          {% endif %}
+        </section>
+        {% endfor %}
+      </div>
+    </div>
+  </qs-target>
+</div>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -13,8 +13,10 @@ search_wc: true
 
 {% assign docversion_index = docversion | replace: '.', '-' %}
 
-{% if site.data.versioned[docversion_index].index %}
-  {% include index-docs.html docversion=docversion %}  
+{% if site.data.versioned[docversion_index].index.categories %}
+  {% include index-categories.html docversion=docversion %}
+{% elsif site.data.versioned[docversion_index].index %}
+  {% include index-docs.html docversion=docversion %}
 {% else %}
   {% assign data_source = "guides-" | append: docversion | replace: '.', '-' %}
   {% include index-guides.html source=data_source docversion=docversion %}  

--- a/_layouts/guides.html
+++ b/_layouts/guides.html
@@ -17,6 +17,7 @@ layout: base
 {% assign page_filename = page.path | replace: '_guides/', '' | replace: '_versions/main/guides/', '' %}
 {% assign relations = site.data.versioned[docversion_index].index.relations %}
 {% assign guide_url = page.url | replace_regex: '^/version/[^/]+(/.*)', '\1' %}
+{% assign has_categories = site.data.versioned[docversion_index].index.categories %}
 
 <section class="full-width-version-bg flexfilterbar guides">
   <div class="guideflexcontainer">
@@ -55,6 +56,67 @@ layout: base
   </div>
 </section>
 
+{% if has_categories %}
+<div class="guide guide-full-width">
+  <div class="guide-layout">
+    <div class="guide-nav-wrapper">
+      {% include guide-nav-sidebar.html docversion=docversion current_filename=page_filename %}
+    </div>
+    <div class="guide-main">
+      {% if docversion == 'latest' or docversion == 'main' %}
+      <a class="editlink" href="https://github.com/quarkusio/quarkus/edit/main/docs/src/main/asciidoc/{{ page_filename }}">{{site.data.guides.texts.edit_this_page}}</a>
+      {% endif %}
+      <h1 class="text-caps">{{page.title}} {{page.docversion}}</h1>
+      {% include guide-metadata-bar.html docversion=docversion current_filename=page_filename %}
+      {{ content }}
+    </div>
+    <div class="guide-toc-wrapper hide-tablet">
+      <div class="toc">{{ page.document | tocify_asciidoc }}</div>
+    </div>
+  </div>
+  {% if relations and relations[guide_url] -%}
+  <h2>{{site.data.guides.texts.related_content}}</h2>
+  <div class="grid-wrapper relations">
+    {% if relations[guide_url].sameExtensions -%}
+    <div class="grid__item width-6-12 width-12-12-m">
+      <h3>{{site.data.guides.texts.on_the_same_extensions}}</h3>
+      <ul class="related-content">
+      {% for guide in relations[guide_url].sameExtensions -%}
+        {% assign is_external_guide = guide.url | startswith: 'http' %}
+        {% if is_external_guide %}
+          {% assign related_guide_url = include.url %}
+        {% elsif docversion == 'latest' %}
+          {% assign related_guide_url = site.baseurl | append: guide.url %}
+        {% else %}
+          {% assign related_guide_url = site.baseurl | append: '/version/' | append: docversion | append: guide.url %}
+        {% endif %}
+        <li class="{{ guide.type }}"><a href="{{ related_guide_url }}">{{ guide.title }}</a></li>
+      {% endfor -%}
+      </ul>
+    </div>
+    {% endif -%}
+    {% if relations[guide_url].sameTopics -%}
+    <div class="grid__item width-6-12 width-12-12-m">
+      <h3>{{site.data.guides.texts.on_the_same_topics}}</h3>
+      <ul class="related-content">
+      {% for guide in relations[guide_url].sameTopics limit:20 -%}
+        {% assign is_external_guide = guide.url | startswith: 'http' %}
+        {% if is_external_guide %}
+          {% assign related_guide_url = include.url %}
+        {% elsif docversion == 'latest' %}
+          {% assign related_guide_url = site.baseurl | append: guide.url %}
+        {% else %}
+          {% assign related_guide_url = site.baseurl | append: '/version/' | append: docversion | append: guide.url %}
+        {% endif %}
+        <li class="{{ guide.type }}"><a href="{{ related_guide_url }}">{{ guide.title }}</a></li>
+      {% endfor -%}
+      </ul>
+    </div>
+    {% endif -%}
+  </div>
+  {% endif -%}
+</div>
+{% else %}
 <div class="guide">
   <div class="grid-wrapper">
     <div class="grid__item width-8-12 width-12-12-m">
@@ -110,3 +172,4 @@ layout: base
   </div>
   {% endif -%}
 </div>
+{% endif %}

--- a/_sass/layouts/categories-index.scss
+++ b/_sass/layouts/categories-index.scss
@@ -1,0 +1,195 @@
+.categories-index {
+  display: grid;
+  grid-template-columns: 3fr 9fr;
+  gap: 2rem;
+  padding-top: 1rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.categories-toc {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 0.75rem;
+  background-color: var(--sec-background-color);
+  border-radius: 4px;
+
+  @media (max-width: 768px) {
+    position: static;
+    max-height: none;
+  }
+
+  h3 {
+    margin: 0 0 0.4rem 0;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-color);
+  }
+
+  > ul {
+    list-style: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    display: block !important;
+
+    > li {
+      display: block !important;
+      clear: both;
+      margin-bottom: 0.35rem;
+      padding: 0;
+      float: none !important;
+
+      &::after {
+        content: none !important;
+      }
+
+      > a {
+        display: block;
+        padding: 0.15rem 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        line-height: 1.5;
+        color: var(--text-color);
+        text-decoration: none;
+        border-radius: 3px;
+
+        &:hover {
+          background-color: var(--hover-background-color, rgba(0, 0, 0, 0.05));
+          color: $link;
+        }
+      }
+
+      > ul {
+        list-style: none !important;
+        padding: 0.1rem 0 0.2rem 0.6rem !important;
+        margin: 0 !important;
+        display: flex !important;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+
+        li {
+          display: inline !important;
+          float: none !important;
+          line-height: 1;
+
+          &::after {
+            content: none !important;
+          }
+
+          a {
+            display: inline-block;
+            padding: 0.1rem 0.45rem;
+            font-size: 0.7rem;
+            line-height: 1.5;
+            color: var(--text-color);
+            opacity: 0.75;
+            text-decoration: none;
+            background-color: var(--hover-background-color, rgba(255, 255, 255, 0.08));
+            border-radius: 8px;
+
+            &:hover {
+              opacity: 1;
+              color: $white;
+              background-color: $link;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+.categories-content {
+
+  .category-section {
+    margin-bottom: 2rem;
+
+    h2 {
+      margin: 0 0 0.15rem 0;
+      padding-bottom: 0.35rem;
+      border-bottom: 2px solid $grey-1;
+      font-size: 1.3rem;
+    }
+
+    .category-desc {
+      margin: 0 0 0.5rem 0;
+      color: var(--text-color);
+      opacity: 0.7;
+      font-size: 0.85rem;
+    }
+  }
+
+  .subcategory-section {
+    margin-bottom: 1rem;
+
+    h3 {
+      margin: 0 0 0.25rem 0;
+      font-size: 1.05rem;
+      color: var(--text-color);
+    }
+  }
+
+  .guide-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.5rem 0;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.1rem 1.5rem;
+
+    @media (max-width: 1100px) {
+      grid-template-columns: 1fr;
+    }
+
+    li {
+      padding: 0.2rem 0;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+
+      qs-guide {
+        display: block;
+        grid-column: unset;
+        margin: 0;
+        padding: 0;
+        background: none;
+        border: none;
+        box-shadow: none;
+        min-height: unset;
+      }
+
+      a {
+        font-weight: 500;
+        text-decoration: none;
+        color: $link;
+
+        &:hover {
+          color: $link-hover;
+          text-decoration: underline;
+        }
+      }
+
+      .guide-summary {
+        display: block;
+        color: var(--text-color);
+        opacity: 0.65;
+        font-size: 0.82rem;
+        margin-top: 0.1rem;
+        line-height: 1.3;
+
+        &::before {
+          content: none;
+        }
+      }
+    }
+
+    .guide-missing {
+      opacity: 0.4;
+      font-style: italic;
+    }
+  }
+}

--- a/_sass/layouts/guide.scss
+++ b/_sass/layouts/guide.scss
@@ -100,6 +100,370 @@ body.guides-configuration-reference div.guides-configuration-reference {
   }
 }
 
+// Full-width guide layout with nav sidebar
+.guide-full-width {
+  margin: 0 -13rem;
+  padding: 0 1rem;
+  overflow-x: hidden;
+  @media screen and (max-width: 1366px) {
+    margin: 0 -4rem;
+  }
+  @media screen and (max-width: 768px) {
+    margin: 0 -2rem;
+  }
+}
+
+.guide-layout {
+  display: grid;
+  grid-template-columns: 250px 1fr 300px;
+  gap: 1.5rem;
+
+  @media screen and (max-width: 1400px) {
+    grid-template-columns: 230px 1fr 250px;
+  }
+  @media screen and (max-width: 1200px) {
+    grid-template-columns: 220px 1fr;
+  }
+  @media screen and (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.guide-nav-wrapper {
+  align-self: start;
+  justify-self: start;
+  position: sticky;
+  top: 1rem;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  width: 100%;
+  text-align: left;
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
+}
+
+.guide-toc-wrapper {
+  align-self: start;
+  position: sticky;
+  top: 1rem;
+  max-height: 90vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-width: 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+
+  @media screen and (max-width: 1200px) {
+    display: none;
+  }
+
+  .toc {
+    position: static;
+    margin: 0;
+    padding: 0.5rem;
+    overflow-x: hidden;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+}
+
+.guide-main {
+  min-width: 0;
+}
+
+// Guide navigation sidebar
+.guide-nav-sidebar {
+  text-align: left;
+  width: 100%;
+
+  .guide-nav-cat {
+    margin: 0 0 0.1rem 0;
+    padding: 0;
+    border: none;
+
+    > summary {
+      display: block;
+      padding: 0.2rem 0.4rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--text-color);
+      cursor: pointer;
+      list-style: none;
+      border-radius: 3px;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &::before {
+        content: "\f054";
+        font-family: "Font Awesome 5 Free";
+        font-weight: 900;
+        font-size: 0.6rem;
+        margin-right: 0.4rem;
+        display: inline-block;
+        transition: transform 0.15s;
+      }
+
+      &:hover {
+        background-color: var(--hover-background-color, rgba(0, 0, 0, 0.05));
+      }
+    }
+
+    &[open] > summary::before {
+      transform: rotate(90deg);
+    }
+  }
+
+  .guide-nav-subcat {
+    margin: 0 0 0 0.75rem;
+    padding: 0;
+    border: none;
+
+    > summary {
+      display: block;
+      padding: 0.15rem 0.4rem;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: var(--text-color);
+      opacity: 0.85;
+      cursor: pointer;
+      list-style: none;
+      border-radius: 3px;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &::before {
+        content: "\f054";
+        font-family: "Font Awesome 5 Free";
+        font-weight: 900;
+        font-size: 0.5rem;
+        margin-right: 0.35rem;
+        display: inline-block;
+        transition: transform 0.15s;
+      }
+
+      &:hover {
+        background-color: var(--hover-background-color, rgba(0, 0, 0, 0.05));
+      }
+    }
+
+    &[open] > summary::before {
+      transform: rotate(90deg);
+    }
+  }
+
+  ul {
+    list-style: none !important;
+    padding: 0 0 0.15rem 1rem !important;
+    margin: 0 !important;
+    display: block !important;
+
+    li {
+      display: block !important;
+      float: none !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      line-height: 1.3;
+
+      &::after {
+        content: none !important;
+      }
+
+      a {
+        display: block;
+        padding: 0.1rem 0.4rem;
+        margin: 0;
+        font-size: 0.78rem;
+        line-height: 1.3;
+        color: var(--text-color);
+        opacity: 0.7;
+        text-decoration: none;
+        border-radius: 3px;
+
+        &:hover {
+          opacity: 1;
+          color: $link;
+        }
+      }
+
+      &.active a {
+        opacity: 1;
+        color: $link;
+        font-weight: 600;
+        background-color: var(--hover-background-color, rgba(0, 0, 0, 0.05));
+      }
+    }
+  }
+}
+
+// Guide metadata bar (categories + topics labels)
+.guide-metadata-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.2rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid $grey-1;
+}
+
+.guide-meta-dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.guide-meta-label {
+  display: inline-block;
+  padding: 0.15rem 0.5rem !important;
+  font-size: 0.75rem !important;
+  line-height: 1.4 !important;
+  height: auto;
+  border-radius: 10px;
+  white-space: nowrap;
+  border: none !important;
+  font-family: inherit;
+  text-transform: none !important;
+  font-weight: normal !important;
+  vertical-align: baseline;
+  box-sizing: border-box;
+  cursor: default;
+  margin: 0 !important;
+  transition: none !important;
+  -webkit-appearance: none;
+  appearance: none;
+
+  &:hover, &:active, &:focus {
+    border: none !important;
+    outline: none;
+  }
+}
+
+button.guide-meta-label {
+  cursor: pointer;
+
+  &.guide-meta-noclick {
+    cursor: default;
+
+    &, &:hover, &:active, &:focus {
+      opacity: 0.5 !important;
+    }
+
+    &.guide-meta-topic, &.guide-meta-topic:hover, &.guide-meta-topic:active, &.guide-meta-topic:focus {
+      background-color: var(--hover-background-color, rgba(255, 255, 255, 0.08)) !important;
+      color: var(--text-color) !important;
+    }
+
+    &.guide-meta-category, &.guide-meta-category:hover, &.guide-meta-category:active, &.guide-meta-category:focus {
+      background-color: rgba($link, 0.2) !important;
+      color: lighten($link, 15%) !important;
+    }
+  }
+}
+
+.guide-meta-category {
+  background-color: rgba($link, 0.2);
+  color: lighten($link, 15%);
+}
+
+.guide-meta-topic {
+  background-color: var(--hover-background-color, rgba(255, 255, 255, 0.08));
+  color: var(--text-color);
+
+  &.guide-meta-noclick {
+    opacity: 0.5;
+  }
+}
+
+button.guide-meta-category:not(:disabled):hover,
+button.guide-meta-category:not(:disabled):active,
+button.guide-meta-category:not(:disabled):focus {
+  background-color: rgba($link, 0.35);
+  color: lighten($link, 25%);
+  outline: none;
+}
+
+button.guide-meta-topic:not(:disabled):hover,
+button.guide-meta-topic:not(:disabled):active,
+button.guide-meta-topic:not(:disabled):focus {
+  opacity: 1;
+  background-color: rgba($link, 0.15);
+  color: $link;
+  outline: none;
+}
+
+.guide-meta-panel {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 200;
+  min-width: 280px;
+  max-width: 400px;
+  max-height: 400px;
+  overflow-y: auto;
+  margin-top: 0.3rem;
+  padding: 0.5rem 0;
+  background-color: var(--sec-background-color, #1a1a2e);
+  border: 1px solid $grey-1;
+  border-radius: 6px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+
+  &.open {
+    display: block;
+  }
+
+  .guide-meta-panel-header {
+    padding: 0.25rem 0.75rem 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-color);
+    border-bottom: 1px solid $grey-1;
+    margin-bottom: 0.25rem;
+  }
+
+  ul {
+    list-style: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    display: block !important;
+
+    li {
+      display: block !important;
+      margin: 0 !important;
+      padding: 0 !important;
+
+      &::after {
+        content: none !important;
+      }
+
+      a {
+        display: block;
+        padding: 0.25rem 0.75rem;
+        font-size: 0.8rem;
+        color: var(--text-color);
+        text-decoration: none;
+
+        &:hover {
+          background-color: var(--hover-background-color, rgba(0, 0, 0, 0.08));
+          color: $link;
+        }
+      }
+
+      &.active a {
+        color: $link;
+        font-weight: 600;
+      }
+    }
+  }
+}
+
 // Edit page style
 .editlink {
   margin-left: 1.3em;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -37,6 +37,7 @@ $baseurl: "{{ site.baseurl }}";
 @import "layouts/get-started";
 @import "layouts/get-started-steps";
 @import "layouts/guides";
+@import "layouts/categories-index";
 @import "layouts/guide";
 @import "layouts/extensions";
 @import "layouts/community";


### PR DESCRIPTION
This is definitely not final and will require some discussions with James and some iterations but it allows showing a bit what would be possible with this new category index.

I haven't adjusted the search at all and also the appearance of the guides is coming from search.quarkus.io and I haven't tweaked it. I would favor a layout that is a bit more compact, ideally, but that's something to tweak later.

All of this is visible if you go to: https://quarkus-website-pr-2749-preview.surge.sh/version/main/guides/ (`main` version).
Here are a couple of screenshots/pointers.

### Guides sorted by categories and category index

The index page is now sorted properly, by category and with a proper order in each category.

There are subcategories in some categories and a category can have a description to have a proper introduction.

<img width="1811" height="1073" alt="Screenshot From 2026-06-22 15-31-52" src="https://github.com/user-attachments/assets/3b7b3997-1156-4615-a7d0-54b2b20deb0e" />

### Menu to switch to other guides

When on a guide, you can easily switch to another guide in the same category, or use the menu to get to something else entirely.

<img width="2161" height="1045" alt="Screenshot From 2026-06-22 15-32-12" src="https://github.com/user-attachments/assets/4d2bc74c-88c4-455e-86c6-ace34a73da62" />

For instance here: https://quarkus-website-pr-2749-preview.surge.sh/version/main/guides/writing-native-applications-tips

### Switch easily to same category/topic

We display both the category(ies) and the topic(s) and you can easily switch to the other items in the category/topic.

<img width="2161" height="1045" alt="Screenshot From 2026-06-22 15-32-28" src="https://github.com/user-attachments/assets/bbf39b59-8c2f-45e4-91d8-72fb0d644290" />

For instance here: https://quarkus-website-pr-2749-preview.surge.sh/version/main/guides/writing-native-applications-tips