### PR TITLE
Replace 8 dead dzone.com links with Wayback Machine URLs

### DIFF
--- a/_data/publications.yaml
+++ b/_data/publications.yaml
@@ -1087,11 +1087,11 @@
   type: "article"
   title: "Quarkus vs. WildFly -- Requests per Second"
   urldate: "2020-03-07"
-- url: "https://web.archive.org/web/20200310225849/https://dzone.com/articles/using-the-openj9-jvm-for-quarkus-applications"
+- url: "https://heidloff.net/article/openj9-jvm-for-quarkus-applications/"
   date: "2020-02-25"
   note: "OpenJ9 is an alternative JavaVM to OpenJDK. In this article Niklas takes\
     \ it for a ride and shows how it stack up against GraalVM and OpenJDK in a basic\
-    \ CRUD application."
+    \ CRUD application. Also syndicated to DZone."
   author: "Niklas Heidloff"
   id: "UsingtheOpenJ9JVMforQuarkusApplicationsDZoneJava-2020-02-25"
   type: "article"
@@ -1976,10 +1976,10 @@
   type: "article"
   title: "Quarkus OAuth2 and security with Keycloak - Piotr's TechBlog"
   urldate: "2020-09-16"
-- url: "https://web.archive.org/web/20201118201421/https://dzone.com/articles/migrating-a-spring-boot-application-to-quarkus-cha"
+- url: "https://aytartana.wordpress.com/2020/08/26/migrating-springboot-petclinic-rest-to-quarkus/"
   date: "2020-09-16"
   note: "In this post, I'm going to cover my experience migrating thee Spring Boot\
-    \ PetClinic REST application to Quarkus."
+    \ PetClinic REST application to Quarkus. Also syndicated to DZone."
   affiliation: "Red Hat"
   author: "Jonathan Vila"
   id: "MigratingSpringBootPetClinicRESTtoQuarkusDZoneJava-2020-09-16"
@@ -2319,10 +2319,11 @@
   title: "From Microservices to Kubernetes with Quarkus (2/2) - Monitoring - Raffaele\
     \ Marcello personal github web site"
   urldate: "2021-02-01"
-- url: "https://web.archive.org/web/20210508164333/https://dzone.com/articles/write-a-quarkus-function-in-two-steps-on-red-hat-o"
+- url: "https://developers.redhat.com/blog/2021/01/29/write-a-quarkus-function-in-two-steps-on-red-hat-openshift-serverless"
   date: "2021-02-01"
   note: "In this article, I’ll walk you through two steps to write a serverless function\
-    \ with super fast boot and response times and built-in resource optimization."
+    \ with super fast boot and response times and built-in resource optimization. Also\
+    \ syndicated to DZone."
   affiliation: "Red Hat"
   author: "Daniel Oh"
   id: "WriteaQuarkusFunctioninTwoStepsonRedHatOpenShiftServerlessDZoneJava-2021-02-01"
@@ -3415,11 +3416,11 @@
   type: "article"
   title: "Quarkus - Quarkus 2.0.2.Final released - Maintenance release"
   urldate: "2021-07-14"
-- url: "https://web.archive.org/web/20220318235523/https://dzone.com/articles/3-reasons-quarkus-20-improves-developer-productivi"
+- url: "https://opensource.com/article/21/7/developer-productivity-linux"
   date: "2021-07-13"
   note: "you can increase development productivity on Linux with Quarkus, a Kubernetes-native\
     \ Java stack. Quarkus 2.0 was released recently with useful new features for testing\
-    \ in the developer console."
+    \ in the developer console. Also syndicated to DZone."
   affiliation: "Red Hat"
   author: "Daniel Oh"
   id: "3reasonsQuarkus20improvesdeveloperproductivityonLinuxDZoneJava-2021-07-13"

--- a/_data/publications.yaml
+++ b/_data/publications.yaml
@@ -1087,7 +1087,7 @@
   type: "article"
   title: "Quarkus vs. WildFly -- Requests per Second"
   urldate: "2020-03-07"
-- url: "https://dzone.com/articles/using-the-openj9-jvm-for-quarkus-applications"
+- url: "https://web.archive.org/web/20200310225849/https://dzone.com/articles/using-the-openj9-jvm-for-quarkus-applications"
   date: "2020-02-25"
   note: "OpenJ9 is an alternative JavaVM to OpenJDK. In this article Niklas takes\
     \ it for a ride and shows how it stack up against GraalVM and OpenJDK in a basic\
@@ -1364,7 +1364,7 @@
   type: "article"
   title: "Hands-On Reactive Application with Angular and Quarkus"
   urldate: "2020-05-11"
