### PR TITLE
Add /releases and /eol pages

### DIFF
--- a/_data/projectfooter.yaml
+++ b/_data/projectfooter.yaml
@@ -20,6 +20,8 @@ links:
         url: /userstories
       - page: Roadmap
         url: https://github.com/orgs/quarkusio/projects/13/views/1
+      - page: Releases
+        url: /releases
       - page: Security&nbsp;policy
         url: /security
       - page: Usage

--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -1,0 +1,446 @@
+policy:
+  lts_cadence: "every 6 months"
+  lts_support_duration: "12 months"
+  non_lts_support_duration: "until the next minor release"
+  lts_description: >
+    LTS releases receive critical bug fixes and security patches
+    for 12 months from their initial release date.
+  eol_description: >
+    When a Quarkus release reaches End-of-Life, it no longer receives
+    security patches, bug fixes, or community support. Running EOL
+    versions exposes your applications to unpatched vulnerabilities,
+    ecosystem drift, and compliance risks.
+
+support_providers:
+  rhbq:
+    name: "Red Hat Build of Quarkus"
+    url: "https://access.redhat.com/products/quarkus"
+  ibm:
+    name: "IBM Enterprise Build of Quarkus"
+    url: "https://www.ibm.com/products/enterprise-build-of-quarkus"
+  herodevs:
+    name: "HeroDevs Never-Ending Support"
+    url: "https://www.herodevs.com/support/quarkus-nes"
+
+eol_support:
+  - name: "HeroDevs Never-Ending Support (NES)"
+    url: "https://www.herodevs.com/support/quarkus-nes"
+    description: >
+      HeroDevs provides continued security patches and compliance
+      support for EOL Quarkus versions, bridging the gap while
+      you plan your upgrade.
+
+releases:
+  - version: "3.37"
+    lts: false
+    upcoming: true
+
+  - version: "3.36"
+    release_date: 2026-05-27
+    eol_date:
+    lts: false
+    latest_patch: "3.36.3"
+    latest_patch_date: 2026-06-18
+    link: /blog/quarkus-3-36-1-released/
+
+  - version: "3.35"
+    release_date: 2026-05-01
+    eol_date: 2026-05-27
+    lts: false
+    latest_patch: "3.35.4"
+    latest_patch_date: 2026-05-20
+    link: /blog/quarkus-3-35-released/
+
+  - version: "3.34"
+    release_date: 2026-03-25
+    eol_date: 2026-05-01
+    lts: false
+    latest_patch: "3.34.7"
+    latest_patch_date: 2026-05-04
+    link: /blog/quarkus-3-34-released/
+
+  - version: "3.33"
+    release_date: 2026-03-25
+    eol_date: 2027-03-25
+    lts: true
+    latest_patch: "3.33.2.1"
+    latest_patch_date: 2026-06-17
+    link: /blog/quarkus-3-33-released/
+    rhbq_eol: 2028-06-30
+    ibm_eol: 2028-06-30
+
+  - version: "3.32"
+    release_date: 2026-02-26
+    eol_date: 2026-03-25
+    lts: false
+    latest_patch: "3.32.4"
+    latest_patch_date: 2026-03-18
+    link: /blog/quarkus-3-32-2-released/
+
+  - version: "3.31"
+    release_date: 2026-01-28
+    eol_date: 2026-02-26
+    lts: false
+    latest_patch: "3.31.4"
+    latest_patch_date: 2026-02-18
+    link: /blog/quarkus-3-31-released/
+
+  - version: "3.30"
+    release_date: 2025-11-26
+    eol_date: 2026-01-28
+    lts: false
+    latest_patch: "3.30.8"
+    latest_patch_date: 2026-01-23
+
+  - version: "3.29"
+    release_date: 2025-10-29
+    eol_date: 2025-11-26
+    lts: false
+    latest_patch: "3.29.4"
+    latest_patch_date: 2025-11-19
+
+  - version: "3.28"
+    release_date: 2025-09-24
+    eol_date: 2025-10-29
+    lts: false
+    latest_patch: "3.28.5"
+    latest_patch_date: 2025-10-22
+
+  - version: "3.27"
+    release_date: 2025-09-24
+    eol_date: 2026-09-24
+    lts: true
+    latest_patch: "3.27.4.1"
+    latest_patch_date: 2026-06-17
+    rhbq_eol: 2027-12-31
+    ibm_eol: 2027-12-31
+
+  - version: "3.26"
+    release_date: 2025-08-28
+    eol_date: 2025-09-24
+    lts: false
+    latest_patch: "3.26.4"
+    latest_patch_date: 2025-09-17
+
+  - version: "3.25"
+    release_date: 2025-07-30
+    eol_date: 2025-08-28
+    lts: false
+    latest_patch: "3.25.4"
+    latest_patch_date: 2025-08-20
+
+  - version: "3.24"
+    release_date: 2025-06-25
+    eol_date: 2025-07-30
+    lts: false
+    latest_patch: "3.24.5"
+    latest_patch_date: 2025-07-23
+
+  - version: "3.23"
+    release_date: 2025-05-28
+    eol_date: 2025-06-25
+    lts: false
+    latest_patch: "3.23.4"
+    latest_patch_date: 2025-06-19
+
+  - version: "3.22"
+    release_date: 2025-04-30
+    eol_date: 2025-05-28
+    lts: false
+    latest_patch: "3.22.3"
+    latest_patch_date: 2025-05-15
+
+  - version: "3.21"
+    release_date: 2025-03-26
+    eol_date: 2025-04-30
+    lts: false
+    latest_patch: "3.21.4"
+    latest_patch_date: 2025-04-24
+
+  - version: "3.20"
+    release_date: 2025-03-26
+    eol_date: 2026-03-28
+    lts: true
+    latest_patch: "3.20.6.2"
+    latest_patch_date: 2026-06-17
+    rhbq_eol: 2027-06-30
+
+  - version: "3.19"
+    release_date: 2025-02-26
+    eol_date: 2025-03-28
+    lts: false
+    latest_patch: "3.19.4"
+    latest_patch_date: 2025-03-19
+
+  - version: "3.18"
+    release_date: 2025-01-29
+    eol_date: 2025-02-26
+    lts: false
+    latest_patch: "3.18.4"
+    latest_patch_date: 2025-02-19
+
+  - version: "3.17"
+    release_date: 2024-11-27
+    eol_date: 2025-01-29
+    lts: false
+    latest_patch: "3.17.8"
+    latest_patch_date: 2025-01-22
+
+  - version: "3.16"
+    release_date: 2024-10-30
+    eol_date: 2024-11-27
+    lts: false
+    latest_patch: "3.16.4"
+    latest_patch_date: 2024-11-20
+
+  - version: "3.15"
+    release_date: 2024-09-25
+    eol_date: 2025-09-25
+    lts: true
+    latest_patch: "3.15.7"
+    latest_patch_date: 2025-09-24
+    rhbq_eol: 2027-03-31
+
+  - version: "3.14"
+    release_date: 2024-08-28
+    eol_date: 2024-09-25
+    lts: false
+    latest_patch: "3.14.4"
+    latest_patch_date: 2024-09-14
+
+  - version: "3.13"
+    release_date: 2024-07-31
+    eol_date: 2024-08-28
+    lts: false
+    latest_patch: "3.13.3"
+    latest_patch_date: 2024-08-20
+
+  - version: "3.12"
+    release_date: 2024-06-26
+    eol_date: 2024-07-31
+    lts: false
+    latest_patch: "3.12.3"
+    latest_patch_date: 2024-07-17
+
+  - version: "3.11"
+    release_date: 2024-05-29
+    eol_date: 2024-06-26
+    lts: false
+    latest_patch: "3.11.3"
+    latest_patch_date: 2024-06-19
+
+  - version: "3.10"
+    release_date: 2024-04-30
+    eol_date: 2024-05-29
+    lts: false
+    latest_patch: "3.10.2"
+    latest_patch_date: 2024-05-22
+
+  - version: "3.9"
+    release_date: 2024-03-27
+    eol_date: 2024-04-30
+    lts: false
+    latest_patch: "3.9.5"
+    latest_patch_date: 2024-04-27
+
+  - version: "3.8"
+    release_date: 2024-02-28
+    eol_date: 2025-02-28
+    lts: true
+    latest_patch: "3.8.6.1"
+    latest_patch_date: 2025-02-27
+    rhbq_eol: 2026-06-30
+
+  - version: "3.7"
+    release_date: 2024-01-31
+    eol_date: 2024-02-28
+    lts: false
+    latest_patch: "3.7.4"
+    latest_patch_date: 2024-02-21
+
+  - version: "3.6"
+    release_date: 2023-11-29
+    eol_date: 2024-01-31
+    lts: false
+    latest_patch: "3.6.9"
+    latest_patch_date: 2024-01-31
+
+  - version: "3.5"
+    release_date: 2023-10-25
+    eol_date: 2023-11-29
+    lts: false
+    latest_patch: "3.5.3"
+    latest_patch_date: 2023-11-21
+
+  - version: "3.4"
+    release_date: 2023-09-20
+    eol_date: 2023-10-25
+    lts: false
+    latest_patch: "3.4.3"
+    latest_patch_date: 2023-10-13
+
+  - version: "3.3"
+    release_date: 2023-08-23
+    eol_date: 2023-09-20
+    lts: false
+    latest_patch: "3.3.3"
+    latest_patch_date: 2023-09-14
+
+  - version: "3.2"
+    release_date: 2023-07-05
+    eol_date: 2024-07-05
+    lts: true
+    latest_patch: "3.2.12"
+    latest_patch_date: 2024-04-16
+    rhbq_eol: 2025-12-31
+
+  - version: "3.1"
+    release_date: 2023-05-31
+    eol_date: 2023-07-05
+    lts: false
+    latest_patch: "3.1.3"
+    latest_patch_date: 2023-06-29
+
+  - version: "3.0"
+    release_date: 2023-04-26
+    eol_date: 2023-05-31
+    lts: false
+    latest_patch: "3.0.4"
+    latest_patch_date: 2023-05-25
+
+  - version: "2.16"
+    release_date: 2023-01-25
+    eol_date: 2023-10-31
+    lts: false
+    latest_patch: "2.16.12"
+    latest_patch_date: 2023-10-17
+
+  - version: "2.15"
+    release_date: 2022-12-14
+    eol_date: 2023-01-25
+    lts: false
+    latest_patch: "2.15.3"
+    latest_patch_date: 2023-01-10
+
+  - version: "2.14"
+    release_date: 2022-11-09
+    eol_date: 2022-12-14
+    lts: false
+    latest_patch: "2.14.3"
+    latest_patch_date: 2022-12-06
+
+  - version: "2.13"
+    release_date: 2022-09-28
+    eol_date: 2022-11-07
+    lts: false
+    latest_patch: "2.13.9"
+    latest_patch_date: 2023-11-22
+    rhbq_eol: 2025-06-30
+
+  - version: "2.12"
+    release_date: 2022-08-31
+    eol_date: 2022-09-21
+    lts: false
+    latest_patch: "2.12.3"
+    latest_patch_date: 2022-09-20
+
+  - version: "2.11"
+    release_date: 2022-07-27
+    eol_date: 2022-08-24
+    lts: false
+    latest_patch: "2.11.3"
+    latest_patch_date: 2022-08-24
+
+  - version: "2.10"
+    release_date: 2022-06-22
+    eol_date: 2022-07-26
+    lts: false
+    latest_patch: "2.10.4"
+    latest_patch_date: 2022-07-27
+
+  - version: "2.9"
+    release_date: 2022-05-11
+    eol_date: 2022-06-15
+    lts: false
+    latest_patch: "2.9.2"
+    latest_patch_date: 2022-05-25
+
+  - version: "2.8"
+    release_date: 2022-04-12
+    eol_date: 2022-05-06
+    lts: false
+    latest_patch: "2.8.3"
+    latest_patch_date: 2022-05-06
+
+  - version: "2.7"
+    release_date: 2022-02-02
+    eol_date: 2022-05-30
+    lts: false
+    latest_patch: "2.7.7"
+    latest_patch_date: 2023-01-26
+    rhbq_eol: 2024-06-30
+
+  - version: "2.6"
+    release_date: 2021-12-22
+    eol_date: 2022-01-26
+    lts: false
+    latest_patch: "2.6.3"
+    latest_patch_date: 2022-01-20
+
+  - version: "2.5"
+    release_date: 2021-11-24
+    eol_date: 2021-12-17
+    lts: false
+    latest_patch: "2.5.4"
+    latest_patch_date: 2021-12-20
+
+  - version: "2.4"
+    release_date: 2021-10-27
+    eol_date: 2021-11-17
+    lts: false
+    latest_patch: "2.4.2"
+    latest_patch_date: 2021-11-12
+
+  - version: "2.3"
+    release_date: 2021-10-06
+    eol_date: 2021-10-20
+    lts: false
+    latest_patch: "2.3.1"
+    latest_patch_date: 2021-10-20
+
+  - version: "2.2"
+    release_date: 2021-08-31
+    eol_date: 2021-12-21
+    lts: false
+    latest_patch: "2.2.5"
+    latest_patch_date: 2021-12-21
+    rhbq_eol: 2023-06-30
+
+  - version: "2.1"
+    release_date: 2021-07-29
+    eol_date: 2021-08-26
+    lts: false
+    latest_patch: "2.1.4"
+    latest_patch_date: 2021-08-26
+
+  - version: "2.0"
+    release_date: 2021-06-30
+    eol_date: 2021-07-22
+    lts: false
+    latest_patch: "2.0.3"
+    latest_patch_date: 2021-07-22
+
+  - version: "1"
+    release_date: 2019-11-25
+    eol_date: 2021-06-23
+    lts: false
+    latest_patch: "1.13.7"
+    latest_patch_date: 2021-06-09
+    rhbq_eol: 2022-06-30
+
+  - version: "0"
+    release_date: 2018-12-12
+    eol_date: 2019-11-25
+    lts: false
+    latest_patch: "0.28.1"
+    latest_patch_date: 2019-11-04

