### PR TITLE
Fix broken Camel Apache links in release blog posts

### DIFF
--- a/_posts/2022-04-05-camel-quarkus-effortless-apis.adoc
+++ b/_posts/2022-04-05-camel-quarkus-effortless-apis.adoc
@@ -18,7 +18,7 @@ Discover Camel, the swiss-knife of integration brought to Quarkus. The example e
 
 Quarkus offers an extensive collection of extensions to connect to web, data and messaging systems, providing the developer fantastic functionality at his disposal. However, in many cases, the problem at hand already belongs to one (or more) of the well-known https://www.enterpriseintegrationpatterns.com/toc.html[enterprise integration patterns^].
 
-Developers often kickstart their projects unaware that Apache Camel has perfected how to best address integration patterns. Camel Quarkus provides https://camel.apache.org/camel-quarkus/2.7.x/reference/index.html[hundreds of connectors^] and rich functionality for data mediation: data formats, transformers, templating, custom processors, etc.
+Developers often kickstart their projects unaware that Apache Camel has perfected how to best address integration patterns. Camel Quarkus provides https://web.archive.org/web/20221003140252/https://camel.apache.org/camel-quarkus/2.7.x/reference/index.html[hundreds of connectors^] and rich functionality for data mediation: data formats, transformers, templating, custom processors, etc.
 
 https://camel.apache.org/camel-quarkus/[Camel Quarkus^] is a subproject in the https://camel.apache.org/[Apache Camel^] community that enables Camel to run on https://developers.redhat.com/products/quarkus/overview[Quarkus^]. Apache Camel, often called the swiss-knife of integration, is the most popular open source community project aimed at solving all things integration.
 
@@ -62,7 +62,7 @@ image::dev-code-first.png[alt=Code-first approach, align=center, width=85%]
 
 Here's a speedy summary for those unfamiliar with Camel and how to implement REST APIs. 
 
-Camel has its domain-specific language (DSL) to define processing flows, known as the Camel DSL. You use Camel components (aka. connectors) in the DSL to move data from sources to targets. Camel Quarkus has https://camel.apache.org/camel-quarkus/2.7.x/reference/index.html[300+ available extensions^].
+Camel has its domain-specific language (DSL) to define processing flows, known as the Camel DSL. You use Camel components (aka. connectors) in the DSL to move data from sources to targets. Camel Quarkus has https://web.archive.org/web/20221003140252/https://camel.apache.org/camel-quarkus/2.7.x/reference/index.html[300+ available extensions^].
 
 Camel provides an additional domain-specific language for specific REST implementations: the REST DSL. When implementing REST services with Camel, you chain both DSLs to define the service’s end-to-end behaviour.
 
@@ -200,7 +200,7 @@ image::vscode-codelens.png[alt=VSCode prepends an action link to open the visual
 
 [TIP]
 ====
-The following https://camel.apache.org/blog/2021/11/vscode-atlasmap-release-0.1.0/[blog in the Apache Camel^] community describes how to use the tooling. 
+The following https://web.archive.org/web/20231208160321/https://camel.apache.org/blog/2021/11/vscode-atlasmap-release-0.1.0/[blog in the Apache Camel^] community describes how to use the tooling. 
 ====
 
 The picture below shows the data mapping definition in AtlasMap for the request flow:

--- a/_posts/2024-08-28-quarkus-3-14-1-released.adoc
+++ b/_posts/2024-08-28-quarkus-3-14-1-released.adoc
@@ -155,7 +155,7 @@ A big thank you to the Quarkus users who reported this issue with amazing reprod
 ==== Camel Quarkus
 
 Camel Quarkus has been updated to 3.14.
-You can find everything you need to know about it in the https://camel.apache.org/blog/2024/08/camel-quarkus-release-3.14.0/[release notes].
+You can find everything you need to know about it in the https://camel.apache.org/releases/q-3.14.0/[release notes].
 
 ==== Quarkus CXF
 

--- a/_posts/2024-09-26-quarkus-3-15-1-released.adoc
+++ b/_posts/2024-09-26-quarkus-3-15-1-released.adoc
@@ -65,7 +65,7 @@ It is recommended to move to the new artifacts but it is not mandated for 3.15 (
 ==== Camel Quarkus
 
 Camel Quarkus has been updated to 3.15.0.
-You can find everything you need to know about it in the https://camel.apache.org/blog/2024/09/camel-quarkus-release-3.15.0/[release notes].
+You can find everything you need to know about it in the https://camel.apache.org/releases/q-3.15.0/[release notes].
 
 ==== Quarkus CXF
 

--- a/_posts/2025-02-26-quarkus-3-19-1-released.adoc
+++ b/_posts/2025-02-26-quarkus-3-19-1-released.adoc
@@ -92,7 +92,7 @@ Check the https://docs.quarkiverse.io/quarkus-cxf/dev/release-notes/3.19.0.html[
 ==== Camel Quarkus
 
 Camel Quarkus has been upgraded to 3.19.0.
-You can consult the https://camel.apache.org/blog/2025/02/camel-quarkus-release-3.19.0/[release notes] for more information.
+You can consult the https://camel.apache.org/releases/q-3.19.0/[release notes] for more information.
 
 == Full changelog
 

--- a/_posts/2025-03-26-quarkus-3-20-0-released.adoc
+++ b/_posts/2025-03-26-quarkus-3-20-0-released.adoc
@@ -54,7 +54,7 @@ but there are still cases that should be handled manually and we recommend readi
 ==== Camel Quarkus
 
 Camel Quarkus has been updated to 3.20.0.
-You can find everything you need to know about it in the https://camel.apache.org/blog/camel-quarkus-release-3.20.0[release notes].
+You can find everything you need to know about it in the https://camel.apache.org/releases/q-3.20.0/[release notes].
 
 ==== Quarkus CXF
 

--- a/_posts/2025-03-26-quarkus-3-21-0-released.adoc
+++ b/_posts/2025-03-26-quarkus-3-21-0-released.adoc
@@ -44,7 +44,7 @@ Check the https://docs.quarkiverse.io/quarkus-cxf/dev/release-notes/3.21.0.html[
 ==== Camel Quarkus
 
 Camel Quarkus has been upgraded to 3.20.0.
-You can consult the https://camel.apache.org/blog/camel-quarkus-release-3.20.0[release notes] for more information.
+You can consult the https://camel.apache.org/releases/q-3.20.0/[release notes] for more information.
 
 ==== Amazon Services
 


### PR DESCRIPTION
Camel moved release announcements from /blog/ to /releases/q-X.Y.Z/. Two older links in the camel-quarkus-effortless-apis post were removed from the Camel site entirely, so point them to Wayback Machine snapshots.
