### PR TITLE
Add checks for raw html and unrendered markdown on specific pages

### DIFF
--- a/src/test/java/io/quarkusio/AuthorPageTest.java
+++ b/src/test/java/io/quarkusio/AuthorPageTest.java
@@ -2,6 +2,8 @@ package io.quarkusio;
 
 import org.junit.jupiter.api.Test;
 
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainRawHtml;
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class AuthorPageTest extends BrowserTest {
@@ -37,5 +39,17 @@ public class AuthorPageTest extends BrowserTest {
         int postCount = page.locator(".blog-list-item").count();
         assertTrue(postCount >= 1,
                 "Expected at least 1 post on author page but found " + postCount);
+    }
+
+    @Test
+    void authorIndexDoesNotContainUnrenderedMarkup() {
+        page.navigate(baseUrl + "/author/");
+        assertDoesNotContainUnrenderedMarkup(page, "Author index");
+    }
+
+    @Test
+    void authorIndexDoesNotContainRawHtmlTags() {
+        page.navigate(baseUrl + "/author/");
+        assertDoesNotContainRawHtml(page, "Author index");
     }
 }

--- a/src/test/java/io/quarkusio/BlogPageTest.java
+++ b/src/test/java/io/quarkusio/BlogPageTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainRawHtml;
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainUnrenderedMarkup;
 import static io.quarkusio.UnrenderedMarkupDetector.findUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -135,6 +137,18 @@ public class BlogPageTest extends BrowserTest {
                 "Post page should show the same number of authors as the blog index");
         assertTrue(postPageAuthorCount > 1,
                 "Expected multiple authors on post page but found " + postPageAuthorCount);
+    }
+
+    @Test
+    void blogIndexDoesNotContainUnrenderedMarkup() {
+        page.navigate(baseUrl + BLOG_PATH);
+        assertDoesNotContainUnrenderedMarkup(page, "Blog index");
+    }
+
+    @Test
+    void blogIndexDoesNotContainRawHtmlTags() {
+        page.navigate(baseUrl + BLOG_PATH);
+        assertDoesNotContainRawHtml(page, "Blog index");
     }
 
     @Test

--- a/src/test/java/io/quarkusio/GuidesPageTest.java
+++ b/src/test/java/io/quarkusio/GuidesPageTest.java
@@ -2,6 +2,7 @@ package io.quarkusio;
 
 import org.junit.jupiter.api.Test;
 
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GuidesPageTest extends BrowserTest {
@@ -50,5 +51,11 @@ public class GuidesPageTest extends BrowserTest {
         int categoryCount = page.locator(".pulldown.category, [class*='category']").count();
         assertTrue(categoryCount > 0,
                 "Expected a category filter on the guides page");
+    }
+
+    @Test
+    void guidesPageDoesNotContainUnrenderedMarkup() {
+        page.navigate(baseUrl + "/guides/");
+        assertDoesNotContainUnrenderedMarkup(page, "Guides page");
     }
 }