--- a/_data/sitemap-links.yaml
+++ b/_data/sitemap-links.yaml
@@ -169,7 +169,20 @@ sections:
         description: "Complete guides"
         priority: 0.9
         changefreq: "daily"
-      
+
+
+      - title: "Releases"
+        url: "/releases"
+        description: "Listing of all releases and support status"
+        priority: 0.5
+        changefreq: "daily"
+
+      - title: "End-of-life releases"
+        url: "/eol"
+        description: "Listing of releases which have reached the end of community support"
+        priority: 0.5
+        changefreq: "weekly"
+
       - title: "User Stories"
         url: "/userstories"
         description: "Success stories"

--- a/_includes/eol-commercial-support-band.html
+++ b/_includes/eol-commercial-support-band.html
@@ -1,0 +1,32 @@
+<div class="full-width-bg component-slim">
+    <div class="grid-wrapper eol-commercial-band">
+        <div class="width-12-12">
+            <h2>Enterprise Support</h2>
+            <p><a href="{{ site.baseurl }}/support/#enterprise-support">Enterprise offerings of Quarkus</a>
+               are actively maintained with longer lifecycles than the community releases.
+               Some versions listed in the table above may still be under active enterprise support.
+               See the <a href="{{ site.baseurl }}/releases/">releases page</a> for details.</p>
+        </div>
+        <div class="width-12-12">
+            <h2>On-Demand Patches for EOL Versions</h2>
+            <p>If your organisation is not yet ready to upgrade from an EOL version,
+               the following vendors can provide security patches and fixes on request.</p>
+        </div>
+        <div class="width-12-12">
+            <div class="eol-provider">
+                <h4><a href="{{ site.data.releases.support_providers.ibm.url }}">{{ site.data.releases.support_providers.ibm.name }}</a></h4>
+                <p>IBM may provide on-demand patches for older versions of their
+                   enterprise Quarkus products, even after the community release
+                   has reached end-of-life.</p>
+            </div>
+        </div>
+        <div class="width-12-12">
+            <div class="eol-provider">
+                <h4><a href="{{ site.data.releases.support_providers.herodevs.url }}">{{ site.data.releases.support_providers.herodevs.name }}</a></h4>
+                <p>HeroDevs provides on-demand security patches and compliance
+                   support for EOL Quarkus versions, bridging the gap while
+                   you plan your upgrade.</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/_includes/eol-explanation-band.html
+++ b/_includes/eol-explanation-band.html
@@ -1,0 +1,45 @@
+<div class="full-width-bg component-slim">
+    <div class="grid-wrapper eol-band">
+        <div class="width-12-12">
+            <h2>What Happens When a Release Reaches End-of-Life</h2>
+            <p>{{ site.data.releases.policy.eol_description }}</p>
+        </div>
+        <div class="width-6-12 width-12-12-m">
+            <div class="eol-consequence">
+                <h4><i class="fas fa-shield-halved"></i> No More Vulnerability Fixes</h4>
+                <p>Security vulnerabilities discovered after EOL will not be patched.
+                   Your applications remain exposed to known exploits.</p>
+            </div>
+        </div>
+        <div class="width-6-12 width-12-12-m">
+            <div class="eol-consequence">
+                <h4><i class="fas fa-puzzle-piece"></i> Ecosystem Drift</h4>
+                <p>Extensions and libraries drop support for EOL versions,
+                   making it progressively harder to update dependencies.</p>
+            </div>
+        </div>
+        <div class="width-6-12 width-12-12-m">
+            <div class="eol-consequence">
+                <h4><i class="fas fa-link-slash"></i> Toolchain Breakage</h4>
+                <p>Build tools, CI systems, and shared libraries may introduce
+                   incompatibilities that are never resolved for EOL releases.</p>
+            </div>
+        </div>
+        <div class="width-6-12 width-12-12-m">
+            <div class="eol-consequence">
+                <h4><i class="fas fa-clipboard-check"></i> Compliance Risks</h4>
+                <p>Industry audits and security frameworks flag unmaintained
+                   runtimes, potentially blocking deployments and certifications.</p>
+            </div>
+        </div>
+        <div class="width-12-12">
+            <p>
+                <strong>We recommend upgrading to an LTS release.</strong>
+                LTS releases are maintained for {{ site.data.releases.policy.lts_support_duration }} with critical bug fixes and security patches.
+            </p>
+        </div>
+        <div class="width-12-12 eol-cta">
+            <a href="{{ site.baseurl }}/releases/" class="button-cta">View all releases</a>
+        </div>
+    </div>
+</div>

