### PR TITLE
Tighten security page test to require a version number before .x

### DIFF
--- a/src/test/java/io/quarkusio/SecurityPageTest.java
+++ b/src/test/java/io/quarkusio/SecurityPageTest.java
@@ -27,8 +27,8 @@ public class SecurityPageTest extends BrowserTest {
                 "Expected at least 4 rows (latest, LTS, older, pre-3.0) but found " + rows.count());
 
         String firstRowText = rows.first().textContent();
-        assertTrue(firstRowText.contains("Latest") && firstRowText.contains(".x"),
-                "First row should show 'Latest X.x' but was: " + firstRowText);
+        assertTrue(firstRowText.matches("(?s).*Latest \\d+\\.x.*"),
+                "First row should show 'Latest <number>.x' but was: " + firstRowText);
         assertTrue(firstRowText.contains("✅"), "Latest release should be marked as supported");
     }
 


### PR DESCRIPTION
The previous check used two separate .contains() calls for "Latest" and ".x", which would pass for "Latest .x" (missing major version digit). Use a regex to ensure the row matches "Latest <digit>.x".

This is the sort of error that's likely to happen (I created the problem locally, and my tests did not fail - woe).

