### PR TITLE
Make CI job to scope link checker more selective, and also quicker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,8 +147,10 @@ jobs:
             exit 0
           fi
 
-          # Compare the built site to what is currently deployed on gh-pages
-          git fetch origin gh-pages 2>/dev/null || {
+          # Compare the built site to what is currently deployed on gh-pages.
+          # Use --filter=blob:none so only tree objects are fetched initially,
+          # then sparse-checkout to materialise just *.html files for rsync.
+          git fetch origin gh-pages --filter=blob:none 2>/dev/null || {
             echo "mode=full" >> $GITHUB_OUTPUT
             echo "Could not fetch gh-pages, running full link check"
             exit 0
@@ -160,6 +162,8 @@ jobs:
             exit 0
           }
 
+          git -C /tmp/gh-pages sparse-checkout set --no-cone '*.html'
+
           RSYNC_OUT=$(rsync -rcn --out-format='%n' \
             --include='*/' --include='*.html' --exclude='*' \
             ${{ steps.detect.outputs.site_dir }}/ /tmp/gh-pages/ 2>/dev/null) || {
@@ -169,7 +173,10 @@ jobs:
             exit 0
           }
 
-          CHANGED=$(echo "$RSYNC_OUT" | grep '\.html$' || true)
+          # Filter out version/main/ guides — these are synced daily from the
+          # quarkus repo and will almost always differ from gh-pages, but are
+          # not part of the PR's changes.
+          CHANGED=$(echo "$RSYNC_OUT" | grep '\.html$' | grep -v '^version/main/' || true)
 
           git worktree remove /tmp/gh-pages 2>/dev/null || true
 
@@ -204,7 +211,7 @@ jobs:
           fi
           mvn -B test -Pe2e -Dtest.url=http://localhost:8090 \
             -Dtest.crawl.check-external=false \
-            -Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main/guides/doc-reference \
+            -Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main \
             $CHANGED_PATHS_ARG
         env:
           PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1


### PR DESCRIPTION
Resolves #2727 

The list of what's changed is picking up a lot of noise from the nightly sync of the `main` guides. I want to diff on the built site, not try to interpolate from the PR diffs, since some small changes can affect loads of files. 

On the other hand, I also don't want to link check content which is in another repo and obviously unrelated to this PR. 

As a side issue, the diff is taking almost three minutes, which is annoyingly long. Doing a sparse-r checkout should hopefully help (the rsync already filters to only diff html files). 