### PR TITLE
CI: use action-build-reporter for test summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,27 +209,18 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1
 
-      - name: Test report
+      - name: Prepare build reports
         if: always()
         run: |
-          {
-            echo "### Test Results"
-            echo ""
-            echo "| Suite | Tests | Passed | Failed | Skipped | Time |"
-            echo "|-------|------:|-------:|-------:|--------:|-----:|"
-            for f in target/surefire-reports/TEST-*.xml; do
-              [ -f "$f" ] || continue
-              suite=$(sed -n 's/.*name="\([^"]*\).*/\1/p' "$f" | head -1)
-              tests=$(sed -n 's/.*tests="\([^"]*\).*/\1/p' "$f" | head -1)
-              fail=$(sed -n 's/.*failures="\([^"]*\).*/\1/p' "$f" | head -1)
-              err=$(sed -n 's/.*errors="\([^"]*\).*/\1/p' "$f" | head -1)
-              skip=$(sed -n 's/.*skipped="\([^"]*\).*/\1/p' "$f" | head -1)
-              time=$(sed -n 's/.*time="\([^"]*\).*/\1/p' "$f" | head -1)
-              pass=$((tests - ${fail:-0} - ${err:-0} - ${skip:-0}))
-              icon=$( [ "${fail:-0}" -gt 0 ] || [ "${err:-0}" -gt 0 ] && echo ":x:" || echo ":white_check_mark:" )
-              echo "| ${icon} ${suite##*.} | $tests | $pass | $((${fail:-0} + ${err:-0})) | ${skip:-0} | ${time}s |"
-            done
-          } >> "$GITHUB_STEP_SUMMARY"
+          mkdir -p build-reports-artifacts/build-reports-build
+          cp -r target build-reports-artifacts/build-reports-build/
+
+      - name: Build report
+        if: always()
+        uses: quarkusio/action-build-reporter@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          build-reports-artifacts-path: build-reports-artifacts
 
       - name: Store PR id
         run: echo ${{ github.event.number }} > ./${{ steps.detect.outputs.site_dir }}/pr-id.txt


### PR DESCRIPTION
As discussed here: https://github.com/quarkusio/quarkusio.github.io/pull/2723#discussion_r3435652643

Replace the hand-rolled shell script that parsed surefire XML with quarkusio/action-build-reporter, consistent with other Quarkus repos.

To make this work, I had to do a bit of output rearrangement. That was maybe the step I missed before, which made the results so disappointing. 
