### PR TITLE
Update dead smallrye.io links to current URLs

### DIFF
--- a/_posts/2020-09-08-kafka-rest-client.adoc
+++ b/_posts/2020-09-08-kafka-rest-client.adoc
@@ -204,4 +204,4 @@ Reactive Messaging and the Rest client contain other gems, check the related gui
 
 - https://quarkus.io/guides/rest-client[Using the Rest Client]
 - https://quarkus.io/guides/kafka[Interacting with Kafka]
-- https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2.2/kafka/kafka.html[The Kafka Connector documentation]
+- https://smallrye.io/smallrye-reactive-messaging/latest/kafka/kafka/[The Kafka Connector documentation]

--- a/_posts/2020-10-06-reactive-messaging-emitter.adoc
+++ b/_posts/2020-10-06-reactive-messaging-emitter.adoc
@@ -130,7 +130,7 @@ Emitter<Movie> emitter3;
 ## Conclusion
 
 This post is a brief introduction to the `Emitter` construct from Reactive Messaging.
-More information is available on the https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2.2/emitter/emitter.html[SmallRye Reactive Messaging documentation].
+More information is available on the https://smallrye.io/smallrye-reactive-messaging/latest/concepts/emitter/[SmallRye Reactive Messaging documentation].
 
 In the next Quarkus version (1.9), this feature will be improved with two very nice enhancements.
 First, it will offer a Mutiny variant, easing the integration with Mutiny APIs. 

--- a/_posts/2020-10-20-kafka-failure-strategy.adoc
+++ b/_posts/2020-10-20-kafka-failure-strategy.adoc
@@ -15,7 +15,7 @@ In this post, we are going to see how we can manage these failures.
 ## Ack and Nack
 
 But, first, we need to explain how it works under the hood.
-When using reactive messaging, your application receives https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2.4/concepts.html#messages[Messages].
+When using reactive messaging, your application receives https://smallrye.io/smallrye-reactive-messaging/latest/concepts/concepts/#messages[Messages].
 Even if your method handles _payloads_, there are Messages under the hood, and it unwraps the payload just before calling your method.
 
 image:/assets/images/posts/kafka-failure-strategy/messages.png[]

--- a/_posts/2020-11-24-mutiny-vertx.adoc
+++ b/_posts/2020-11-24-mutiny-vertx.adoc
@@ -227,7 +227,7 @@ private Uni<String> call(String path) {
 
 TIP: Something missing? Open an issue on https://github.com/smallrye/smallrye-reactive-utils/issues[SmallRye Reactive Utils].
 
-TIP: The Javadoc is available http://smallrye.io/smallrye-reactive-utils/apidocs/[here].
+TIP: The Javadoc is available https://javadoc.io/doc/io.smallrye.reactive/mutiny/latest/index.html[here].
 
 == The road ahead: Vert.x 4!
 

--- a/_posts/2021-01-18-getting-started-kafka.adoc
+++ b/_posts/2021-01-18-getting-started-kafka.adoc
@@ -14,7 +14,7 @@ There are many articles to help you drive your decision, such as https://medium.
 This post is about Kafka, and an equivalent post about AMQP will be published later.
 
 In this post, you will learn how to get started with Apache Kafka in your Quarkus application in less than 10 steps.
-We will use https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2.7/index.html[Reactive Messaging] - a declarative approach to build event-driven microservices, but you can also use _bare_ Kafka APIs or Kafka Streams.
+We will use https://smallrye.io/smallrye-reactive-messaging/latest/[Reactive Messaging] - a declarative approach to build event-driven microservices, but you can also use _bare_ Kafka APIs or Kafka Streams.
 
 NOTE: The complete code is available from https://github.com/cescoffier/getting-started-quarkus-kafka[GitHub].
 

--- a/_posts/2021-02-02-getting-started-amqp.adoc
+++ b/_posts/2021-02-02-getting-started-amqp.adoc
@@ -13,7 +13,7 @@ AMQP is a robust and mature protocol widely used in event-driven applications.
 
 This post is the equivalent of the https://quarkus.io/blog/getting-started-kafka/[Kafka getting started post], but focuses on the usage of AMQP.
 You will learn how to get started with AMQP in your Quarkus application in less than ten steps.
-We will use https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2.7/index.html[SmallRye Reactive Messaging] - a declarative approach to building event-driven microservices.
+We will use https://smallrye.io/smallrye-reactive-messaging/latest/[SmallRye Reactive Messaging] - a declarative approach to building event-driven microservices.
 
 NOTE: The complete code is available from https://github.com/cescoffier/getting-started-quarkus-amqp[GitHub].
 


### PR DESCRIPTION
The SmallRye docs restructured their URL scheme. This does mean using `latest` urls but I think that's ok, because pinned ones will become useless quickly. 

  - smallrye-reactive-utils/apidocs/ → javadoc.io/doc/io.smallrye.reactive/mutiny/latest/ (project absorbed into Mutiny)
  - 4 smallrye-reactive-messaging versioned URLs → /latest/ equivalents
