### PR TITLE
Use DOMCONTENTLOADED for insights page navigation in tests to improve test robustness

### DIFF
--- a/src/test/java/io/quarkusio/InsightsPageTest.java
+++ b/src/test/java/io/quarkusio/InsightsPageTest.java
@@ -1,5 +1,7 @@
 package io.quarkusio;
 
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.WaitUntilState;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -8,7 +10,8 @@ public class InsightsPageTest extends BrowserTest {
 
     @Test
     void insightsPageHasUpcomingSession() {
-        page.navigate(baseUrl + "/insights/");
+        page.navigate(baseUrl + "/insights/",
+                new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
 
         var convertedTime = page.locator("#convertedTime");
         assertTrue(convertedTime.isVisible(), "Expected #convertedTime to be visible");
@@ -20,7 +23,8 @@ public class InsightsPageTest extends BrowserTest {
 
     @Test
     void insightsPageHasScheduledSessions() {
-        page.navigate(baseUrl + "/insights/");
+        page.navigate(baseUrl + "/insights/",
+                new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
 
         var scheduledTitles = page.locator(".card-static .title");
         int count = scheduledTitles.count();


### PR DESCRIPTION
The insights page embeds a YouTube iframe whose load event depends on external network conditions, causing flaky 30s timeouts. The tests only check DOM elements, so DOMCONTENTLOADED is sufficient and reliable.

Most of the time when I run this test it passed, but I did get one failure today. Flaky UI tests are the worse, so hopefully this will be more robust. 