-- url: "https://dzone.com/articles/quarkus-supersonic-subatomic-java-goes-faster-in-t"
+- url: "https://web.archive.org/web/20231003121005/https://dzone.com/articles/quarkus-supersonic-subatomic-java-goes-faster-in-t"
   date: "2020-05-11"
   note: "How to deploy a plain Quarkus application in the cloud with Platform.sh"
   affiliation: "Platform.sh"
@@ -1454,7 +1454,7 @@
   type: "video"
   title: "Introduction to Quarkus with Kotlin"
   urldate: "2020-05-13"
-- url: "https://dzone.com/articles/quarkus-supersonic-subatomic-java-deploy-faster-in"
+- url: "https://web.archive.org/web/20231003120905/https://dzone.com/articles/quarkus-supersonic-subatomic-java-deploy-faster-in"
   date: "2020-05-13"
   note: "In the second of this seires on deploying Quarkus to the cloud, we take a\
     \ look at building the Quarkus app in preparation for deployment."
@@ -1555,7 +1555,7 @@
   type: "article"
   title: "Deploy Quarkus Faster in the Cloud with Platform.sh. Part 5 - DZone Java"
   urldate: "2020-05-20"
-- url: "https://dzone.com/articles/deploy-quarkus-faster-in-the-cloud-with-platformsh-3"
+- url: "https://web.archive.org/web/20201009193857/https://dzone.com/articles/deploy-quarkus-faster-in-the-cloud-with-platformsh-3"
   date: "2020-05-19"
   note: "How to deploy a Panache/MongoDB Quarkus application in the cloud with Platform.sh"
   affiliation: "Platform.sh"
@@ -1976,7 +1976,7 @@
   type: "article"
   title: "Quarkus OAuth2 and security with Keycloak - Piotr's TechBlog"
   urldate: "2020-09-16"
-- url: "https://dzone.com/articles/migrating-a-spring-boot-application-to-quarkus-cha"
+- url: "https://web.archive.org/web/20201118201421/https://dzone.com/articles/migrating-a-spring-boot-application-to-quarkus-cha"
   date: "2020-09-16"
   note: "In this post, I'm going to cover my experience migrating thee Spring Boot\
     \ PetClinic REST application to Quarkus."
@@ -2319,7 +2319,7 @@
   title: "From Microservices to Kubernetes with Quarkus (2/2) - Monitoring - Raffaele\
     \ Marcello personal github web site"
   urldate: "2021-02-01"
-- url: "https://dzone.com/articles/write-a-quarkus-function-in-two-steps-on-red-hat-o?utm_source=dlvr.it&utm_medium=twitter"
+- url: "https://web.archive.org/web/20210508164333/https://dzone.com/articles/write-a-quarkus-function-in-two-steps-on-red-hat-o"
   date: "2021-02-01"
   note: "In this article, I’ll walk you through two steps to write a serverless function\
     \ with super fast boot and response times and built-in resource optimization."
@@ -3415,7 +3415,7 @@
   type: "article"
   title: "Quarkus - Quarkus 2.0.2.Final released - Maintenance release"
   urldate: "2021-07-14"
-- url: "https://dzone.com/articles/3-reasons-quarkus-20-improves-developer-productivi?utm_source=dlvr.it&utm_medium=twitter"
+- url: "https://web.archive.org/web/20220318235523/https://dzone.com/articles/3-reasons-quarkus-20-improves-developer-productivi"
   date: "2021-07-13"
   note: "you can increase development productivity on Linux with Quarkus, a Kubernetes-native\
     \ Java stack. Quarkus 2.0 was released recently with useful new features for testing\
@@ -3793,7 +3793,7 @@
   type: "article"
   title: "My first Quarkus project. A simple hands-on project to setup and…"
   urldate: "2021-09-20"
-- url: "https://dzone.com/articles/how-can-java-bring-you-into-kubernetes-native-futu"
+- url: "https://web.archive.org/web/20220905212139/https://dzone.com/articles/how-can-java-bring-you-into-kubernetes-native-futu"
   date: "2021-09-15"
   note: "How can Java bring you into Kubernetes-Native Future"
   author: "Daniel Oh"


### PR DESCRIPTION
These articles returned 410 Gone. Replace with archived versions where available.

Since DZone is often syndication of other articles, I've gone with the original source rather than the wayback machine where I could.

