### PR TITLE
Make version table in security.adoc use data from _data

### DIFF
--- a/_includes/security-supported-versions.html
+++ b/_includes/security-supported-versions.html
@@ -1,0 +1,47 @@
+{%- assign today = 'now' | date: '%Y-%m-%d' -%}
+{%- assign latest_version = nil -%}
+{%- for release in site.data.releases.releases -%}
+  {%- unless release.upcoming -%}
+    {%- unless latest_version -%}
+      {%- assign latest_version = release.version -%}
+      {%- assign latest_major = release.version | split: '.' | first -%}
+    {%- endunless -%}
+  {%- endunless -%}
+{%- endfor -%}
+<table class="tableblock frame-all grid-all fit-content">
+<colgroup>
+<col>
+<col>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Version</th>
+<th class="tableblock halign-center valign-top">Supported</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Latest {{ latest_major }}.x</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">✅</p></td>
+</tr>
+{%- for release in site.data.releases.releases -%}
+{%- if release.lts -%}
+{%- assign eol_str = release.eol_date | date: '%Y-%m-%d' -%}
+{%- if eol_str > today and release.version != latest_version %}
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">{{ release.version }} LTS</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">✅</p></td>
+</tr>
+{%- endif -%}
+{%- endif -%}
+{%- endfor %}
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Older {{ latest_major }}.x</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">❌</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt; {{ latest_major }}.0</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">❌</p></td>
+</tr>
+</tbody>
+</table>

--- a/_layouts/security.html
+++ b/_layouts/security.html
@@ -1,0 +1,18 @@
+---
+layout: base
+---
+
+{% include title-band.html %}
+
+<div class="full-width-bg component">
+  <div class="grid-wrapper">
+    <div class="width-12-12 width-12-12-m">
+
+{% assign parts = content | split: '<div id="security-table-placeholder"></div>' %}
+{{ parts[0] }}
+{% include security-supported-versions.html %}
+{{ parts[1] }}
+
+    </div>
+  </div>
+</div>

--- a/security.adoc
+++ b/security.adoc
@@ -1,12 +1,12 @@
 ---
-layout: base-fullwidthcontent
+layout: security
 title: Security
 subtitle: The Quarkus team and community take all security bugs very seriously. You can find our guidelines here regarding our policy and security disclosure.
 permalink: /security/
 ---
 
 ////
-    Content copied from https://github.com/quarkusio/quarkus/blob/master/SECURITY.md 
+    Content copied from https://github.com/quarkusio/quarkus/blob/master/SECURITY.md
     Edit there too
 ////
 
@@ -43,27 +43,12 @@ Due to the sensitive nature of security bugs, the disclosure process is more con
 
 The community will fix security bugs for the latest major.minor version published at https://quarkus.io/get-started/.
 
-[%autowidth,cols="1,^1"]
-|===
-|Version |Supported 
-
-|Latest 3.x
-|✅
-
-|3.33 LTS
-|✅
-
-|3.27 LTS
-|✅
-
-|Older 3.x
-|❌
-
-|< 3.0
-|❌
-|===
+++++
+<div id="security-table-placeholder"></div>
+++++
 
 We may fix the vulnerability to older versions depending on the severity of the issue and the age of the release, but we are only committing to the versions mentioned above as supported.
+Running an end-of-life version? See our link:/eol/[End-of-Life guidance].
 
 == Handling security issues
 

--- a/src/test/java/io/quarkusio/SecurityPageTest.java
+++ b/src/test/java/io/quarkusio/SecurityPageTest.java
@@ -1,0 +1,63 @@
+package io.quarkusio;
+
+import com.microsoft.playwright.Locator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SecurityPageTest extends BrowserTest {
+
+    @Test
+    void supportedVersionsTableIsPresent() {
+        page.navigate(baseUrl + "/security/");
+        Locator table = page.locator("table.tableblock");
+        assertTrue(table.isVisible(), "Supported versions table should be visible");
+
+        Locator headers = table.locator("thead th");
+        assertEquals(2, headers.count(), "Table should have 2 columns");
+        assertTrue(headers.nth(0).textContent().contains("Version"), "First column should be Version");
+        assertTrue(headers.nth(1).textContent().contains("Supported"), "Second column should be Supported");
+    }
+
+    @Test
+    void supportedVersionsTableShowsLatestRelease() {
+        page.navigate(baseUrl + "/security/");
+        Locator rows = page.locator("table.tableblock tbody tr");
+        assertTrue(rows.count() >= 4,
+                "Expected at least 4 rows (latest, LTS, older, pre-3.0) but found " + rows.count());
+
+        String firstRowText = rows.first().textContent();
+        assertTrue(firstRowText.contains("Latest") && firstRowText.contains(".x"),
+                "First row should show 'Latest X.x' but was: " + firstRowText);
+        assertTrue(firstRowText.contains("✅"), "Latest release should be marked as supported");
+    }
+
+    @Test
+    void supportedVersionsTableShowsLtsVersions() {
+        page.navigate(baseUrl + "/security/");
+        Locator cells = page.locator("table.tableblock tbody td");
+        boolean foundLts = false;
+        for (int i = 0; i < cells.count(); i++) {
+            if (cells.nth(i).textContent().contains("LTS")) {
+                foundLts = true;
+                break;
+            }
+        }
+        assertTrue(foundLts, "Table should contain at least one LTS version row");
+    }
+
+    @Test
+    void supportedVersionsTableShowsUnsupportedRows() {
+        page.navigate(baseUrl + "/security/");
+        Locator rows = page.locator("table.tableblock tbody tr");
+        String lastRowText = rows.last().textContent();
+        assertTrue(lastRowText.contains("❌"), "Last row should be marked as unsupported");
+    }
+
+    @Test
+    void pageLinksToEol() {
+        page.navigate(baseUrl + "/security/");
+        Locator eolLink = page.locator("a[href*='/eol/']");
+        assertTrue(eolLink.count() >= 1, "Page should link to the EOL page");
+    }
+}

--- a/src/test/java/io/quarkusio/SmokePageTest.java
+++ b/src/test/java/io/quarkusio/SmokePageTest.java
@@ -25,7 +25,8 @@ public class SmokePageTest extends BrowserTest {
             "/events/",
             "/userstories/",
             "/releases/",
-            "/eol/"
+            "/eol/",
+            "/security/"
     })
     void criticalPageReturns200(String path) {
         Response response = page.navigate(baseUrl + path);


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkusio.github.io/issues/2776

Manually maintaining this table is boring, and unnecessary now that we have a single source of truth about lts versions. 

Annoyingly, we can't do the template interpolation into adoc, so I had to make a franken-page which kept some adoc parts (because adoc is nicer to edit), but used html for the table. 

This should produce a /security which is exactly identical to the current one, with the exception of the link to /eol. 

Before:
https://quarkus.io/security/
<img width="1144" height="493" alt="image" src="https://github.com/user-attachments/assets/063d130c-448c-4a53-b45b-6b1b020abe15" />

After:
https://quarkus-website-pr-2782-preview.surge.sh/security
<img width="1155" height="484" alt="image" src="https://github.com/user-attachments/assets/0cf6ff54-99ba-493e-bbbd-c86442427de7" />
