### PR TITLE
Fix LinkCrawlerTest to rewrite production URLs in pagination links

### DIFF
--- a/src/test/java/io/quarkusio/LinkCrawlerTest.java
+++ b/src/test/java/io/quarkusio/LinkCrawlerTest.java
@@ -262,6 +262,9 @@ public class LinkCrawlerTest extends BrowserTest {
                     continue;
                 }
 
+                // Rewrite production URLs to localhost for testing
+                href = rewriteToLocal(href);
+
                 ResolvedLink resolved = resolveLink(pageUrl, href);
                 if (resolved == null) {
                     continue;
@@ -504,6 +507,12 @@ public class LinkCrawlerTest extends BrowserTest {
 
     private static final Set<String> PRODUCTION_HOSTS = Set.of("quarkus.io", "www.quarkus.io");
 
+    // Paths that should NOT be rewritten to localhost - they are served from different repos
+    private static final Set<String> EXTERNAL_QUARKUSIO_PATHS = Set.of(
+            "/extensions",     // Extensions registry (separate service)
+            "/benchmarks"      // Benchmark results (separate service)
+    );
+
     private String rewriteToLocal(String target) {
         if (!target.startsWith("http://") && !target.startsWith("https://")) {
             return target;
@@ -513,6 +522,12 @@ public class LinkCrawlerTest extends BrowserTest {
             if (PRODUCTION_HOSTS.contains(targetUri.getHost())) {
                 String path = targetUri.getPath();
                 if (path != null && !path.isEmpty()) {
+                    // Don't rewrite paths that are served from other repositories
+                    for (String externalPath : EXTERNAL_QUARKUSIO_PATHS) {
+                        if (path.equals(externalPath) || path.startsWith(externalPath + "/")) {
+                            return target;  // Keep original production URL
+                        }
+                    }
                     return baseUrl + path;
                 }
             }


### PR DESCRIPTION
I noticed that for some links, the link crawler ended up crawling quarkus.io instead of the localhost that was built for a PR. This is not what's wanted in a pre-review check! The problem is that both the literal "quarkus.io" and the configured site url are embedded into lots of links. Sometimes that's an error and a relative link should have been used, and sometimes it's the right thing to do – but either way, the link checker should be checking what's just been built, not the published site.

The rewriteToLocal() method existed but only ran on meta-refresh targets, not regular <a href> links.

I only noticed the problem because quarkus.io sometimes returns a 503, and so it popped up in the failures list.

Fix:
- Call rewriteToLocal() on all extracted hrefs before resolving
- Production URLs (quarkus.io) are rewritten to localhost:8090
- Links are correctly treated as internal and checked locally