--- a/src/test/java/io/quarkusio/SmokePageTest.java
+++ b/src/test/java/io/quarkusio/SmokePageTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainRawHtml;
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SmokePageTest extends BrowserTest {
@@ -53,6 +55,18 @@ public class SmokePageTest extends BrowserTest {
                 "Page title should not contain 'error' for " + path + ", got: " + title);
         assertFalse(lowerTitle.contains("exception"),
                 "Page title should not contain 'Exception' for " + path + ", got: " + title);
+    }
+
+    @Test
+    void homepageDoesNotContainUnrenderedMarkup() {
+        page.navigate(baseUrl + "/");
+        assertDoesNotContainUnrenderedMarkup(page, "Homepage");
+    }
+
+    @Test
+    void homepageDoesNotContainRawHtmlTags() {
+        page.navigate(baseUrl + "/");
+        assertDoesNotContainRawHtml(page, "Homepage");
     }
 
     @Test

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
@@ -1,7 +1,14 @@
 package io.quarkusio;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class UnrenderedMarkupDetector {
@@ -32,8 +39,56 @@ public class UnrenderedMarkupDetector {
             // Markdown image: ![alt](url)
             new MarkupPattern(Pattern.compile("!\\[[^]]*]\\("), "Markdown image (![alt](url))"),
             // Markdown code fence
-            new MarkupPattern(Pattern.compile("(?m)^```[a-z]*\\s*$"), "Markdown code fence (```)")
+            new MarkupPattern(Pattern.compile("(?m)^```[a-z]*\\s*$"), "Markdown code fence (```)"),
+
+            // Template block tags: {% if ... %} or {%- ... -%}
+            new MarkupPattern(Pattern.compile("\\{%-?\\s+\\w"), "Template tag ({% ... %})"),
+            // Template output tags: {{ variable }}
+            new MarkupPattern(Pattern.compile("\\{\\{\\s*\\w"), "Template output ({{ ... }})"),
+            // Template error messages
+            new MarkupPattern(Pattern.compile("(?i)(liquid|template) (error|syntax error|warning)"), "Template error message"),
+            // YAML front matter: --- at very start of visible text
+            new MarkupPattern(Pattern.compile("\\A---\\s*\\n"), "YAML front matter (---)")
     );
+
+    private static final Pattern HTML_TAG = Pattern.compile("</?[a-zA-Z][a-zA-Z0-9]*[\\s>/]");
+
+    public static String findRawHtmlTag(String text) {
+        Matcher matcher = HTML_TAG.matcher(text);
+        if (matcher.find()) {
+            int start = Math.max(0, matcher.start() - 20);
+            int end = Math.min(text.length(), matcher.end() + 20);
+            String context = text.substring(start, end).replace("\n", "\\n");
+            return "Raw HTML tag \"" + matcher.group() + "\" in context: \"..." + context + "...\"";
+        }
+        return null;
+    }
+
+    public static void assertDoesNotContainRawHtml(String text, String pageDescription) {
+        assertNull(findRawHtmlTag(text), pageDescription + " contains raw HTML");
+    }
+
+    public static void assertDoesNotContainRawHtml(Locator locator, String pageDescription) {
+        assertDoesNotContainRawHtml(locator.innerText(), pageDescription);
+    }
+
+    public static void assertDoesNotContainRawHtml(Page page, String pageDescription) {
+        assertDoesNotContainRawHtml(page.locator("body"), pageDescription);
+    }
+
+    public static void assertDoesNotContainUnrenderedMarkup(String text, String pageDescription) {
+        List<String> findings = findUnrenderedMarkup(text);
+        assertTrue(findings.isEmpty(),
+                pageDescription + " contains unrendered markup: " + String.join("; ", findings));
+    }
+
+    public static void assertDoesNotContainUnrenderedMarkup(Locator locator, String pageDescription) {
+        assertDoesNotContainUnrenderedMarkup(locator.innerText(), pageDescription);
+    }
+
+    public static void assertDoesNotContainUnrenderedMarkup(Page page, String pageDescription) {
+        assertDoesNotContainUnrenderedMarkup(page.locator("body"), pageDescription);
+    }
 
     public static List<String> findUnrenderedMarkup(String text) {
         List<String> findings = new ArrayList<>();

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
@@ -67,6 +67,36 @@ class UnrenderedMarkupDetectorTest {
     }
 
     @Test
+    void detectsTemplateTags() {
+        assertDetects("before {% if page.layout %} after", "Template tag");
+        assertDetects("before {%- for item in list -%} after", "Template tag");
+    }
+
+    @Test
+    void detectsTemplateOutput() {
+        assertDetects("Hello {{ user.name }} welcome", "Template output");
+    }
+
+    @Test
+    void detectsTemplateErrors() {
+        assertDetects("Liquid error: undefined variable", "Template error");
+        assertDetects("template syntax error in tag", "Template error");
+    }
+
+    @Test
+    void detectsYamlFrontMatter() {
+        assertDetects("---\ntitle: My Page\n---\nContent", "YAML front matter");
+    }
+
+    @Test
+    void doesNotFlagYamlFrontMatterMidText() {
+        List<String> findings = findUnrenderedMarkup(
+                "Some text before\n---\nsome text after");
+        assertTrue(findings.stream().noneMatch(f -> f.contains("YAML front matter")),
+                "Should not flag --- in the middle of text but got: " + findings);
+    }
+
+    @Test
     void doesNotFlagCleanHtml() {
         List<String> findings = findUnrenderedMarkup(
                 "This is a normal blog post with headings and paragraphs. "

--- a/src/test/java/io/quarkusio/WorkingGroupsPageTest.java
+++ b/src/test/java/io/quarkusio/WorkingGroupsPageTest.java
@@ -2,6 +2,8 @@ package io.quarkusio;
 
 import org.junit.jupiter.api.Test;
 
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainRawHtml;
+import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WorkingGroupsPageTest extends BrowserTest {
@@ -12,5 +14,17 @@ public class WorkingGroupsPageTest extends BrowserTest {
         int count = page.locator(".card .card-title").count();
         assertTrue(count >= 5,
                 "Expected at least 5 working groups but found " + count);
+    }
+
+    @Test
+    void workingGroupsPageDoesNotContainUnrenderedMarkup() {
+        page.navigate(baseUrl + "/working-groups/");
+        assertDoesNotContainUnrenderedMarkup(page, "Working groups page");
+    }
+
+    @Test
+    void workingGroupsPageDoesNotContainRawHtmlTags() {
+        page.navigate(baseUrl + "/working-groups/");
+        assertDoesNotContainRawHtml(page, "Working groups page");
     }
 }


### PR DESCRIPTION
I don't want to test the whole site because that's (a) slow and (b) makes life a nightmare on pages about raw html and raw markdown, but we don't want raw html in important places like the frontpage.