### PR TITLE
Update perf graphics to use 'latest'

### DIFF
--- a/_includes/homepage-performance-band.html
+++ b/_includes/homepage-performance-band.html
@@ -4,8 +4,8 @@
       <h2>Quarkus offers unequaled performance </h2>
     </div>
     <div class="width-12-12 block-content">
-      <img class="light-only" src="https://quarkus.io/benchmarks/spring-quarkus-perf-comparison/2026-03-03_03-19-23/metrics-tuned-composite-for-main-comparison-light.svg" alt="Quarkus metrics graphic">
-      <img class="dark-only" src="https://quarkus.io/benchmarks/spring-quarkus-perf-comparison/2026-03-03_03-19-23/metrics-tuned-composite-for-main-comparison-dark.svg" alt="Quarkus metrics graphic">
+      <img class="light-only" src="https://quarkus.io/benchmarks/tuned/spring-quarkus-perf-comparison-latest-tuned-composite-for-main-comparison-light.svg" alt="Quarkus metrics graphic">
+      <img class="dark-only" src="https://quarkus.io/benchmarks/tuned/spring-quarkus-perf-comparison-latest-tuned-composite-for-main-comparison-dark.svg" alt="Quarkus metrics graphic">
     </div>
   </div>
 </div>


### PR DESCRIPTION
We haven't seen anything hideously unstable in the published benchmarks graphics, and updated the link on the front page is kind of tedious. We said after a period of stabilisation we'd switch to latest, so I propose that time is now. 