### PR TITLE
Fix broken GitHub links in blog posts and contributor data

### DIFF
--- a/_data/1kcontributor-list.yaml
+++ b/_data/1kcontributor-list.yaml
@@ -136,7 +136,7 @@ links:
     name: Andrea Peruffo
     avatar: "https://avatars.githubusercontent.com/u/5792097?u=4b5cf9b70eb1633a91849488fef988110c305bec&v=4"
   - login: andreas-eberle
-    url: https://github.com/andreas-eberle
+    url: https://github.com/ghost
     name: Andreas Eberle
     avatar: "https://avatars.githubusercontent.com/u/9267365?u=c24ef28c32e10c9b2c49d8dabe826871d8d791e8&v=4"
   - login: paschi
@@ -1652,7 +1652,7 @@ links:
     name: Jonas Eriksson
     avatar: "https://avatars.githubusercontent.com/u/586047?v=4"
   - login: jonasjensen-brolstark
-    url: https://github.com/jonasjensen-brolstark
+    url: https://github.com/ghost
     name: Jonas Jensen
     avatar: "https://avatars.githubusercontent.com/u/46445487?u=075a13056a73ff3ee05f06be56b4438cba7a7188&v=4"
   - login: JonasKleinebecker
@@ -2740,7 +2740,7 @@ links:
     name: Petr Široký
     avatar: "https://avatars.githubusercontent.com/u/670547?v=4"
   - login: PhilKes
-    url: https://github.com/PhilKes
+    url: https://github.com/ghost
     name: Phil
     avatar: "https://avatars.githubusercontent.com/u/39240633?u=6193d49ab5f3d08fb96b5533bdc27e4c615f1490&v=4"
   - login: deewhyweb
@@ -2904,7 +2904,7 @@ links:
     name: Rolfe Dlugy-Hegwer
     avatar: "https://avatars.githubusercontent.com/u/350907?u=a3fad67d735c02b5a2fffc790f61ef98427e81c0&v=4"
   - login: BadRoro
-    url: https://github.com/BadRoro
+    url: https://github.com/ghost
     name: Romain BADINO
     avatar: "https://avatars.githubusercontent.com/u/64273293?u=915086dc41a00313a064f617c916442779fc6ac4&v=4"
   - login: rquinio
@@ -3080,7 +3080,7 @@ links:
     name: Severin Gehwolf
     avatar: "https://avatars.githubusercontent.com/u/357222?v=4"
   - login: shivam-sharma7
-    url: https://github.com/shivam-sharma7
+    url: https://github.com/ghost
     name: Shivam Sharma
     avatar: "https://avatars.githubusercontent.com/u/91419219?u=b74de58911455580711b78f1a664b8433c7549a5&v=4"
   - login: DShivansh
@@ -3460,7 +3460,7 @@ links:
     name: YeSun
     avatar: "https://avatars.githubusercontent.com/u/39059254?u=2c5022cb11f2b8aa3ad57d8fe9dd94541e59f49e&v=4"
   - login: Yelzhasdev
-    url: https://github.com/Yelzhasdev
+    url: https://github.com/ghost
     name: Yelzhas Suleimenov
     avatar: "https://avatars.githubusercontent.com/u/27397233?u=04471ef85b96ef80b298bcb375f3560d22728546&v=4"
   - login: YeonguChoe
@@ -3796,7 +3796,7 @@ links:
     name: manob
     avatar: "https://avatars.githubusercontent.com/u/15947082?u=083ccebbd457ed9e310b138f140d67242f97d0d7&v=4"
   - login: manofthepeace
-    url: https://github.com/manofthepeace
+    url: https://github.com/ghost
     name: manofthepeace
     avatar: "https://avatars.githubusercontent.com/u/13215031?u=218cc241798fdf88efba5529ccf794ea8d1c6fa7&v=4"
   - login: maschoene

--- a/_posts/2020-08-20-codestarts-preview.adoc
+++ b/_posts/2020-08-20-codestarts-preview.adoc
@@ -104,13 +104,13 @@ So please give it a try and report any bug you may find :-)
 
 If you have an extension and would like to provide a codestart for it:
 
-- Doc: https://github.com/quarkusio/quarkus/blob/master/independent-projects/tools/codestarts/codestarts.adoc
+- Doc: https://github.com/quarkusio/quarkus/blob/main/independent-projects/tools/codestarts/README.adoc
 
