### PR TITLE
Add contributor data generation pipeline

### DIFF
--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -1,0 +1,61 @@
+name: Sync contributors
+
+env:
+  JVM_VERSION: '21'
+
+on:
+  schedule:
+    - cron: '17 3 * * 1' # weekly on Monday
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sync:
+    if: github.repository == 'quarkusio/quarkusio.github.io'
+    runs-on: ubuntu-latest
+    environment: quarkus-push-website
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
+          private-key: ${{ secrets.QUARKUS_PUSH_WEBSITE_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Install JDK ${{ env.JVM_VERSION }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ env.JVM_VERSION }}
+
+      - name: Set up JBang
+        uses: jbangdev/setup-jbang@2b1b465a7b75f4222b81426f23a01e013aa7b95c # v0.1.1
+
+      - name: Run script
+        run: |
+          jbang --java ${JVM_VERSION} -Dcontributors.output=_data/contributors.yaml contributors/main.java
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_WORKING_GROUP_TOKEN }}
+
+      - name: Configure Git author
+        run: |
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+
+      - name: Commit changes
+        shell: bash
+        run: |
+            git add _data/contributors.yaml
+            if [ -n "$(git status --porcelain)" ]; then
+              git commit -am "Sync contributors"
+            fi
+            git pull origin main --rebase
+            git push origin main