--- a/_includes/eol-table-band.html
+++ b/_includes/eol-table-band.html
@@ -1,0 +1,36 @@
+<div class="full-width-bg component-slim">
+    <div class="grid-wrapper eol-table-band">
+        <div class="width-12-12">
+            <h2>EOL Versions</h2>
+            <div class="table-responsive">
+                <table class="releases-table">
+                    <thead>
+                        <tr>
+                            <th>Release</th>
+                            <th>Released</th>
+                            <th>End of Life</th>
+                            <th>Final Patch</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% assign today = 'now' | date: '%Y-%m-%d' %}
+                        {% for release in site.data.releases.releases %}
+                        {% assign eol_str = release.eol_date | date: '%Y-%m-%d' %}
+                        {% if release.eol_date and eol_str <= today %}
+                        <tr>
+                            <td>
+                                {{ release.version }}
+                                {% if release.lts %}<span class="release-badge lts">LTS</span>{% endif %}
+                            </td>
+                            <td>{{ release.release_date | date: '%d %b %Y' }}</td>
+                            <td>{{ release.eol_date | date: '%d %b %Y' }}</td>
+                            <td>{{ release.latest_patch }}</td>
+                        </tr>
+                        {% endif %}
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -43,6 +43,7 @@
         <ul class="submenu">
           <li><a href="{{site.baseurl}}/get-started" class="{% if page.url contains '/get-started/' %}active{% endif %}">GET STARTED</a></li>
           <li><a href="{{site.baseurl}}/guides" class="{% if page.url contains '/guides/' %}active{% endif %}">DOCUMENTATION</a></li>
