### PR TITLE
Extend guides tests to check for main as well as the default version

### DIFF
--- a/src/test/java/io/quarkusio/GuidesPageTest.java
+++ b/src/test/java/io/quarkusio/GuidesPageTest.java
@@ -1,11 +1,74 @@
 package io.quarkusio;
 
+import com.microsoft.playwright.Response;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GuidesPageTest extends BrowserTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/",
+            "/version/main/guides/"
+    })
+    void guidesPageRendersWithSubstantialContent(String path) {
+        page.navigate(baseUrl + path);
+        int guideCount = page.locator(".docslist h4 a[href*='/guides/']").count();
+        assertTrue(guideCount >= 50,
+                path + ": Expected at least 50 guides but found " + guideCount);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/",
+            "/version/main/guides/"
+    })
+    void guidesPageHasSearchInput(String path) {
+        page.navigate(baseUrl + path);
+        int searchCount = page.locator("input[type='search'], input[placeholder*='ilter'], input[placeholder*='earch'], .search input").count();
+        assertTrue(searchCount > 0,
+                path + ": Expected a search/filter input on the guides page");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/",
+            "/version/main/guides/"
+    })
+    void guidesPageHasCategorySections(String path) {
+        page.navigate(baseUrl + path);
+        int sectionCount = page.locator(".doclist-header").count();
+        assertTrue(sectionCount >= 3,
+                path + ": Expected at least 3 guide category sections but found " + sectionCount);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/",
+            "/version/main/guides/"
+    })
+    void guidesPageHasVersionSelector(String path) {
+        page.navigate(baseUrl + path);
+        int versionCount = page.locator(".pulldown.version, select:has(option), [class*='version']").count();
+        assertTrue(versionCount > 0,
+                path + ": Expected a version selector on the guides page");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/",
+            "/version/main/guides/"
+    })
+    void guidesPageHasCategoryFilter(String path) {
+        page.navigate(baseUrl + path);
+        int categoryCount = page.locator(".pulldown.category, [class*='category']").count();
+        assertTrue(categoryCount > 0,
+                path + ": Expected a category filter on the guides page");
+    }
 
     @Test
     void guidesPageTitleIsExact() {
@@ -14,48 +77,53 @@ public class GuidesPageTest extends BrowserTest {
     }
 
     @Test
-    void guidesPageRendersWithSubstantialContent() {
-        page.navigate(baseUrl + "/guides/");
-        int guideCount = page.locator(".docslist h4 a[href*='/guides/']").count();
-        assertTrue(guideCount >= 50,
-                "Expected at least 50 guides but found " + guideCount);
-    }
-
-    @Test
-    void guidesPageHasSearchInput() {
-        page.navigate(baseUrl + "/guides/");
-        int searchCount = page.locator("input[type='search'], input[placeholder*='ilter'], input[placeholder*='earch'], .search input").count();
-        assertTrue(searchCount > 0,
-                "Expected a search/filter input on the guides page");
-    }
-
-    @Test
-    void guidesPageHasCategorySections() {
-        page.navigate(baseUrl + "/guides/");
-        int sectionCount = page.locator(".doclist-header").count();
-        assertTrue(sectionCount >= 3,
-                "Expected at least 3 guide category sections but found " + sectionCount);
-    }
-
-    @Test
-    void guidesPageHasVersionSelector() {
-        page.navigate(baseUrl + "/guides/");
-        int versionCount = page.locator(".pulldown.version, select:has(option), [class*='version']").count();
-        assertTrue(versionCount > 0,
-                "Expected a version selector on the guides page");
-    }
-
-    @Test
-    void guidesPageHasCategoryFilter() {
-        page.navigate(baseUrl + "/guides/");
-        int categoryCount = page.locator(".pulldown.category, [class*='category']").count();
-        assertTrue(categoryCount > 0,
-                "Expected a category filter on the guides page");
-    }
-
-    @Test
     void guidesPageDoesNotContainUnrenderedMarkup() {
         page.navigate(baseUrl + "/guides/");
         assertDoesNotContainUnrenderedMarkup(page, "Guides page");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/getting-started",
+            "/guides/rest",
+            "/guides/hibernate-orm",
+            "/guides/cdi",
+            "/guides/getting-started-testing",
+            "/guides/security-overview",
+            "/version/main/guides/getting-started",
+            "/version/main/guides/rest"
+    })
+    void specificGuideReturns200(String path) {
+        Response response = page.navigate(baseUrl + path);
+        assertNotNull(response, "No response for " + path);
+        assertEquals(200, response.status(),
+                "Expected 200 for " + path + " but got " + response.status());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/getting-started",
+            "/guides/rest",
+            "/guides/hibernate-orm",
+            "/version/main/guides/getting-started"
+    })
+    void specificGuideHasContent(String path) {
+        page.navigate(baseUrl + path);
+        String title = page.title();
+        assertFalse(title == null || title.isBlank(),
+                path + ": Guide page title should not be blank");
+        assertTrue(title.toLowerCase().contains("quarkus"),
+                path + ": Guide page title should contain 'Quarkus', got: " + title);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/guides/getting-started",
+            "/guides/rest",
+            "/version/main/guides/getting-started"
+    })
+    void specificGuideDoesNotContainUnrenderedMarkup(String path) {
+        page.navigate(baseUrl + path);
+        assertDoesNotContainUnrenderedMarkup(page, path);
     }
 }

--- a/src/test/java/io/quarkusio/SmokePageTest.java
+++ b/src/test/java/io/quarkusio/SmokePageTest.java
@@ -19,7 +19,6 @@ public class SmokePageTest extends BrowserTest {
             "/guides/",
             "/get-started/",
             "/support/",
-            "/extensions/",
             "/newsletter/",
             "/community/",
             "/events/",


### PR DESCRIPTION
I realised the guides tests check for the latest stable, but not main or some older versions. That would be an easy thing to regress (and we can't even check it in the previews). Sadly, we also can't check anything but main and latest in CI, because the `_only_latest_guides_config.yml` is being used. 

I had a lovely version of this which avoided hardcoding version strings and used the data in #2750, but it fails in CI because the pages aren't built. So I've scaled down my ambitions and only check main. 