--- a/_data/contributors.yaml
+++ b/_data/contributors.yaml
@@ -1,0 +1,678 @@
+---
+generated: "2026-06-19T17:05:09.09413Z"
+period-months: 6
+total-commits: 1640
+companies:
+  - name: "Red Hat & IBM"
+    contributions: 1333
+    contributors: 62
+    percentage: 81.3
+  - name: "Community"
+    contributions: 299
+    contributors: 99
+    percentage: 18.2
+  - name: "Lunatech"
+    contributions: 5
+    contributors: 2
+    percentage: 0.3
+  - name: "Melloware Inc"
+    contributions: 3
+    contributors: 1
+    percentage: 0.2
+contributors:
+  - login: "gsmet"
+    name: "Guillaume Smet"
+    contributions: 238
+    company: "Red Hat & IBM"
+  - login: "geoand"
+    name: "Georgios Andrianakis"
+    contributions: 189
+    company: "Red Hat & IBM"
+  - login: "holly-cummins"
+    name: "Holly Cummins"
+    contributions: 72
+    company: "Red Hat & IBM"
+  - login: "phillip-kruger"
+    name: "Phillip Krüger"
+    contributions: 71
+    company: "Red Hat & IBM"
+  - login: "yrodiere"
+    name: "Yoann Rodière"
+    contributions: 60
+    company: "Red Hat & IBM"
+  - login: "gastaldi"
+    name: "George Gastaldi"
+    contributions: 58
+    company: "Red Hat & IBM"
+  - login: "aloubyansky"
+    name: "Alexey Loubyansky"
+    contributions: 50
+    company: "Red Hat & IBM"
+  - login: "michalvavrik"
+    name: "Michal Vavřík"
+    contributions: 50
+    company: "Community"
+  - login: "FroMage"
+    name: "Stéphane Épardaud"
+    contributions: 49
+    company: "Red Hat & IBM"
+  - login: "radcortez"
+    name: "Roberto Cortez"
+    contributions: 43
+    company: "Red Hat & IBM"
+  - login: "sberyozkin"
+    name: "Sergey Beryozkin"
+    contributions: 41
+    company: "Red Hat & IBM"
+  - login: "cescoffier"
+    name: "Clement Escoffier"
+    contributions: 38
+    company: "Red Hat & IBM"
+  - login: "mkouba"
+    name: "Martin Kouba"
+    contributions: 34
+    company: "Red Hat & IBM"
+  - login: "Sanne"
+    name: "Sanne Grinovero"
+    contributions: 33
+    company: "Red Hat & IBM"
+  - login: "reaver585"
+    name: "Teymur Babayev"
+    contributions: 33
+    company: "Community"
+  - login: "brunobat"
+    name: "Bruno Baptista"
+    contributions: 32
+    company: "Red Hat & IBM"
+  - login: "zakkak"
+    name: "Foivos Zakkak"
+    contributions: 30
+    company: "Red Hat & IBM"
+  - login: "ozangunalp"
+    name: "Ozan Gunalp"
+    contributions: 25
+    company: "Red Hat & IBM"
+  - login: "lucamolteni"
+    name: "Luca Molteni"
+    contributions: 21
+    company: "Red Hat & IBM"
+  - login: "dmlloyd"
+    name: "David M. Lloyd"
+    contributions: 21
+    company: "Red Hat & IBM"
+  - login: "mariofusco"
+    name: "Mario Fusco"
+    contributions: 20
+    company: "Red Hat & IBM"
+  - login: "metacosm"
+    name: "Chris Laprun"
+    contributions: 19
+    company: "Red Hat & IBM"
+  - login: "kathbigra"
+    name: "Faisal Dilawar"
+    contributions: 19
+    company: "Community"
+  - login: "Ladicek"
+    name: "Ladislav Thon"
+    contributions: 17
+    company: "Red Hat & IBM"
+  - login: "tiwari91"
+    name: "tiwari91"
+    contributions: 16
+    company: "Community"
+  - login: "jponge"
+    name: "Julien Ponge"
+    contributions: 14
+    company: "Red Hat & IBM"
+  - login: "galderz"
+    name: "Galder Zamarreño"
+    contributions: 14
+    company: "Red Hat & IBM"
+  - login: "xstefank"
+    name: "Martin Stefanko"
+    contributions: 13
+    company: "Red Hat & IBM"
+  - login: "jmartisk"
+    name: "Jan Martiska"
+    contributions: 12
+    company: "Red Hat & IBM"
+  - login: "MichalMaler"
+    name: "Mickey Maler"
+    contributions: 12
+    company: "Red Hat & IBM"
+  - login: "manovotn"
+    name: "Matej Novotny"
+    contributions: 10
+    company: "Red Hat & IBM"
+  - login: "MdTanwer"
+    name: "MdTanwer"
+    contributions: 9
+    company: "Community"
+  - login: "mbellade"
+    name: "Marco Belladelli"
+    contributions: 9
+    company: "Red Hat & IBM"
+  - login: "Postremus"
+    name: "Martin Panzer"
+    contributions: 8
+    company: "Community"
+  - login: "MikeEdgar"
+    name: "Michael Edgar"
+    contributions: 8
+    company: "Red Hat & IBM"
+  - login: "mcruzdev"
+    name: "Matheus Cruz"
+    contributions: 7
+    company: "Red Hat & IBM"
+  - login: "marko-bekhta"
+    name: "Marko Bekhta"
+    contributions: 7
+    company: "Community"
+  - login: "osoohynn"
+    name: "권수현"
+    contributions: 7
+    company: "Community"
+  - login: "lloydmeta"
+    name: "Lloyd"
+    contributions: 7
+    company: "Community"
+  - login: "alesj"
+    name: "Aleš Justin"
+    contributions: 7
+    company: "Red Hat & IBM"
+  - login: "aureamunoz"
+    name: "Aurea Muñoz Hernández"
+    contributions: 6
+    company: "Red Hat & IBM"
+  - login: "anavarr"
+    name: "anavarr"
+    contributions: 6
+    company: "Community"
+  - login: "carlesarnal"
+    name: "Carles Arnal"
+    contributions: 5
+    company: "Red Hat & IBM"
+  - login: "krickert"
+    name: "Kristian Rickert"
+    contributions: 5
+    company: "Community"
+  - login: "jedla97"
+    name: "Jakub Jedlička"
+    contributions: 5
+    company: "Community"
+  - login: "andreaTP"
+    name: "Andrea Peruffo"
+    contributions: 5
+    company: "Red Hat & IBM"
+  - login: "Eng-Fouad"
+    name: "Fouad Almalki"
+    contributions: 5
+    company: "Community"
+  - login: "rolfedh"
+    name: "Rolfe Dlugy-Hegwer"
+    contributions: 5
+    company: "Red Hat & IBM"
+  - login: "wjglerum"
+    name: "Willem Jan Glerum"
+    contributions: 4
+    company: "Lunatech"
+  - login: "cdsap"
+    name: "Iñaki Villar"
+    contributions: 4
+    company: "Community"
+  - login: "amaechler"
+    name: "Andreas Maechler"
+    contributions: 4
+    company: "Community"
+  - login: "lu1tr0n"
+    name: "Luis Navarro"
+    contributions: 4
+    company: "Community"
+  - login: "marcosgopen"
+    name: "Marco Sappé Griot"
+    contributions: 4
+    company: "Red Hat & IBM"
+  - login: "matheusandre1"
+    name: "Matheus André"
+    contributions: 3
+    company: "Community"
+  - login: "alerosmile"
+    name: "Roman Huber"
+    contributions: 3
+    company: "Community"
+  - login: "Karm"
+    name: "Karm Michal Babacek"
+    contributions: 3
+    company: "Red Hat & IBM"
+  - login: "rsvoboda"
+    name: "Rostislav Svoboda"
+    contributions: 3
+    company: "Red Hat & IBM"
+  - login: "sheilamjones"
+    name: "sheilamjones"
+    contributions: 3
+    company: "Community"
+  - login: "chiroito"
+    name: "Chihiro Ito"
+    contributions: 3
+    company: "Community"
+  - login: "manusa"
+    name: "Marc Nuri"
+    contributions: 3
+    company: "Red Hat & IBM"
+  - login: "loiclefevre"
+    name: "Loïc LEFEVRE"
+    contributions: 3
+    company: "Community"
+  - login: "maxandersen"
+    name: "Max Rydahl Andersen"
+    contributions: 3
+    company: "Red Hat & IBM"
+  - login: "iam-ssrivastav"
+    name: "iam-ssrivastav"
+    contributions: 3
+    company: "Community"
+  - login: "snazy"
+    name: "Robert Stupp"
+    contributions: 3
+    company: "Community"
+  - login: "cstamas"
+    name: "Tamas Cservenak"
+    contributions: 3
+    company: "Community"
+  - login: "melloware"
+    name: "Melloware"
+    contributions: 3
+    company: "Melloware Inc"
+  - login: "franz1981"
+    name: "Francesco Nigro"
+    contributions: 2
+    company: "Community"
+  - login: "pavou"
+    name: "Pantazis Vouzaxakis"
+    contributions: 2
+    company: "Community"
+  - login: "jamesnetherton"
+    name: "James Netherton"
+    contributions: 2
+    company: "Community"
+  - login: "kyooosukedn"
+    name: "Daniel Purnomo"
+    contributions: 2
+    company: "Community"
+  - login: "stalep"
+    name: "Ståle Pedersen"
+    contributions: 2
+    company: "Red Hat & IBM"
+  - login: "lberrymage"
+    name: "Logan Magee"
+    contributions: 2
+    company: "Community"
+  - login: "matejvasek"
+    name: "Matej Vašek"
+    contributions: 2
+    company: "Red Hat & IBM"
+  - login: "roberttoyonaga"
+    name: "Robert Toyonaga"
+    contributions: 2
+    company: "Red Hat & IBM"
+  - login: "apupier"
+    name: "Aurélien Pupier"
+    contributions: 2
+    company: "Red Hat & IBM"
+  - login: "DavideD"
+    name: "Davide D'Alto"
+    contributions: 2
+    company: "Community"
+  - login: "ppalaga"
+    name: "Peter Palaga"
+    contributions: 2
+    company: "Red Hat & IBM"
+  - login: "jcarranzan"
+    name: "Jose Carranza"
+    contributions: 2
+    company: "Community"
+  - login: "shawkins"
+    name: "Steven Hawkins"
+    contributions: 2
+    company: "Red Hat & IBM"
+  - login: "JiriOndrusek"
+    name: "JiriOndrusek"
+    contributions: 2
+    company: "Community"
+  - login: "cxjava"
+    name: "Char"
+    contributions: 2
+    company: "Community"
+  - login: "alex-martel"
+    name: "Alex Martel"
+    contributions: 2
+    company: "Community"
+  - login: "ash-thakur-rh"
+    name: "Ashish Thakur"
+    contributions: 2
+    company: "Red Hat & IBM"
+  - login: "djarnis73"
+    name: "Jens Teglhus Møller"
+    contributions: 2
+    company: "Community"
+  - login: "devictorqroz"
+    name: "Victor Queiroz "
+    contributions: 1
+    company: "Community"
+  - login: "SAY-5"
+    name: "Sai Asish Y"
+    contributions: 1
+    company: "Community"
+  - login: "nikolassv"
+    name: "Nikolas Schmidt-Voigt"
+    contributions: 1
+    company: "Community"
+  - login: "arend-von-reinersdorff"
+    name: "Arend von Reinersdorff"
+    contributions: 1
+    company: "Community"
+  - login: "gansheer"
+    name: "Gaëlle Fournier"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "dve"
+    name: "Daniel Vergien"
+    contributions: 1
+    company: "Community"
+  - login: "LarsSven"
+    name: "Lars"
+    contributions: 1
+    company: "Community"
+  - login: "mabartos"
+    name: "Martin Bartoš"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "abuinitski"
+    name: "Arseni Buinitski"
+    contributions: 1
+    company: "Community"
+  - login: "hervst"
+    name: "hervst"
+    contributions: 1
+    company: "Community"
+  - login: "jtama"
+    name: "Jérôme Tama"
+    contributions: 1
+    company: "Community"
+  - login: "oehme"
+    name: "Stefan Oehme"
+    contributions: 1
+    company: "Community"
+  - login: "SDAChess"
+    name: "Simon Scatton"
+    contributions: 1
+    company: "Community"
+  - login: "mzellho"
+    name: "Maximilian Zellhofer"
+    contributions: 1
+    company: "Community"
+  - login: "daanhoogenboezem"
+    name: "Daan Hoogenboezem"
+    contributions: 1
+    company: "Lunatech"
+  - login: "laurentgo"
+    name: "Laurent Goujon"
+    contributions: 1
+    company: "Community"
+  - login: "cfitzw"
+    name: "cfitzw"
+    contributions: 1
+    company: "Community"
+  - login: "enoquefcd"
+    name: "Enoque Duarte"
+    contributions: 1
+    company: "Community"
+  - login: "Jamal-Dabari"
+    name: "Jamal Dabari"
+    contributions: 1
+    company: "Community"
+  - login: "dimas-b"
+    name: "Dmitri Bourlatchkov"
+    contributions: 1
+    company: "Community"
+  - login: "luneo7"
+    name: "Lucas Rogerio Caetano Ferreira"
+    contributions: 1
+    company: "Community"
+  - login: "karesti"
+    name: "Katia Aresti"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "ahus1"
+    name: "Alexander Schwartz"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "bst27"
+    name: "Bastian"
+    contributions: 1
+    company: "Community"
+  - login: "Beutlin"
+    name: "Beutlin"
+    contributions: 1
+    company: "Community"
+  - login: "atharv01h"
+    name: "Atharv Hatwar"
+    contributions: 1
+    company: "Community"
+  - login: "sNiXx"
+    name: "sNiXx"
+    contributions: 1
+    company: "Community"
+  - login: "jmesnil"
+    name: "Jeff Mesnil"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "dreab8"
+    name: "Andrea Boriero"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "jrenaat"
+    name: "Jan Schatteman"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "mskacelik"
+    name: "Marek Skácelík"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "Asger-KB"
+    name: "Asger Askov Blekinge"
+    contributions: 1
+    company: "Community"
+  - login: "plevart"
+    name: "Peter Levart"
+    contributions: 1
+    company: "Community"
+  - login: "jerboaa"
+    name: "Severin Gehwolf"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "singhvishalkr"
+    name: "Vishal Kumar Singh"
+    contributions: 1
+    company: "Community"
+  - login: "Delawen"
+    name: "María Arias de Reyna Domínguez"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "tomsontom"
+    name: "Tom Schindl"
+    contributions: 1
+    company: "Community"
+  - login: "jprinet"
+    name: "Jérôme Prinet"
+    contributions: 1
+    company: "Community"
+  - login: "vincent-duluth"
+    name: "vincent-duluth"
+    contributions: 1
+    company: "Community"
+  - login: "angelozerr"
+    name: "Angelo"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "nickrobison"
+    name: "Nick Robison"
+    contributions: 1
+    company: "Community"
+  - login: "pcasaes"
+    name: "Paulo Casaes"
+    contributions: 1
+    company: "Community"
+  - login: "tsegismont"
+    name: "Thomas Segismont"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "suryateja-g13"
+    name: "suryateja-g13"
+    contributions: 1
+    company: "Community"
+  - login: "chrisruffalo"
+    name: "Chris Ruffalo"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "weih-kahoot"
+    name: "Wei Huang"
+    contributions: 1
+    company: "Community"
+  - login: "Zahanturel"
+    name: "Zahanturel"
+    contributions: 1
+    company: "Community"
+  - login: "adutra"
+    name: "Alexandre Dutra"
+    contributions: 1
+    company: "Community"
+  - login: "Foobartender"
+    name: "Foobartender"
+    contributions: 1
+    company: "Community"
+  - login: "pandareen"
+    name: "pandareen"
+    contributions: 1
+    company: "Community"
+  - login: "tomjenkinson"
+    name: "Tom Jenkinson"
+    contributions: 1
+    company: "Community"
+  - login: "c15yi"
+    name: "Christian Navolskyi"
+    contributions: 1
+    company: "Community"
+  - login: "pschaub"
+    name: "Patrick Schaub"
+    contributions: 1
+    company: "Community"
+  - login: "nh2297"
+    name: "Nico Hinrichs"
+    contributions: 1
+    company: "Community"
+  - login: "anuragg-saxenaa"
+    name: "Anurag Saxena"
+    contributions: 1
+    company: "Community"
+  - login: "SimonScholz"
+    name: "Simon Scholz"
+    contributions: 1
+    company: "Community"
+  - login: "dcheng1248"
+    name: "Dorothy Cheng"
+    contributions: 1
+    company: "Community"
+  - login: "vsevel"
+    name: "Vincent Sevel"
+    contributions: 1
+    company: "Community"
+  - login: "denniskniep"
+    name: "Dennis Kniep"
+    contributions: 1
+    company: "Community"
+  - login: "victordalosto"
+    name: "VictorDalosto"
+    contributions: 1
+    company: "Community"
+  - login: "basteez"
+    name: "Tiziano Basile"
+    contributions: 1
+    company: "Community"
+  - login: "Mr-357"
+    name: "Mihajlo Veljković"
+    contributions: 1
+    company: "Community"
+  - login: "loicmathieu"
+    name: "Loïc Mathieu"
+    contributions: 1
+    company: "Community"
+  - login: "fkeichfe"
+    name: "Frank Eichfelder"
+    contributions: 1
+    company: "Community"
+  - login: "nconcetti"
+    name: "Nicola Concetti"
+    contributions: 1
+    company: "Community"
+  - login: "ynojima"
+    name: "Yoshikazu Nojima"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "vjovanov"
+    name: "Vojin Jovanovic"
+    contributions: 1
+    company: "Community"
+  - login: "j-white"
+    name: "Jesse White"
+    contributions: 1
+    company: "Community"
+  - login: "diamondo25"
+    name: "Erwin Oegema"
+    contributions: 1
+    company: "Community"
+  - login: "PreetiYadav1991"
+    name: "PreetiYadav"
+    contributions: 1
+    company: "Community"
+  - login: "Olivier-aka-Raiden"
+    name: "Olivier V."
+    contributions: 1
+    company: "Community"
+  - login: "CodeSimcoe"
+    name: "Clément de Tastes"
+    contributions: 1
+    company: "Community"
+  - login: "cristianonicolai"
+    name: "Cristiano Nicolai"
+    contributions: 1
+    company: "Community"
+  - login: "mauro3005"
+    name: "mauro3005"
+    contributions: 1
+    company: "Community"
+  - login: "DerFrZocker"
+    name: ""
+    contributions: 1
+    company: "Community"
+  - login: "ia3andy"
+    name: "Andy Damevin"
+    contributions: 1
+    company: "Red Hat & IBM"
+  - login: "JeffersonSantos29"
+    name: "Jefferson A. dos Santos"
+    contributions: 1
+    company: "Community"
+  - login: "thomas-mc-work"
+    name: "Thomas McWork"
+    contributions: 1
+    company: "Community"
+  - login: "tomas1885"
+    name: "tomas1885"
+    contributions: 1
+    company: "Community"
+  - login: "anis-campos"
+    name: "Anis Da Silva Campos"
+    contributions: 1
+    company: "Community"