+          <li><a href="{{site.baseurl}}/releases/" class="{% if page.url contains '/releases/' %}active{% endif %}">RELEASES</a></li>
           <li><a href="{{site.baseurl}}/userstories/" class="{% if page.url contains '/userstories/' %}active{% endif %}">USER STORIES</a></li>  
           <li><a href="{{site.baseurl}}/qtips" class="{% if page.url contains '/qtips/' %}active{% endif %}">"Q" TIP VIDEOS</a></li>          
           <li><a href="{{site.baseurl}}/books" class="{% if page.url contains '/books/' %}active{% endif %}">BOOKS</a></li>

--- a/_includes/releases-table-band.html
+++ b/_includes/releases-table-band.html
@@ -1,0 +1,140 @@
+<div class="full-width-bg component-slim">
+    <div class="grid-wrapper releases-band">
+        <div class="width-12-12">
+            {% assign today = 'now' | date: '%Y-%m-%d' %}
+            {% for release in site.data.releases.releases %}
+                {% assign eol_str = release.eol_date | date: '%Y-%m-%d' %}
+                {% if release.lts and eol_str > today %}
+                    {% unless recommended_lts %}
+                        {% assign recommended_lts = release %}
+                    {% endunless %}
+                {% endif %}
+            {% endfor %}
+            {% if recommended_lts %}
+            <div class="lts-callout">
+                <i class="fas fa-star"></i>
+                <strong>Recommended for production:</strong> use the latest LTS release,
+                <a href="https://code.quarkus.io/?S={{ recommended_lts.version }}">Quarkus {{ recommended_lts.version }}</a>.
+                LTS releases receive critical fixes and security patches for {{ site.data.releases.policy.lts_support_duration }}.
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="width-12-12">
+            <p>
+                New minor versions of Quarkus are released every 4–6 weeks.
+                <strong>LTS releases</strong> are published {{ site.data.releases.policy.lts_cadence }} and maintained for {{ site.data.releases.policy.lts_support_duration }} with critical bug fixes and security patches.
+                Non-LTS releases are supported {{ site.data.releases.policy.non_lts_support_duration }}.
+            </p>
+            <p>
+                Running an unsupported version? See our <a href="{{ site.baseurl }}/eol/">End-of-Life guidance</a>.
+            </p>
+        </div>
+
+        <div class="width-12-12">
+            <div class="releases-filter">
+                <label>
+                    <input type="checkbox" id="hide-eol" checked /> Hide end-of-life releases
+                </label>
+            </div>
+
+            <div class="table-responsive">
+                <table class="releases-table">
+                    <thead>
+                        <tr>
+                            <th>Release</th>
+                            <th>Released</th>
+                            <th>Community Maintenance</th>
+                            <th><a href="{{ site.baseurl }}/support/#enterprise-support">Enterprise Support</a></th>
+                            <th>EOL Patches Available</th>
+                            <th>Latest Community Micro</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% assign today = 'now' | date: '%Y-%m-%d' %}
+                        {% for release in site.data.releases.releases %}
+                        {% assign eol_str = release.eol_date | date: '%Y-%m-%d' %}
+                        {% assign rhbq_active = false %}
+                        {% assign ibm_active = false %}
+                        {% if release.rhbq_eol %}
+                            {% assign rhbq_eol_str = release.rhbq_eol | date: '%Y-%m-%d' %}
+                            {% if rhbq_eol_str > today %}{% assign rhbq_active = true %}{% endif %}
+                        {% endif %}
+                        {% if release.ibm_eol %}
+                            {% assign ibm_eol_str = release.ibm_eol | date: '%Y-%m-%d' %}
+                            {% if ibm_eol_str > today %}{% assign ibm_active = true %}{% endif %}
+                        {% endif %}
+                        <tr class="release-row{% if release.upcoming %} release-upcoming{% elsif release.eol_date == nil %} release-active{% endif %}{% if release.lts %} release-lts{% endif %}" data-eol="{{ eol_str }}"{% if rhbq_active or ibm_active %} data-supported="true"{% endif %}>
+                            <td>
+                                {% if release.upcoming %}
+                                {{ release.version }}
+                                {% elsif release.eol_date == nil %}
+                                <a href="https://code.quarkus.io/?S={{ release.version }}">{{ release.version }}</a>
+                                {% else %}
+                                    {% if eol_str > today %}
+                                <a href="https://code.quarkus.io/?S={{ release.version }}">{{ release.version }}</a>
+                                    {% else %}
+                                {{ release.version }}
+                                    {% endif %}
+                                {% endif %}
+                                {% if release.lts %}<span class="release-badge lts">LTS</span>{% endif %}
+                            </td>
+                            <td>
+                                {% if release.upcoming %}
+                                —
+                                {% else %}
+                                {{ release.release_date | date: '%d %b %Y' }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if release.upcoming %}
+                                <span class="release-status-badge upcoming">Upcoming</span>
+                                {% elsif release.eol_date == nil %}
+                                <span class="release-status-badge active">Active</span>
+                                {% else %}
+                                    {% if eol_str > today %}
+                                <span class="release-status-badge active">Until {{ release.eol_date | date: '%d %b %Y' }}</span>
+                                    {% else %}
+                                <span class="release-status-badge eol">Ended {{ release.eol_date | date: '%d %b %Y' }}</span>
+                                    {% endif %}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if rhbq_active %}
+                                <a href="{{ site.data.releases.support_providers.rhbq.url }}" class="release-support-badge rhbq">RHBQ</a>
+                                {% endif %}
+                                {% if ibm_active %}
+                                <a href="{{ site.data.releases.support_providers.ibm.url }}" class="release-support-badge ibm">IBM</a>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if ibm_active %}
+                                <a href="{{ site.data.releases.support_providers.ibm.url }}" class="release-support-badge ibm">IBM</a>
+                                {% endif %}
+                                {% if release.eol_date %}
+                                    {% unless eol_str > today %}
+                                <a href="{{ site.data.releases.support_providers.herodevs.url }}" class="release-support-badge herodevs">HeroDevs</a>
+                                    {% endunless %}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if release.upcoming %}
+                                —
+                                {% elsif release.link %}
+                                <a href="{{ site.baseurl }}{{ release.link }}">{{ release.latest_patch }}</a>
+                                <span class="patch-date">({{ release.latest_patch_date | date: '%d %b %Y' }})</span>
+                                {% else %}
+                                {{ release.latest_patch }}
+                                <span class="patch-date">({{ release.latest_patch_date | date: '%d %b %Y' }})</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="{{ '/assets/javascript/releases-filter.js' | relative_url }}" type="text/javascript"></script>

