### PR TITLE
Harmonise cache methods in CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Cache Ruby gems
         if: steps.detect.outputs.jekyll == 'true'
@@ -58,13 +59,6 @@ jobs:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
-
-      - name: Cache Maven repository
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
 
       - name: Cache Playwright browsers
         id: playwright-cache
@@ -87,14 +81,6 @@ jobs:
       - name: Build Jekyll site
         if: steps.detect.outputs.jekyll == 'true'
         run: bundle exec jekyll build --future --config _config.yml,_only_latest_guides_config.yml
-
-      - name: Set up JDK
-        if: steps.detect.outputs.roq == 'true'
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-          cache: 'maven'
 
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'


### PR DESCRIPTION
I noticed that when I'm doing Roq builds, the maven cache never gets a hit. I think this is because there are two build workflows, one for PRs, and one for the real site. The PR one uses an explicit cache mechanism but as it only ever runs on PRs, the cache will never get written. The PR one *also* uses the nice `cache: maven` method that's used in the main build, because it does setup-java too many times. So I've fixed that as well. 