-- Example codestarts dir: https://github.com/quarkusio/quarkus/tree/main/devtools/platform-descriptor-json/src/main/resources/codestarts
+- Example codestarts dir: https://github.com/quarkusio/quarkus/tree/main/devtools/project-core-extension-codestarts/src/main/resources/codestarts
 
 Feel free to contact us via https://quarkusio.zulipchat.com/[Zulip] or the https://groups.google.com/forum/#!forum/quarkus-dev[Quarkus Development mailing list] for any question or suggestion.
 
-NOTE: Here are the Codestarts https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/codestarts[core code], and the https://github.com/quarkusio/quarkus/tree/main/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts[base codestarts] used to scaffold your Quarkus application.
+NOTE: Here are the Codestarts https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/codestarts[core code], and the https://github.com/quarkusio/quarkus/tree/main/devtools/project-core-extension-codestarts/src/main/resources/codestarts[base codestarts] used to scaffold your Quarkus application.
 
 == The door is now open to an endless new playground
 

--- a/_posts/2020-12-07-extension-codestarts-a-new-way-to-learn-and-discover-quarkus.adoc
+++ b/_posts/2020-12-07-extension-codestarts-a-new-way-to-learn-and-discover-quarkus.adoc
@@ -62,7 +62,7 @@ jbang cli@quarkusio create qute
 Codestarts are designed to make it easy and quick to provide new examples for extensions. So whether you are an extension owner, or you are keen to create an example for an extension you like, contributions are very welcome!
 
 [NOTE]
-We provide https://github.com/quarkusio/quarkus/blob/master/independent-projects/tools/codestarts/README.adoc[doc and tooling,role=external,window=_blank] for it, you may also https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Codestarts.2E.2E.2E[come and ping me (@ia3andy) on Zulip,role=external,window=_blank] for more info.
+We provide https://github.com/quarkusio/quarkus/blob/main/independent-projects/tools/codestarts/README.adoc[doc and tooling,role=external,window=_blank] for it, you may also https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Codestarts.2E.2E.2E[come and ping me (@ia3andy) on Zulip,role=external,window=_blank] for more info.
 
 [NOTE]
-For now, we focus on the https://github.com/quarkusio/quarkus/blob/master/extensions[core extensions,role=external,window=_blank], but we will make it available to the broader ecosystem soon.
+For now, we focus on the https://github.com/quarkusio/quarkus/blob/main/extensions[core extensions,role=external,window=_blank], but we will make it available to the broader ecosystem soon.

--- a/_posts/2020-12-08-avro-native.adoc
+++ b/_posts/2020-12-08-avro-native.adoc
@@ -28,7 +28,7 @@ As a result, your application does not have to configure anything, "it just work
 Let's come back to Avro.
 Avro uses https://docs.oracle.com/javase/9/docs/api/java/lang/invoke/MethodHandles.html[method handles] that are not supported by the GraalVM native compiler.
 
-To workaround the unsupported constructs used by Avro, we implemented a set of https://github.com/quarkusio/quarkus/blob/master/extensions/avro/runtime/src/main/java/io/quarkus/avro/graal/AvroSubstitutions.java[substitutions].
+To workaround the unsupported constructs used by Avro, we implemented a set of https://github.com/quarkusio/quarkus/blob/main/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/graal/AvroSubstitutions.java[substitutions].
 We replaced method handles with reflection.
 
 The `GenericDatumReader` also needs a bit of work as it touches threads at build time.

--- a/_posts/2022-02-22-quarkus-superheroes-to-the-rescue.adoc
+++ b/_posts/2022-02-22-quarkus-superheroes-to-the-rescue.adoc
@@ -114,7 +114,7 @@ The entire application or a subset of it can be started with a single Docker Com
 
 ==== Running the Entire Application
 