--- a/_layouts/eol.html
+++ b/_layouts/eol.html
@@ -1,0 +1,8 @@
+---
+layout: base
+---
+
+{% include title-band.html %}
+{% include eol-explanation-band.html %}
+{% include eol-table-band.html %}
+{% include eol-commercial-support-band.html %}

--- a/_layouts/releases.html
+++ b/_layouts/releases.html
@@ -1,0 +1,6 @@
+---
+layout: base
+---
+
+{% include title-band.html %}
+{% include releases-table-band.html %}

--- a/_sass/layouts/releases.scss
+++ b/_sass/layouts/releases.scss
@@ -1,0 +1,178 @@
+.lts-callout {
+  background-color: rgba($quarkus-blue, 0.1);
+  border-left: 4px solid $quarkus-blue;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  border-radius: 0 0.375rem 0.375rem 0;
+  font-size: 0.95rem;
+
+  i {
+    color: $quarkus-blue;
+    margin-right: 0.4rem;
+  }
+}
+
+.releases-band, .eol-band, .eol-table-band, .eol-commercial-band {
+
+  .releases-filter {
+    margin-bottom: 1rem;
+    label {
+      cursor: pointer;
+      font-size: 0.95rem;
+    }
+  }
+
+  .table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .releases-table {
+    width: 100%;
+    border-collapse: collapse;
+
+    thead th {
+      font-size: 1.1rem;
+      line-height: 1.6rem;
+      color: white !important;
+      font-weight: 600 !important;
+      text-align: left;
+      padding: 1rem;
+      background-color: var(--table-head-background-color);
+      border: 1px solid var(--sec-border-color);
+
+      a {
+        color: inherit;
+        font-weight: inherit;
+        text-decoration: none;
+      }
+    }
+
+    tbody td {
+      padding: .5rem 1rem;
+      border: 1px solid var(--sec-border-color);
+      white-space: nowrap;
+    }
+
+    tbody tr {
+      &:nth-child(even) {
+        background-color: var(--table-row-stripe);
+      }
+      &.release-hidden {
+        display: none;
+      }
+      &.release-upcoming {
+        opacity: 0.7;
+      }
+    }
+
+    .patch-date {
+      font-size: 0.85rem;
+      opacity: 0.7;
+    }
+  }
+}
+
+.release-badge {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  text-align: center;
+  vertical-align: middle;
+  border-radius: 0.375rem;
+  margin-left: 0.4rem;
+
+  &.lts {
+    color: #fff !important;
+    background-color: $dark-blue-1;
+  }
+
+  &.upcoming {
+    color: #fff !important;
+    background-color: $dark-blue-1;
+  }
+}
+
+.release-status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 0.375rem;
+
+  &.active {
+    color: #fff !important;
+    background-color: RGBA(25, 135, 84, 1);
+  }
+
+  &.eol {
+    color: #fff !important;
+    background-color: RGBA(108, 117, 125, 1);
+  }
+
+  &.upcoming {
+    color: #fff !important;
+    background-color: $dark-blue-1;
+  }
+}
+
+a.release-support-badge,
+.release-support-badge {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 0.375rem;
+  margin-right: 0.3rem;
+  color: #fff !important;
+  text-decoration: none;
+
+  &.rhbq {
+    background-color: #c00;
+    &:hover { background-color: #a00; }
+  }
+
+  &.ibm {
+    background-color: #0f62fe;
+    &:hover { background-color: #0043ce; }
+  }
+
+  &.herodevs {
+    background-color: #6b21a8;
+    &:hover { background-color: #581c87; }
+  }
+}
+
+.eol-consequence {
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--card-outline);
+  border-radius: 10px;
+
+  h4 {
+    margin-top: 0;
+    i {
+      color: $quarkus-blue;
+      margin-right: 0.5rem;
+    }
+  }
+
+  p {
+    margin-bottom: 0;
+  }
+}
+
+.eol-cta {
+  margin-top: 1rem;
+}
+
+.eol-provider {
+  padding: 1.5rem;
+  border: 1px solid var(--card-outline);
+  border-radius: 10px;
+  margin-bottom: 1rem;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -46,6 +46,7 @@
 @import "layouts/publications";
 @import "layouts/documentation";
 @import "layouts/working-groups";
+@import "layouts/releases";
 @import "includes/header-navigation";
 @import "includes/libraries-standards-band";
 @import "includes/homepage-hero-band";

--- a/assets/javascript/releases-filter.js
+++ b/assets/javascript/releases-filter.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var checkbox = document.getElementById('hide-eol');
+  if (!checkbox) return;
+
+  var today = new Date().toISOString().split('T')[0];
+
+  function applyFilter() {
+    var rows = document.querySelectorAll('.release-row');
+    rows.forEach(function(row) {
+      var eol = row.getAttribute('data-eol');
+      var supported = row.hasAttribute('data-supported');
+      if (eol && eol <= today && !supported) {
+        row.classList.toggle('release-hidden', checkbox.checked);
+      }
+    });
+  }
+
+  applyFilter();
+  checkbox.addEventListener('change', applyFilter);
+});

--- a/eol.md
+++ b/eol.md
@@ -1,0 +1,6 @@
+---
+layout: eol
+title: End-of-Life Releases
+subtitle: Guidance for applications running on unsupported Quarkus versions.
+permalink: /eol/
+---

--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,6 @@
+---
+layout: releases
+title: Quarkus Releases
+subtitle: Release history and support status for all Quarkus versions.
+permalink: /releases/
+---

--- a/src/test/java/io/quarkusio/EolPageTest.java
+++ b/src/test/java/io/quarkusio/EolPageTest.java
@@ -1,0 +1,51 @@
+package io.quarkusio;
+
+import com.microsoft.playwright.Locator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EolPageTest extends BrowserTest {
+
+    @Test
+    void eolPageHasConsequenceSections() {
+        page.navigate(baseUrl + "/eol/");
+        int consequenceCount = page.locator(".eol-consequence").count();
+        assertTrue(consequenceCount >= 2,
+                "Expected at least 2 EOL consequence sections but found " + consequenceCount);
+    }
+
+    @Test
+    void eolPageMentionsLts() {
+        page.navigate(baseUrl + "/eol/");
+        String text = page.locator(".eol-band").textContent();
+        assertTrue(text.contains("LTS"),
+                "EOL page should mention LTS releases");
+    }
+
+    @Test
+    void eolPageHasEolTable() {
+        page.navigate(baseUrl + "/eol/");
+        Locator table = page.locator(".eol-table-band .releases-table");
+        assertTrue(table.isVisible(), "EOL table should be visible");
+        int rowCount = page.locator(".eol-table-band .releases-table tbody tr").count();
+        assertTrue(rowCount >= 5,
+                "Expected at least 5 EOL releases in the table but found " + rowCount);
+    }
+
+    @Test
+    void eolPageHasCommercialSupportSection() {
+        page.navigate(baseUrl + "/eol/");
+        Locator providers = page.locator(".eol-provider");
+        assertTrue(providers.count() >= 2,
+                "Expected at least two EOL support providers but found " + providers.count());
+    }
+
+    @Test
+    void eolPageHasViewAllReleasesButton() {
+        page.navigate(baseUrl + "/eol/");
+        Locator cta = page.locator(".eol-cta a[href*='/releases/']");
+        assertTrue(cta.count() >= 1,
+                "Expected a 'View all releases' button linking to /releases/");
+    }
+}

--- a/src/test/java/io/quarkusio/ReleasesPageTest.java
+++ b/src/test/java/io/quarkusio/ReleasesPageTest.java
@@ -1,0 +1,131 @@
+package io.quarkusio;
+
+import com.microsoft.playwright.Locator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReleasesPageTest extends BrowserTest {
+
+    @Test
+    void releasesTableHasKeyColumns() {
+        page.navigate(baseUrl + "/releases/");
+        String headerText = page.locator(".releases-table thead").textContent();
+        Locator headers = page.locator(".releases-table thead th");
+        assertTrue(headers.count() >= 4,
+                "Expected at least 4 table columns but found " + headers.count());
+        assertTrue(headerText.contains("Release"), "Table should have a Release column");
+        assertTrue(headerText.contains("Support"), "Table should have a support-related column");
+    }
+
+    @Test
+    void releasesTableHasSubstantialContent() {
+        page.navigate(baseUrl + "/releases/");
+        int rowCount = page.locator(".releases-table tbody tr.release-row").count();
+        assertTrue(rowCount >= 10,
+                "Expected at least 10 release rows but found " + rowCount);
+    }
+
+    @Test
+    void ltsCalloutIsPresent() {
+        page.navigate(baseUrl + "/releases/");
+        Locator callout = page.locator(".lts-callout");
+        assertTrue(callout.isVisible(), "LTS callout should be visible");
+    }
+
+    @Test
+    void ltsCalloutHasActionableLink() {
+        page.navigate(baseUrl + "/releases/");
+        Locator links = page.locator(".lts-callout a");
+        assertTrue(links.count() >= 1,
+                "LTS callout should contain at least one link");
+        String href = links.first().getAttribute("href");
+        assertNotNull(href, "LTS callout link should have an href");
+        assertFalse(href.isBlank(), "LTS callout link href should not be blank");
+    }
+
+    @Test
+    void releaseTableHasLtsBadges() {
+        page.navigate(baseUrl + "/releases/");
+        int ltsCount = page.locator(".release-badge.lts").count();
+        assertTrue(ltsCount >= 2,
+                "Expected at least 2 LTS badges but found " + ltsCount);
+    }
+
+    @Test
+    void releaseTableHasUpcomingRelease() {
+        page.navigate(baseUrl + "/releases/");
+        Locator upcoming = page.locator("tr.release-upcoming");
+        assertTrue(upcoming.count() >= 1,
+                "Expected at least one upcoming release row");
+        Locator badge = upcoming.locator(".release-status-badge.upcoming");
+        assertTrue(badge.count() >= 1,
+                "Upcoming release should have an upcoming status badge");
+    }
+
+    @Test
+    void enterpriseSupportColumnHasBadges() {
+        page.navigate(baseUrl + "/releases/");
+        int rhbqCount = page.locator(".releases-table .release-support-badge.rhbq").count();
+        assertTrue(rhbqCount >= 1,
+                "Expected at least one RHBQ badge but found " + rhbqCount);
+    }
+
+    @Test
+    void eolFilterDefaultsToChecked() {
+        page.navigate(baseUrl + "/releases/");
+        Locator checkbox = page.locator("#hide-eol");
+        assertTrue(checkbox.isChecked(),
+                "Hide EOL checkbox should be checked by default");
+    }
+
+    @Test
+    void eolFilterHidesUnsupportedReleases() {
+        page.navigate(baseUrl + "/releases/");
+        Locator hidden = page.locator("tr.release-row.release-hidden");
+        assertTrue(hidden.count() > 0,
+                "Some EOL releases should be hidden by default");
+    }
+
+    @Test
+    void eolFilterDoesNotHideSupportedReleases() {
+        page.navigate(baseUrl + "/releases/");
+        Locator supportedRows = page.locator("tr.release-row[data-supported='true']");
+        for (int i = 0; i < supportedRows.count(); i++) {
+            assertFalse(supportedRows.nth(i).evaluate("el => el.classList.contains('release-hidden')").equals(true),
+                    "Rows with enterprise support should not be hidden by the EOL filter");
+        }
+    }
+
+    @Test
+    void uncheckingEolFilterShowsAllReleases() {
+        page.navigate(baseUrl + "/releases/");
+        Locator checkbox = page.locator("#hide-eol");
+        checkbox.uncheck();
+        int hidden = page.locator("tr.release-row.release-hidden").count();
+        assertEquals(0, hidden,
+                "No releases should be hidden after unchecking the filter");
+    }
+
+    @Test
+    void eolFilterHidesRowsWithExpiredEnterpriseSupport() {
+        page.navigate(baseUrl + "/releases/");
+        Locator eolWithoutSupport = page.locator("tr.release-row.release-hidden:not([data-supported])");
+        assertTrue(eolWithoutSupport.count() > 0,
+                "Releases past both community and enterprise EOL should be hidden by default");
+        for (int i = 0; i < eolWithoutSupport.count(); i++) {
+            String eol = eolWithoutSupport.nth(i).getAttribute("data-eol");
+            assertNotNull(eol, "Hidden row should have a data-eol attribute");
+            assertFalse(eolWithoutSupport.nth(i).isVisible(),
+                    "Row with expired enterprise support (eol=" + eol + ") should not be visible");
+        }
+    }
+
+    @Test
+    void enterpriseSupportHeaderLinksToSupportPage() {
+        page.navigate(baseUrl + "/releases/");
+        Locator link = page.locator(".releases-table thead a[href*='/support/']");
+        assertTrue(link.count() >= 1,
+                "Enterprise Support header should link to the support page");
+    }
+}

--- a/src/test/java/io/quarkusio/SmokePageTest.java
+++ b/src/test/java/io/quarkusio/SmokePageTest.java
@@ -21,7 +21,9 @@ public class SmokePageTest extends BrowserTest {
             "/newsletter/",
             "/community/",
             "/events/",
-            "/userstories/"
+            "/userstories/",
+            "/releases/",
+            "/eol/"
     })
     void criticalPageReturns200(String path) {
         Response response = page.navigate(baseUrl + path);


### PR DESCRIPTION
This is something we've been wanting to do for ages, so that people don't have to go to https://endoflife.date/quarkus-framework to find information we should be providing ourselves.

I've added a releases page showing all Quarkus versions with support status, LTS badges, code.quarkus.io links for supported versions, and linked RHBQ/IBM/HeroDevs support badges. I also added an end-of-life page, modelled on https://node.js/eol, explaining EOL consequences with enterprise support options from HeroDevs.

The releases page is linked off the learn menu (and itself links to the /support page). The /eol page is just linked from the /releases page. 

As a tactical first step the data file is manually generated and maintained, but of course my intention is to automate the process of collecting the data (or at least the skeleton of the data). 