--- a/contributors/application.yaml
+++ b/contributors/application.yaml
@@ -1,0 +1,13 @@
+contributors:
+  org: quarkusio
+  repo: quarkus
+  months: 24
+  output: contributors.yaml
+  opt-in-url: https://raw.githubusercontent.com/quarkusio/quarkus-extension-catalog/main/named-contributing-orgs-opt-in.yml
+
+quarkus:
+  smallrye-graphql-client:
+    github:
+      url: https://api.github.com/graphql
+      header:
+        Authorization: Bearer ${GITHUB_TOKEN}

--- a/contributors/main.java
+++ b/contributors/main.java
@@ -1,0 +1,476 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVAC_OPTIONS -parameters
+//DEPS io.quarkus.platform:quarkus-bom:3.12.1@pom
+//DEPS io.quarkus:quarkus-picocli
+//DEPS io.quarkus:quarkus-smallrye-graphql-client
+//DEPS io.quarkus:quarkus-qute
+//DEPS io.quarkus:quarkus-config-yaml
+//DEPS org.yaml:snakeyaml:2.2
+//FILES templates/=templates/*
+//FILES application.yaml
+
+import io.quarkus.logging.Log;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.smallrye.graphql.client.GraphQLClient;
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+import jakarta.inject.Inject;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.yaml.snakeyaml.Yaml;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@CommandLine.Command(name = "generate-contributors", mixinStandardHelpOptions = true)
+public class main implements Callable<Integer> {
+
+    @ConfigProperty(name = "github.token")
+    String token;
+
+    @ConfigProperty(name = "contributors.org", defaultValue = "quarkusio")
+    String org;
+
+    @ConfigProperty(name = "contributors.repo", defaultValue = "quarkus")
+    String repo;
+
+    @ConfigProperty(name = "contributors.months", defaultValue = "6")
+    int months;
+
+    @ConfigProperty(name = "contributors.output", defaultValue = "contributors.yaml")
+    File out;
+
+    @ConfigProperty(name = "contributors.opt-in-url",
+            defaultValue = "https://raw.githubusercontent.com/quarkusio/quarkus-extension-catalog/main/named-contributing-orgs-opt-in.yml")
+    String optInUrl;
+
+    @GraphQLClient("github")
+    DynamicGraphQLClient githubClient;
+
+    @Inject
+    @Location("contributors.yaml.template")
+    Template yaml;
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final Map<String, String> companyCache = new HashMap<>();
+
+    @Override
+    public Integer call() throws Exception {
+        Log.infof("Fetching contributor data for %s/%s over the last %d months", org, repo, months);
+
+        Set<String> optInNames = fetchOptInList();
+        Log.infof("Loaded %d opted-in organization names", optInNames.size());
+
+        List<RawCommit> commits = fetchCommitHistory();
+        Log.infof("Fetched %d commits (after filtering merges and bots)", commits.size());
+
+        Map<String, ContributorData> byLogin = aggregateByContributor(commits);
+        Log.infof("Found %d unique contributors", byLogin.size());
+
+        List<CompanyData> companies = aggregateByCompany(byLogin.values(), optInNames);
+
+        // To include individual contributors in the output, pass them to the template as "contributors"
+        // (also restore the contributors section in contributors.yaml.template)
+
+        int totalCommits = byLogin.values().stream().mapToInt(ContributorData::contributions).sum();
+
+        for (CompanyData c : companies) {
+            c.percentage = Math.round(c.contributions * 1000.0 / totalCommits) / 10.0;
+        }
+
+        String generated = Instant.now().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        String output = yaml
+                .data("generated", generated)
+                .data("periodMonths", months)
+                .data("totalCommits", totalCommits)
+                .data("companies", companies)
+                .render();
+
+        Files.writeString(out.toPath(), output);
+        Log.infof("Wrote contributor data to %s", out.getPath());
+
+        return 0;
+    }
+
+    // --- GitHub GraphQL: fetch commit history with pagination ---
+
+    List<RawCommit> fetchCommitHistory() throws ExecutionException, InterruptedException {
+        List<RawCommit> result = new ArrayList<>();
+        String since = Instant.now().minus((long) (months * 30.5), ChronoUnit.DAYS)
+                .atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        String cursor = null;
+        boolean hasNextPage = true;
+
+        while (hasNextPage) {
+            String afterClause = cursor != null ? ", after: \"" + cursor + "\"" : "";
+
+            String query = """
+                    query {
+                        repository(owner: "%s", name: "%s") {
+                            defaultBranchRef {
+                                target {
+                                    ... on Commit {
+                                        history(since: "%s"%s, first: 100) {
+                                            pageInfo {
+                                                hasNextPage
+                                                endCursor
+                                            }
+                                            edges {
+                                                node {
+                                                    ... on Commit {
+                                                        parents(first: 1) {
+                                                            totalCount
+                                                        }
+                                                        author {
+                                                            user {
+                                                                login
+                                                                name
+                                                                company
+                                                                url
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    """.formatted(org, repo, since, afterClause);
+
+            Response response = githubClient.executeSync(query);
+
+            if (response.hasError()) {
+                Log.errorf("GraphQL errors: %s", response.getErrors());
+                break;
+            }
+
+            JsonObject history = response.getData()
+                    .getJsonObject("repository")
+                    .getJsonObject("defaultBranchRef")
+                    .getJsonObject("target")
+                    .getJsonObject("history");
+
+            JsonObject pageInfo = history.getJsonObject("pageInfo");
+            hasNextPage = pageInfo.getBoolean("hasNextPage");
+            cursor = pageInfo.getString("endCursor");
+
+            JsonArray edges = history.getJsonArray("edges");
+            for (JsonValue edge : edges) {
+                JsonObject node = edge.asJsonObject().getJsonObject("node");
+
+                int parentCount = node.getJsonObject("parents").getInt("totalCount");
+                if (parentCount > 1) {
+                    continue;
+                }
+
+                JsonObject author = node.getJsonObject("author");
+                if (author.isNull("user")) {
+                    continue;
+                }
+                JsonObject user = author.getJsonObject("user");
+
+                String login = user.getString("login", null);
+                if (login == null || isBot(login)) {
+                    continue;
+                }
+
+                String name = user.getString("name", login);
+                String company = user.getString("company", null);
+                if (company != null && company.isBlank()) {
+                    company = null;
+                }
+                String url = user.getString("url", null);
+
+                result.add(new RawCommit(login, name, company, url));
+            }
+
+            Log.infof("Fetched %d commits so far (hasNextPage=%b)", result.size(), hasNextPage);
+        }
+
+        return result;
+    }
+
+    // --- Company name resolution and normalization (ported from sponsorFinder.js) ---
+
+    String resolveAndNormalizeCompanyName(String company) {
+        if (company == null) {
+            return null;
+        }
+
+        if (company.startsWith("@")) {
+            String[] parts = company.split("[@ ]");
+            // First element is empty (before @), take second
+            String login = parts.length > 1 ? parts[1].replace(",", "").trim() : null;
+            if (login != null && !login.isBlank()) {
+                return normalizeCompanyName(resolveCompanyFromGitHubLogin(login));
+            }
+            return null;
+        }
+
+        return normalizeCompanyName(company);
+    }
+
+    static final Pattern PARENTHESIS_PATTERN = Pattern.compile("(.*?)\\s+\\(.*\\)");
+    static final Pattern AT_PATTERN = Pattern.compile("(.*?)( - )?@.*");
+    static final Pattern BY_PATTERN = Pattern.compile("(.*?)\\s+by\\s+.*");
+
+    static String normalizeCompanyName(String company) {
+        if (company == null || company.isBlank()) {
+            return null;
+        }
+
+        // If multiple companies listed, take the first
+        String name = company.split("(,|\\band\\b|&)")[0];
+
+        name = name
+                .replace(", Inc.", "")
+                .replace(", Inc", "")
+                .replace(" GmbH", "");
+
+        Matcher m = PARENTHESIS_PATTERN.matcher(name);
+        if (m.matches()) {
+            name = m.group(1);
+        }
+
+        m = AT_PATTERN.matcher(name);
+        if (m.matches()) {
+            name = m.group(1);
+        }
+
+        m = BY_PATTERN.matcher(name);
+        if (m.matches()) {
+            name = m.group(1);
+        }
+
+        name = name
+                .replace("https://www.redhat.com/", "Red Hat")
+                .replace("http://www.redhat.com/", "Red Hat");
+
+        name = name.replace(",", "").trim();
+
+        name = name.replace("International Business Machines", "IBM");
+        name = name.replace("JBoss", "Red Hat");
+
+        if (name.startsWith("Red Hat")) {
+            name = "Red Hat & IBM";
+        } else if (name.startsWith("IBM")) {
+            name = "Red Hat & IBM";
+        }
+
+        return name;
+    }
+
+    String resolveCompanyFromGitHubLogin(String login) {
+        if (companyCache.containsKey(login)) {
+            return companyCache.get(login);
+        }
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.github.com/users/" + login))
+                    .header("Authorization", "Bearer " + token)
+                    .header("Accept", "application/vnd.github+json")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                // Simple JSON parsing — extract "name" field
+                String body = response.body();
+                String name = extractJsonStringField(body, "name");
+                if (name == null || name.isBlank()) {
+                    name = login;
+                }
+                companyCache.put(login, name);
+                return name;
+            }
+        } catch (Exception e) {
+            Log.warnf("Failed to resolve GitHub login %s: %s", login, e.getMessage());
+        }
+
+        companyCache.put(login, login);
+        return login;
+    }
+
+    static String extractJsonStringField(String json, String field) {
+        // Minimal JSON field extraction to avoid adding a JSON parsing dependency for REST responses
+        Pattern p = Pattern.compile("\"" + field + "\"\\s*:\\s*\"([^\"]*?)\"");
+        Matcher m = p.matcher(json);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    // --- Bot filtering ---
+
+    static boolean isBot(String login) {
+        return login.contains("[bot]")
+                || "actions-user".equals(login)
+                || "quarkiversebot".equals(login);
+    }
+
+    // --- Aggregation ---
+
+    Map<String, ContributorData> aggregateByContributor(List<RawCommit> commits) {
+        Map<String, ContributorData> byLogin = new HashMap<>();
+
+        for (RawCommit commit : commits) {
+            String resolvedCompany = resolveAndNormalizeCompanyName(commit.company);
+
+            ContributorData existing = byLogin.get(commit.login);
+            if (existing != null) {
+                existing.contributions++;
+            } else {
+                byLogin.put(commit.login, new ContributorData(
+                        commit.login,
+                        commit.name != null ? commit.name : commit.login,
+                        1,
+                        resolvedCompany != null ? resolvedCompany : "Community"
+                ));
+            }
+        }
+
+        return byLogin;
+    }
+
+    List<CompanyData> aggregateByCompany(java.util.Collection<ContributorData> contributors, Set<String> optInNames) {
+        Map<String, CompanyData> byCompany = new HashMap<>();
+
+        for (ContributorData c : contributors) {
+            String companyName = isOptedIn(c.company, optInNames) ? c.company : "Community";
+
+            CompanyData existing = byCompany.get(companyName);
+            if (existing != null) {
+                existing.contributions += c.contributions;
+                existing.contributorCount++;
+            } else {
+                byCompany.put(companyName, new CompanyData(companyName, c.contributions, 1, 0));
+            }
+        }
+
+        List<CompanyData> result = new ArrayList<>(byCompany.values());
+        result.sort(Comparator.comparingInt(CompanyData::contributions).reversed());
+        return result;
+    }
+
+    // --- Opt-in list ---
+
+    @SuppressWarnings("unchecked")
+    Set<String> fetchOptInList() {
+        Set<String> names = new HashSet<>();
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(optInUrl))
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                Yaml yamlParser = new Yaml();
+                Map<String, Object> data = yamlParser.load(response.body());
+
+                if (data.containsKey("named-sponsors")) {
+                    Object sponsors = data.get("named-sponsors");
+                    if (sponsors instanceof List) {
+                        ((List<String>) sponsors).forEach(s -> names.add(normalizeCompanyName(s)));
+                    }
+                }
+
+                if (data.containsKey("named-contributing-orgs")) {
+                    Object orgs = data.get("named-contributing-orgs");
+                    if (orgs instanceof List) {
+                        ((List<String>) orgs).forEach(s -> names.add(normalizeCompanyName(s)));
+                    }
+                }
+            } else {
+                Log.warnf("Failed to fetch opt-in list (HTTP %d), all companies will appear as Community", response.statusCode());
+            }
+        } catch (Exception e) {
+            Log.warnf("Failed to fetch opt-in list: %s. All companies will appear as Community", e.getMessage());
+        }
+
+        // Community is always allowed
+        names.add("Community");
+
+        return names;
+    }
+
+    static boolean isOptedIn(String companyName, Set<String> optInNames) {
+        return companyName != null && optInNames.contains(companyName);
+    }
+
+    // --- Data types ---
+
+    record RawCommit(String login, String name, String company, String url) {
+    }
+
+    static final class ContributorData {
+        final String login;
+        final String name;
+        int contributions;
+        String company;
+
+        ContributorData(String login, String name, int contributions, String company) {
+            this.login = login;
+            this.name = name;
+            this.contributions = contributions;
+            this.company = company;
+        }
+
+        public String login() { return login; }
+        public String name() { return name; }
+        public int contributions() { return contributions; }
+        public String company() { return company; }
+    }
+
+    static final class CompanyData {
+        final String name;
+        int contributions;
+        int contributorCount;
+        double percentage;
+
+        CompanyData(String name, int contributions, int contributorCount, double percentage) {
+            this.name = name;
+            this.contributions = contributions;
+            this.contributorCount = contributorCount;
+            this.percentage = percentage;
+        }
+
+        public String name() { return name; }
+        public int contributions() { return contributions; }
+        public int contributorCount() { return contributorCount; }
+        public double percentage() { return percentage; }
+    }
+}

--- a/contributors/templates/contributors.yaml.template
+++ b/contributors/templates/contributors.yaml.template
@@ -1,0 +1,11 @@
+---
+generated: "{generated}"
+period-months: {periodMonths}
+total-commits: {totalCommits}
+companies:
+  {#for company in companies}
+  - name: "{company.name}"
+    contributions: {company.contributions}
+    contributors: {company.contributorCount}
+    percentage: {company.percentage}
+  {/for}


### PR DESCRIPTION
This reproduces the logic, but not the code, from what we do over on the extensions site. I wondered about reusing the code but it's so coupled to gatsby, I decided there wasn't enough left after stripping that out. And it's javascript.

I thought we had a pressing need for it, and then that need slightly vanished, but raising a PR in case it's useful. This change generates data we can then use in pages to show commit counts from opted-in companies. This could be used, for example, to enrich company cards on the 'benefactors' page with a graphic about their contribution levels, or to sort cards according to contribution levels. 

_Implementation:_ 
JBang script queries GitHub GraphQL API for commit history on quarkusio/quarkus, normalizes company names, aggregates by company, applies opt-in filtering from quarkus-extension-catalog, and writes YAML to _data/contributors.yaml. Weekly CI job mirrors the working-groups sync pattern.

cc @Sanne 