-The https://github.com/quarkusio/quarkus-super-heroes/tree/main/deploy/docker-compose[`+deploy/docker-compose+`^] directory in the https://github.com/quarkusio/quarkus-super-heroes[root of the respository^] contains compose files for each of the four versions of the application: JVM 11, JVM 17, native built with Java 11, and native built with Java 17. Additionally, https://prometheus.io[Prometheus^] monitoring can be started with the https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/docker-compose/prometheus.yml[supplied `+prometheus.yml+` file^].
+The https://github.com/quarkusio/quarkus-super-heroes/tree/main/deploy/docker-compose[`+deploy/docker-compose+`^] directory in the https://github.com/quarkusio/quarkus-super-heroes[root of the respository^] contains compose files for each of the four versions of the application: JVM 11, JVM 17, native built with Java 11, and native built with Java 17. Additionally, https://prometheus.io[Prometheus^] monitoring can be started with the https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/docker-compose/monitoring.yml[supplied `+monitoring.yml+` file^].
 
 From the +quarkus-super-heroes+ directory, simply run the https://github.com/quarkusio/quarkus-super-heroes#running-locally-via-docker-compose[command based on the version of the application you want to run^]. For example, to run the native Java 17 version, run `+docker-compose -f deploy/docker-compose/native-java17.yml -f deploy/docker-compose/prometheus.yml up+`.
 
@@ -173,7 +173,7 @@ The https://github.com/quarkusio/quarkus-super-heroes/tree/main/deploy/k8s[`+dep
 
 For example, to deploy the native Java 17 version to OpenShift, simply run `+kubectl apply -f deploy/k8s/native-java17-openshift.yml+` (or `+oc apply -f deploy/k8s/native-java17-openshift.yml+`).
 
-To deploy Prometheus monitoring in addition to the application, `+kubectl apply -f+` (or `+oc apply -f+` if using OpenShift) the appropriate Prometheus Kubernetes descriptor based on the target Kubernetes environment: https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/k8s/prometheus-openshift.yml[`+prometheus-openshift.yml+`^], https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/k8s/prometheus-minikube.yml[`+prometheus-minikube.yml+`^], or https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/k8s/prometheus-kubernetes.yml[`+prometheus-kubernetes.yml+`^].
+To deploy Prometheus monitoring in addition to the application, `+kubectl apply -f+` (or `+oc apply -f+` if using OpenShift) the appropriate Prometheus Kubernetes descriptor based on the target Kubernetes environment: https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/k8s/monitoring-openshift.yml[`+monitoring-openshift.yml+`^], https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/k8s/monitoring-minikube.yml[`+monitoring-minikube.yml+`^], or https://github.com/quarkusio/quarkus-super-heroes/blob/main/deploy/k8s/monitoring-kubernetes.yml[`+monitoring-kubernetes.yml+`^].
 
 NOTE: On Minikube or Kubernetes only the Super Heroes UI and the Fights service is exposed outside the cluster. If you want to access Prometheus or the Event Statistics service then you will need to expose it, either by using an `+Ingress+` or doing a `+kubectl port-forward+` of the Pod. On OpenShift, all of the applications have ``Route``s which expose them outside the cluster.
 

--- a/_posts/2022-11-17-our-bumpy-road-to-jakarta-ee-10.adoc
+++ b/_posts/2022-11-17-our-bumpy-road-to-jakarta-ee-10.adoc
@@ -121,7 +121,7 @@ Except if a blocking issue is discovered:
 
 == Interested in this work?
 
-All the "code" for this work is published in https://github.com/quarkusio/quarkus/tree/main/jakarta[the `jakarta` root folder of the Quarkus repository].
+All the "code" for this work is published in https://web.archive.org/web/20230531224732/https://github.com/quarkusio/quarkus/tree/main/jakarta[the `jakarta` root folder of the Quarkus repository].
 
 You can consume it in several ways:
 
@@ -129,4 +129,4 @@ You can consume it in several ways:
 * Use our snapshots, they are published daily to https://s01.oss.sonatype.org/content/repositories/snapshots/ with the `999-jakarta-SNAPSHOT` version.
 * Build the `jakarta-rewrite` branch yourself, it is published daily with the result of the transformation from current `main`.
 
-You can find more information about it in https://github.com/quarkusio/quarkus/tree/main/jakarta#jakarta-migration[the README.md of the `jakarta` folder].
+You can find more information about it in https://web.archive.org/web/20230531224732/https://github.com/quarkusio/quarkus/tree/main/jakarta#jakarta-migration[the README.md of the `jakarta` folder].

