### PR TITLE
Drop search attribute which does not exist in config and is not used

### DIFF
--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -1,12 +1,7 @@
 {% assign docversion = include.docversion %}
 {% assign data_source = include.source %}
 
-<div id="guides-app"
-     data-quarkus-version="{{ docversion }}"
-     data-language="{{ site.language }}"
-     data-initial-timeout="{{ site.search.initial-timeout }}"
-     data-more-timeout="{{ site.search.more-timeout }}"
-     data-min-chars="{{ site.search.min-chars }}">
+<div id="guides-app">
   <qs-form server="{{ site.search.host }}"
            quarkus-version="{{ docversion }}"
            language="{{ site.language }}"

--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -2,7 +2,6 @@
 {% assign data_source = include.source %}
 
 <div id="guides-app"
-     data-search-api-server="{{ site.search.url }}"
      data-quarkus-version="{{ docversion }}"
      data-language="{{ site.language }}"
      data-initial-timeout="{{ site.search.initial-timeout }}"


### PR DESCRIPTION
The Roq conversion tripped over this – I can hack round it, but we may as well tidy up. 

Part of our search page references `search.url`, a property that is not defined in `_config.yml`. Claude says `search.url` was the original config key, then later `search.host` replaced it. But the `data-search-api-server attribute` on the div was never updated to use `host` instead of `url`. The `data-search-api-server` is likely unused since the web component reads from its own server attribute.