### PR TITLE
Update Java versions used in CI to 25 (from 21)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Cache Ruby gems
@@ -91,7 +91,7 @@ jobs:
         if: steps.detect.outputs.roq == 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
         if: steps.detect.outputs.roq == 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
 

--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -1,7 +1,7 @@
 name: Sync contributors
 
 env:
-  JVM_VERSION: '21'
+  JVM_VERSION: '25'
 
 on:
   schedule:

--- a/.github/workflows/sync-working-groups.yml
+++ b/.github/workflows/sync-working-groups.yml
@@ -1,7 +1,7 @@
 name: Sync working groups
 
 env:
-  JVM_VERSION: '21'
+  JVM_VERSION: '25'
 
 on:
   schedule:

--- a/src/test/java/io/quarkusio/RssFeedTest.java
+++ b/src/test/java/io/quarkusio/RssFeedTest.java
@@ -57,6 +57,8 @@ public class RssFeedTest extends BrowserTest {
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setAttribute("jdk.xml.maxGeneralEntitySizeLimit", 0);
+            factory.setAttribute("jdk.xml.totalEntitySizeLimit", 0);
             factory.newDocumentBuilder().parse(new InputSource(new StringReader(body)));
         } catch (Exception e) {
             fail("Feed XML is not valid: " + e.getMessage());
@@ -75,6 +77,8 @@ public class RssFeedTest extends BrowserTest {
         String body = response.body();
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setAttribute("jdk.xml.maxGeneralEntitySizeLimit", 0);
+        factory.setAttribute("jdk.xml.totalEntitySizeLimit", 0);
         Document doc = factory.newDocumentBuilder().parse(new InputSource(new StringReader(body)));
 
         int itemCount = doc.getElementsByTagName("item").getLength();


### PR DESCRIPTION
As requested by @gsmet. There's no reason for our CI to be using 21 rather than 25.

[Edit: No reason, except for the fact that tests fail. :| Turns out the test was using a deprecated property in the xml factory, so I've fixed that.]