--- a/_posts/2023-09-25-virtual-threads-3.adoc
+++ b/_posts/2023-09-25-virtual-threads-3.adoc
@@ -140,7 +140,7 @@ java.lang.AssertionError: The test testInitialItems() was expected to NOT pin th
 	jdk.internal.vm.Continuation.enterSpecial(jdk.internal.vm.Continuation.java:-1)
 ----
 
-Find more about the loom-unit extension on https://github.com/cescoffier/loom-unit[the project repository] or its https://github.com/quarkusio/quarkus/tree/main/independent-projects/junit5-virtual-threads[Quarkus sibling].
+Find more about the loom-unit extension on https://github.com/cescoffier/loom-unit[the project repository] or its https://github.com/quarkusio/quarkus/tree/main/independent-projects/junit-virtual-threads[Quarkus sibling].
 
 ## Summary
 

--- a/_posts/2025-01-29-introducing-mcp-servers.adoc
+++ b/_posts/2025-01-29-introducing-mcp-servers.adoc
@@ -86,7 +86,7 @@ image::mcp-jdbc-goose.png[Goose using the JDBC server to connect to the SQLLite 
 
 All that is great, but why use Quarkus for implementing the MCP servers?
 
-First is that the programming model provided by Quarkus is very powerful, allowing you to easily focus on the business logic of your application. See https://quarkus.io/blog/mcp-server/[previous blog] for details on how to implement a server or look at the https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/src/main/java/io/quarkus/mcp/servers/jdbc/MCPServerJDBC.java[code of the JDBC servers]. Notice how compact it is!
+First is that the programming model provided by Quarkus is very powerful, allowing you to easily focus on the business logic of your application. See https://quarkus.io/blog/mcp-server/[previous blog] for details on how to implement a server or look at the https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/src/main/java/io/quarkiverse/mcp/servers/jdbc/MCPServerJDBC.java[code of the JDBC servers]. Notice how compact it is!
 
 Second, is the vast Java ecosystem provides things like JDBC drivers which enables us to make a single server that works with any JDBC-compatible database. We use `jbang` to dynamically download https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jdbc/.scripts/mcpjdbc.java[the right JDBC driver] and then launch the quarkus mcp server. Similar is done for `jfx` to https://github.com/quarkiverse/quarkus-mcp-servers/blob/main/jbang-catalog.json#L34[fetch] the right OS specific JavaFX dependencies.
 

--- a/_posts/2025-02-20-agentic-ai-with-quarkus-p2.adoc
+++ b/_posts/2025-02-20-agentic-ai-with-quarkus-p2.adoc
@@ -261,7 +261,7 @@ So, it would take approximately 9.62 seconds for a leopard running at full speed
 
 This example illustrates how an agent can use _tools_ to retrieve data.
 While we use a search engine here, you can easily implement a tool that queries a database or another service to retrieve the needed information.
-You can check https://github.com/quarkusio/quarkus-workshop-langchain4j/blob/main/step-08/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java[this example] to see how to implement a tool that queries a database using a Quarkus Panache repository.
+You can check https://github.com/quarkusio/quarkus-workshop-langchain4j/blob/main/section-1/step-08/src/main/java/dev/langchain4j/quarkus/workshop/BookingRepository.java[this example] to see how to implement a tool that queries a database using a Quarkus Panache repository.
 
 === Agents and Conversational AI
 

--- a/_posts/2025-05-21-secure-mcp-client.adoc
+++ b/_posts/2025-05-21-secure-mcp-client.adoc
@@ -41,7 +41,7 @@ The demo shows that Quarkus MCP Client can work effectively in such architecture
 
 We are now ready to start working on the `Secure MCP Client Server` demo.
 
-You can find the complete project source in the https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples/secure-mcp-sse-client-server[Quarkus LangChain4j Secure MCP Client Server sample].
+You can find the complete project source in the https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples/secure-mcp-client-server[Quarkus LangChain4j Secure MCP Client Server sample].
 
 [[create-mcp-server]]
 == Step 1 - Create and start MCP server
@@ -243,7 +243,7 @@ mvn quarkus:dev -Duser.name="Your GitHub account name" <1>
 
 [NOTE]
 ====
-The MCP server's security-related configuration remains exactly the same in prod mode, therefore we are not going to talk about running the MCP server in prod to save some blog post space. Please check the https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples/secure-mcp-sse-client-server[Quarkus LangChain4j Secure MCP Client Server sample] if you would like to run MCP server in prod mode - you will only need to make sure PostresSQL is available in prod mode too.
+The MCP server's security-related configuration remains exactly the same in prod mode, therefore we are not going to talk about running the MCP server in prod to save some blog post space. Please check the https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples/secure-mcp-client-server[Quarkus LangChain4j Secure MCP Client Server sample] if you would like to run MCP server in prod mode - you will only need to make sure PostresSQL is available in prod mode too.
 ====
 
 [[create-poem-service]]
@@ -357,7 +357,7 @@ public class LoginResource {
 ----
 <1> Require an authenticated access. It forces an authorization code flow for users who did not login with GitHub yet and a session verification for the already authenticated users.
 <2> GitHub access tokens are binary and Quarkus OIDC indirectly verifies them by using them to request GitHub specific `UserInfo` representation.
-<3> After the user logs in to GitHub and is redirected to this endpoint, an HTML page with a user name and a link to the <<jaxrs-poem-resource,Poem Resource endpoint>> is generated with a simple https://github.com/quarkiverse/quarkus-langchain4j/blob/main/samples/secure-mcp-sse-client-server/secure-mcp-client/src/main/resources/templates/poem.html[Qute template] and returned to the user.
+<3> After the user logs in to GitHub and is redirected to this endpoint, an HTML page with a user name and a link to the <<jaxrs-poem-resource,Poem Resource endpoint>> is generated with a simple https://github.com/quarkiverse/quarkus-langchain4j/blob/main/samples/secure-mcp-client-server/secure-mcp-client/src/main/resources/templates/poem.html[Qute template] and returned to the user.
 
 [[jaxrs-poem-resource]]
 === Create Poem Resource endpoint
@@ -446,7 +446,7 @@ mvn quarkus:dev
 
 [NOTE]
 ====
-All the Poem Service configuration remains exactly the same in prod mode, therefore we are not going to talk about running it in prod to save some blog post space. Please check the https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples/secure-mcp-sse-client-server[Quarkus LangChain4j Secure MCP Client Server sample] if you would like to run it in prod mode.
+All the Poem Service configuration remains exactly the same in prod mode, therefore we are not going to talk about running it in prod to save some blog post space. Please check the https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples/secure-mcp-client-server[Quarkus LangChain4j Secure MCP Client Server sample] if you would like to run it in prod mode.
 ====
 
 We are ready to test our AI `Poem Service` application.

--- a/_posts/2026-01-19-a2a-java-sdk-1-0-0-alpha1.adoc
+++ b/_posts/2026-01-19-a2a-java-sdk-1-0-0-alpha1.adoc
@@ -21,7 +21,7 @@ The move to version 1.0 of the A2A specification marks its transition from exper
 
 === 1. Specification Alignment
 
-The SDK now implements protocol version `1.0` and aligns with the latest https://github.com/a2aproject/A2A/blob/main/specification/grpc/a2a.proto[a2a.proto] definitions. Key specification changes include:
+The SDK now implements protocol version `1.0` and aligns with the latest https://github.com/a2aproject/A2A/blob/main/specification/a2a.proto[a2a.proto] definitions. Key specification changes include:
 
 * *AgentCard evolution*: The `AgentCard` now uses a `supportedInterfaces` list instead of separate `url`, `preferredTransport`, and `additionalInterfaces` fields. This provides a cleaner, more flexible way to advertise multiple protocol bindings.
 * *Removed kind discriminators*: The 1.0 specification eliminates the `kind` field as a type discriminator, simplifying the protocol.


### PR DESCRIPTION
Fixed 20 GitHub dead links across 11 files:

- Update 7 deleted contributor profiles to point to github.com/ghost

  Blog post fixes (13 links):
  - a2a.proto moved out of grpc/ subdirectory
  - secure-mcp-sse-client-server renamed to secure-mcp-client-server
  - MCP servers package io.quarkus → io.quarkiverse
  - Super-heroes prometheus.yml → monitoring.yml (4 files)
  - Workshop step-08/ moved to section-1/step-08/
  - Avro substitutions: master → main + package path change
  - Codestarts: codestarts.adoc → README.adoc, moved directory (3 links)
  - junit5-virtual-threads → junit-virtual-threads
  - jakarta/ directory → Wayback Machine (removed after migration completed)

