### PR TITLE
Image Alt tab fix...

### DIFF
--- a/_includes/1kcontributor-list-band.html
+++ b/_includes/1kcontributor-list-band.html
@@ -7,7 +7,7 @@
       <p>Quarkus core repository reached a significant milestone by amassing a community of over 1,000 contributors in September 2024. All contributors who have propelled the project forward since its inception in June 2018. The Community has played a vital role in the development and growth of Quarkus. Through their collective efforts, these contributors have been instrumental in adding new features, identifying and resolving bugs, and rigorously testing the platform to ensure its stability and reliability. The diversity of the Quarkus community, which includes developers, engineers, and enthusiasts from around the world, has been a key factor in its success, bringing a wealth of expertise and innovative ideas to the table. The remarkable achievement of reaching 1,000 contributors is a testament to the project's growing popularity, the quality of its codebase, and the unwavering commitment of the individuals who have dedicated their time and skills to making Quarkus a true standout in the open-source software landscape. The Quarkus leadership team would like to say thank you to everyone who've contributed to this incredible community.</p>
     </div>
     <div class="width-6-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/1kcontributors/1kcontributors_image.png">
+      <img src="{{site.baseurl}}/assets/images/1kcontributors/1kcontributors_image.png" alt="Quarkus 1000 contributors celebration image">
     </div>
   </div>
   <div class="width-12-12 width-12-12-m ">
@@ -19,7 +19,7 @@
       <div class="card">
         <a href="{{ item.url }}" target="_blank"></a>
         <div>
-          <img class="headshot" src="{{ item.avatar }}">
+          <img class="headshot" src="{{ item.avatar }}" alt="{{ item.name }} avatar">
         </div>
         <div>
           <p class="title">{{ item.name }}</p>

--- a/_includes/1kcontributors-header.html
+++ b/_includes/1kcontributors-header.html
@@ -1,3 +1,3 @@
 <div class="image-header-centered">
-      <img src="{{site.baseurl}}/assets/images/1kcontributors/hero_1k_graphic.svg" class="project-logo" title="Quarkus Core reaches 1000 Contributors milestone">
+      <img src="{{site.baseurl}}/assets/images/1kcontributors/hero_1k_graphic.svg" class="project-logo" title="Quarkus Core reaches 1000 Contributors milestone" alt="Quarkus Core reaches 1000 Contributors milestone">
 </div>

--- a/_includes/CF-footerband.html
+++ b/_includes/CF-footerband.html
@@ -1,7 +1,7 @@
 <div class="content cf-footer">
   <div class="flexcontainer">
     <div class="cf-logo">
-      <a class="cf-logo" href="https://www.commonhaus.org/" target="_blank"><img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_reverse.svg"/></a>
+      <a class="cf-logo" href="https://www.commonhaus.org/" target="_blank"><img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_reverse.svg" alt="Commonhaus Foundation logo"/></a>
     </div>
     <div class="license">
       Copyright © <a href="/">Quarkus</a>. All rights reserved. For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>. Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association.

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -3,8 +3,8 @@
     <div class="width-12-12 width-12-12-m">
     <div class="imagetext-container">
       <div class="imagetext-image">
-        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg">
-        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg">
+        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg" alt="">
+        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg" alt="">
       </div>
       <div class="imagetext-text">
         <h3>Developer Joy</h3>
@@ -13,8 +13,8 @@
     </div>
     <div class="imagetext-container">
       <div class="imagetext-image">
-        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg">
-        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg">
+        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg" alt="">
+        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg" alt="">
       </div>
       <div class="imagetext-text">
         <h3>Kubernetes-native</h3>
@@ -24,8 +24,8 @@
     </div>
     <div class="imagetext-container">
       <div class="imagetext-image">
-        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg">
-        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg">
+        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg" alt="">
+        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg" alt="">
       </div>
       <div class="imagetext-text">
         <h3>Best of Breed Libraries and Standards</h3>
@@ -35,8 +35,8 @@
     </div>
     <div class="imagetext-container">
       <div class="imagetext-image">
-        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-reactive.svg">
-        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-reactive-dark.svg">
+        <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-reactive.svg" alt="">
+        <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-reactive-dark.svg" alt="">
       </div>
       <div class="imagetext-text">
         <h3>Imperative and reactive code</h3>

--- a/_includes/blog-band.html
+++ b/_includes/blog-band.html
@@ -31,7 +31,7 @@
               {% for author_key in authors_clean %}
                 {% assign author = site.data.authors[author_key] %}
                 {% if author.emailhash %}
-                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}" alt="{{ author.name }} avatar">
                 {% endif %}
                 <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>{% unless forloop.last %}, {% endunless %}
               {% endfor %}

--- a/_includes/books-band.html
+++ b/_includes/books-band.html
@@ -7,7 +7,7 @@
       <div class="card">
         <a href="{{ item.link }}"></a>
         <div>
-          <img src="{{site.baseurl}}/assets/images/books/{{ item.thumbnail }}">          
+          <img src="{{site.baseurl}}/assets/images/books/{{ item.thumbnail }}" alt="{{ item.title }}">
           <p class="title">{{ item.title }}</p>
           <div class="description">
           <p>{{ item.description }}</p></div>

--- a/_includes/catalog-index-band.html
+++ b/_includes/catalog-index-band.html
@@ -4,7 +4,7 @@
       <input type="text" id="search-text" placeholder="Keyword Search" />
     </div>
     <div class="filterselectheader">Selected Filters</div>
-    <div class="filterselectarrow"><img src="{{site.baseurl}}/assets/images/catalog_arrow_active.png" title="your selected filters"></div>
+    <div class="filterselectarrow"><img src="{{site.baseurl}}/assets/images/catalog_arrow_active.png" title="your selected filters" alt=""></div>
     <div class="yourchoices">
       <ul class="choices">
         <li><a href="#">Version 1.1</a></li>
@@ -15,7 +15,7 @@
       </ul>
     </div>
     <div class="filterheader">Filter the Extensions</div>
-    <div class="filterheaderarrow"><img src="{{site.baseurl}}/assets/images/catalog_arrow_header.png" title="filter extensions"></div>
+    <div class="filterheaderarrow"><img src="{{site.baseurl}}/assets/images/catalog_arrow_header.png" title="filter extensions" alt=""></div>
     <h3>Quarkus Version</h3>
       <select name="version">
         <option value="2.0">2.0 (Latest)</option>

--- a/_includes/developer-joy.html
+++ b/_includes/developer-joy.html
@@ -1,8 +1,8 @@
 <div class="full-width-bg component">
   <div class="grid-wrapper">
     <div class="width-3-12 width-12-12-m">
-    <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg">
-    <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg" alt="">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg" alt="">
     </div>
     <div class="width-9-12 width-12-12-m">
       <p class="intropara">Quarkus is not just about being great for writing Web Applications or Micro-Services. We’re focusing on more than the feature set: we make sure that every feature works well, simply, with little to no configuration, in the most intuitive way possible. It should be trivial to develop simple things, and easy to develop the more complex ones.</p>

--- a/_includes/events-band.html
+++ b/_includes/events-band.html
@@ -8,7 +8,7 @@
       <div class="grid-wrapper">
         <div class="img-wrapper">
           <a href="{{ item.link }}" target="_blank">
-            <img src="{{site.baseurl}}/assets/images/events/{{ item.thumbnail }}">
+            <img src="{{site.baseurl}}/assets/images/events/{{ item.thumbnail }}" alt="{{ item.title }}">
           </a>
         </div>
         <div class="info-wrapper">

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -4,7 +4,7 @@
       <input type="checkbox" id="checkbox" />
       <nav id="main-nav" class="main-nav">
         <div class="logo-wrapper">
-           <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_600px_reverse.png" class="project-logo" title="Quarkus"></a>
+           <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_600px_reverse.png" class="project-logo" title="Quarkus" alt="Quarkus"></a>
         </div>
     <label class="nav-toggle" for="checkbox">
       <i class="fa fa-bars"></i>

--- a/_includes/homepage-container_first-band.html
+++ b/_includes/homepage-container_first-band.html
@@ -7,7 +7,7 @@
       <p>Quarkus tailors your application for GraalVM and HotSpot. Amazingly fast boot time, incredibly low RSS memory (not just heap size!) offering near instant scale up and high density memory utilization in container orchestration platforms like Kubernetes. We use a technique we call compile time boot. <a href="/container-first">Learn more.</a></p>
       <pre class="highlightjs highlight"><code class="bash">$ ./my-native-java-rest-app
 Quarkus started in 0.008s</code></pre>
-      <img src="{{site.baseurl}}/assets/images/quarkus_metrics_graphic_bootmem_wide.png">
+      <img src="{{site.baseurl}}/assets/images/quarkus_metrics_graphic_bootmem_wide.png" alt="Quarkus boot time and memory usage metrics compared to other Java frameworks">
     </div>
   </div>
 </div>

--- a/_includes/homepage-developer_joy-band.html
+++ b/_includes/homepage-developer_joy-band.html
@@ -27,10 +27,10 @@ $ gradle build -Dquarkus.package.type=native</code></pre>
         <a href="/developer-joy">Learn more</a>
     </div>
     <div class="width-6-12 width-12-12-m block-image justify-self-start align-self-end">
-      <img src="{{site.baseurl}}/assets/images/homepage_comic_1.png"/ class="img-md">
+      <img src="{{site.baseurl}}/assets/images/homepage_comic_1.png" alt="Developer Joy comic strip part 1" class="img-md">
     </div>
     <div class="width-6-12 width-12-12-m block-image justify-self-end align-self-end">
-      <img src="{{site.baseurl}}/assets/images/homepage_comic_2.png"/ class="img-md">
+      <img src="{{site.baseurl}}/assets/images/homepage_comic_2.png" alt="Developer Joy comic strip part 2" class="img-md">
     </div>
   </div>
 </div>

--- a/_includes/homepage-extensions-band.html
+++ b/_includes/homepage-extensions-band.html
@@ -7,7 +7,7 @@
       <p>Quarkus provides a cohesive, fun to use, full-stack framework by leveraging a growing list of hundreds of best-of-breed libraries that you love and use. All wired on a standard backbone. <a href="/standards">Learn more about Quarkus Extensions</a>.</p>
     </div>
     <div class="width-7-12 width-12-12-m block-image justify-self-center">
-      <img src="{{site.baseurl}}/assets/images/homepage_extensions_graphic.png"/ class="img-md">
+      <img src="{{site.baseurl}}/assets/images/homepage_extensions_graphic.png" alt="Quarkus extensions ecosystem graphic" class="img-md">
     </div>
   </div>
 </div>

--- a/_includes/homepage-features-band.html
+++ b/_includes/homepage-features-band.html
@@ -1,7 +1,7 @@
 <div class="full-width-bg component homepage-content-band">
   <div class="grid-wrapper">
     <div class="grid__item width-4-12">
-      <img src="{{site.baseurl}}/assets/images/homepage-kube-native.svg">
+      <img src="{{site.baseurl}}/assets/images/homepage-kube-native.svg" alt="Illustration for Kube-Native: fast boot time and low memory in Kubernetes">
     </div>
     <div class="grid__item width-8-12">
       <h2>Kube-Native</h2>
@@ -20,14 +20,14 @@ Quarkus started in 0.008s</code></pre>
       <p><a href="/continuum">Learn more</a>></p>
     </div>
     <div class="grid__item width-4-12">
-      <img src="{{site.baseurl}}/assets/images/homepage-reactive.svg">
+      <img src="{{site.baseurl}}/assets/images/homepage-reactive.svg" alt="Illustration for Unifies Imperative and Reactive programming model">
     </div>
   </div>
 </div>
 <div class="full-width-bg component homepage-content-band">
   <div class="grid-wrapper">
     <div class="grid__item width-4-12">
-      <img src="{{site.baseurl}}/assets/images/homepage-standards.svg">
+      <img src="{{site.baseurl}}/assets/images/homepage-standards.svg" alt="Illustration for Community and Standards: best-of-breed libraries on a standard backbone">
     </div>
     <div class="grid__item width-8-12">
       <h2>Community and Standards</h2>
@@ -51,7 +51,7 @@ Quarkus started in 0.008s</code></pre>
       <p><a href="/developer-joy">Learn more</a>></p>
     </div>
     <div class="grid__item width-4-12">
-      <img src="{{site.baseurl}}/assets/images/homepage-developerjoy.svg">
+      <img src="{{site.baseurl}}/assets/images/homepage-developerjoy.svg" alt="Illustration for Developer Joy: unified config, live reload, and native executable generation">
     </div>
   </div>
 </div>

--- a/_includes/homepage-features-icon-band.html
+++ b/_includes/homepage-features-icon-band.html
@@ -6,38 +6,38 @@
   </div>
   <div class="grid-container">
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy.svg" alt="">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-developerjoy-dark.svg" alt="">
       <h3><a href="/developer-joy">Developer Joy</a></h3>
       <p>A cohesive platform for optimized developer joy with unified configuration and no hassle native executable generation. Zero config, live reload in the blink of an eye and streamlined code for the 80% common usages, flexible for the remainder 20%.</p>
     </div>
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/performance/icon-performance.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/performance/icon-performance-dark.svg">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/performance/icon-performance.svg" alt="">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/performance/icon-performance-dark.svg" alt="">
       <h3><a href="/performance">Performance</a></h3>
       <p>Quarkus streamlines framework optimizations in the build phase to reduce runtime dependencies and improve efficiency. By precomputing metadata and optimizing class loading, it ensures fast startup times for JVM and native binary deployments, cutting down on memory usage.</p>
     </div>
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg" alt="">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg" alt="">
       <h3><a href="/kubernetes-native">Kube-Native</a></h3>
       <p>The combination of Quarkus and Kubernetes provides an ideal environment for creating scalable, fast, and lightweight applications. Quarkus significantly increases developer productivity with tooling, pre-built integrations, application services, and more.</p>
     </div>
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg" alt="">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg" alt="">
       <h3><a href="/standards">Community and Standards</a></h3>
       <p>Quarkus provides a cohesive, fun to use, full-stack framework by leveraging a growing list of over fifty best-of-breed libraries that you love and use. All wired on a standard backbone.</p>
     </div>
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-versatility.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-versatility-dark.svg">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-versatility.svg" alt="">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-versatility-dark.svg" alt="">
       <h3><a href="/continuum">Reactive Core</a></h3>
       <p>Built on a robust reactive core, Quarkus ensures fast and efficient performance, supporting the development of a wide variety of modern applications.</p>
     </div>
     <div class="width-4-12 width-12-12-m contrib-block">
-      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst.svg">
-      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst-dark.svg">
+      <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst.svg" alt="">
+      <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-containerfirst-dark.svg" alt="">
       <h3><a href="/container-first">Container First</a></h3>
       <p>Quarkus tailors your application for GraalVM and HotSpot. Amazingly fast boot time, incredibly low RSS memory (not just heap size!) offering near instant scale up and high density memory utilization in container orchestration platforms like Kubernetes. We use a technique we call compile time boot.</p>
     </div>

--- a/_includes/homepage-hero-1kcontributors.html
+++ b/_includes/homepage-hero-1kcontributors.html
@@ -1,7 +1,7 @@
 <div class="grid-wrapper homepage-hero-band">
   <div class="grid__item width-3-12"></div>
   <div class="grid__item width-6-12 text-center">
-      <img src="{{site.baseurl}}/assets/images/1kcontributors/hero_1k_graphic.svg" class="project-logo" title="Quarkus Core reaches 1000 Contributors milestone">
+      <img src="{{site.baseurl}}/assets/images/1kcontributors/hero_1k_graphic.svg" class="project-logo" title="Quarkus Core reaches 1000 Contributors milestone" alt="Quarkus Core reaches 1000 Contributors milestone">
           <h2>Quarkus  Core repository has reached the incredible milestone of 1000 community contributors!</h2>
           <a href="{{site.baseurl}}/1000contributors/" class="button-cta">Celebrate with us</a>
           <p><a href="{{site.baseurl}}/get-started/">Get Started with Quarkus</a>&nbsp;|&nbsp;<a href="{{site.baseurl}}/guides/" >Read the Guides</a></p>

--- a/_includes/homepage-hero-newrelease-band.html
+++ b/_includes/homepage-hero-newrelease-band.html
@@ -3,7 +3,7 @@
   <div class="grid__item width-6-12 text-center">
     <h1>QUARKUS 3<br /> has launched.</h1>
       <h3>Quarkus 3 continues the mission of making Java the preferred framework for Kubernetes-native development with new developer tools and improved performance.</h3>
-      <img src="{{site.baseurl}}/assets/images/quarkus3/homeiconset.svg" class="project-logo" title="Quarkus 3.0 feature icons">
+      <img src="{{site.baseurl}}/assets/images/quarkus3/homeiconset.svg" class="project-logo" title="Quarkus 3.0 feature icons" alt="Quarkus 3.0 feature icons">
       <a href="{{site.baseurl}}/quarkus3/" class="button-cta">Learn More about 3</a>
   </div>
   <div class="grid__item width-12-12 homepage-hero-band-scroll">

--- a/_includes/homepage-userstory-callout.html
+++ b/_includes/homepage-userstory-callout.html
@@ -2,16 +2,16 @@
 <div class="full-width-bg component homepage-callout">
   <div class="grid-wrapper">
     <div class="grid__item width-3-12 width-12-12-m quote-image">
-     <a href="{{site.baseurl}}/blog/aviatar-experiences-significant-savings/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_lufthuansa.png"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_lufthuansa-dark.png"></a>
+     <a href="{{site.baseurl}}/blog/aviatar-experiences-significant-savings/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_lufthuansa.png" alt="Lufthansa Aviatar user story"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_lufthuansa-dark.png" alt="Lufthansa Aviatar user story"></a>
     </div>
     <div class="grid__item width-3-12 width-12-12-m quote-image">
-     <a href="{{site.baseurl}}/blog/logicdrop-customer-story/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_logicdrop.png"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_logicdrop-dark.png"></a>
+     <a href="{{site.baseurl}}/blog/logicdrop-customer-story/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_logicdrop.png" alt="Logicdrop user story"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_logicdrop-dark.png" alt="Logicdrop user story"></a>
     </div>
     <div class="grid__item width-3-12 width-12-12-m quote-image">
-     <a href="{{site.baseurl}}/blog/banco-do-brasil-open-banking-user-story/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_bancodobrasil.png"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_bancodobrasil-dark.png"></a>
+     <a href="{{site.baseurl}}/blog/banco-do-brasil-open-banking-user-story/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_bancodobrasil.png" alt="Banco do Brasil open banking user story"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_bancodobrasil-dark.png" alt="Banco do Brasil open banking user story"></a>
     </div>
     <div class="grid__item width-3-12 width-12-12-m quote-image">
-     <a href="{{site.baseurl}}/blog/adoptium-customer-story/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_adoptium.png"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_adoptium-dark.png"></a>
+     <a href="{{site.baseurl}}/blog/adoptium-customer-story/"><img class="light-only" src="{{site.baseurl}}/assets/images/home/userstories_adoptium.png" alt="Adoptium user story"><img class="dark-only" src="{{site.baseurl}}/assets/images/home/userstories_adoptium-dark.png" alt="Adoptium user story"></a>
     </div>
   </div>
   <div class="grid-wrapper quote-spacer">

--- a/_includes/homepage-worldtour-band.html
+++ b/_includes/homepage-worldtour-band.html
@@ -1,7 +1,7 @@
 <div class="full-width-bg component alt-background">
   <div class="grid-wrapper">
     <div class="width-7-12 width-12-12-m block-image justify-self-center">
-      <a href="/worldtour/"><img src="{{site.baseurl}}/assets/images/worldtour/2023/homepage_worldtour.png" class="img-md"></a>
+      <a href="/worldtour/"><img src="{{site.baseurl}}/assets/images/worldtour/2023/homepage_worldtour.png" class="img-md" alt="Quarkus World Tour 2023 promotional banner"></a>
     </div>
     <div class="grid__item width-5-12 width-12-12-m">
       <h2>Quarkus World Tour 2023</h2>

--- a/_includes/kubernetes-native.html
+++ b/_includes/kubernetes-native.html
@@ -1,8 +1,8 @@
 <div class="full-width-bg component">
   <div class="grid-wrapper">
     <div class="width-3-12 width-12-12-m">
-    <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg">
-    <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native.svg" alt="">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-kube-native-dark.svg" alt="">
     </div>
     <div class="width-9-12 width-12-12-m">
       <p class="intropara">The combination of Quarkus and Kubernetes provides an ideal environment for creating scalable, fast, and lightweight applications. Quarkus significantly increases developer productivity with tooling, pre-built integrations, application services, and more.

--- a/_includes/project-footer.html
+++ b/_includes/project-footer.html
@@ -1,7 +1,7 @@
 <div class="content project-footer">
   <div class="footer-section">
     <div class="logo-wrapper">
-      <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_reverse.svg" class="project-logo" title="Quarkus"></a>
+      <a href="{{site.baseurl}}/"><img src="{{site.baseurl}}/assets/images/quarkus_logo_horizontal_rgb_reverse.svg" class="project-logo" title="Quarkus" alt="Quarkus"></a>
     </div>
   </div>
   <div class="grid-wrapper">

--- a/_includes/recent-posts-band.html
+++ b/_includes/recent-posts-band.html
@@ -32,7 +32,7 @@
                 {% assign author = site.data.authors[author_key] %}
                 {% if author.emailhash %}
                 <div>
-                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}" alt="{{ author.name }} avatar">
                 </div>
                 {% endif %}
                 <div>

--- a/_includes/standards.html
+++ b/_includes/standards.html
@@ -1,8 +1,8 @@
 <div class="full-width-bg component">
   <div class="grid-wrapper">
     <div class="width-3-12 width-12-12-m">
-    <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg">
-    <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/about/icon-standards.svg" alt="">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/about/icon-standards-dark.svg" alt="">
     </div>
     <div class="width-9-12 width-12-12-m">
         <p class="intropara"> We don’t want you to spend hours learning new technologies. Instead, the Quarkus programming model builds on top of proven standards. Be it official standards such as Eclipse MicroProfile or leading frameworks in a specific domain such as Eclipse Vert.x.</p>
@@ -16,7 +16,7 @@
 
   <div class="grid-wrapper center">
     <div class="width-3-12 width-12-12-m">
-      <a href="https://jakarta.ee"><img src="{{site.baseurl}}/assets/images/about/jakarta.svg"></a>
+      <a href="https://jakarta.ee"><img src="{{site.baseurl}}/assets/images/about/jakarta.svg" alt="Jakarta EE logo"></a>
     </div>
     <div class="width-9-12 width-12-12-m">
       <br><a href="https://jakarta.ee/specifications/coreprofile/">Jakarta Core 10</a>
@@ -39,7 +39,7 @@
       <a href="https://microprofile.io">
         <picture>
           <source srcset="{{site.baseurl}}/assets/images/about/microprofile-dark.svg" media="(prefers-color-scheme:dark)">
-            <img src="{{site.baseurl}}/assets/images/about/microprofile.svg">
+            <img src="{{site.baseurl}}/assets/images/about/microprofile.svg" alt="Eclipse MicroProfile logo">
           </picture>
         </a>
     </div>
@@ -63,7 +63,7 @@
 
   <div class="grid-wrapper center">
     <div class="width-3-12 width-12-12-m">
-      <a href="https://opentelemetry.io"><img src="{{site.baseurl}}/assets/images/about/opentelemetry.svg"></a>
+      <a href="https://opentelemetry.io"><img src="{{site.baseurl}}/assets/images/about/opentelemetry.svg" alt="OpenTelemetry logo"></a>
     </div>
     <div class="width-9-12 width-12-12-m">
       <a href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/trace">OpenTelemetry Trace 1.39</a>

--- a/_includes/sticker-band.html
+++ b/_includes/sticker-band.html
@@ -5,87 +5,87 @@
 </div>
 <div class="component-wrapper contributions-band">
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_vertical.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_vertical.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_vertical.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_vertical.png" alt="Quarkus logo vertical sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_vertical.pdf">Vertical Logo Sticker</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_horizontal.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_horizontal.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_horizontal.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_horizontal.png" alt="Quarkus logo horizontal sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_horizontal.pdf">Horizontal Logo Sticker</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_hex_light.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_hex_light.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_hex_light.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_hex_light.png" alt="Quarkus logo hexagon light sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_hex_light.pdf">Hex Logo Sticker - Light</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_hex-dark.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_hex_dark.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_hex-dark.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_hex_dark.png" alt="Quarkus logo hexagon dark sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_logo_hex-dark.pdf">Hex Logo Sticker - Dark</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_icon_hex_light.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_icon_hex_light.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_icon_hex_light.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_icon_hex_light.png" alt="Quarkus icon hexagon light sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_icon_hex_light.pdf">Hex Icon Sticker - Light</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_icon_hex-dark.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_icon_hex_dark.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_icon_hex-dark.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_icon_hex_dark.png" alt="Quarkus icon hexagon dark sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_icon_hex-dark.pdf">Hex Icon Sticker - Dark</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_motto.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_motto.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_motto.pdf"><img src="{{site.baseurl}}/assets/images/stickers/sticker_logo_motto.png" alt="Quarkus logo with motto sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkus_motto.pdf">Supersonic Subatomic Java</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/sticker_3x3_cartoon.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_3x3_cartoon.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/sticker_3x3_cartoon.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_3x3_cartoon.png" alt="Quarkus cartoon sticker sheet preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/sticker_3x3_cartoon.pdf">Supersonic Cartoon</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkusbot.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_quarkusbot.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_quarkusbot.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_quarkusbot.png" alt="Quarkus Bot character sticker preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_quarkusbot.pdf">Quarkus Github Bot</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar1.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar1.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar1.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar1.png" alt="Rocking Duke guitar sticker variant 1 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar1.pdf">Rocking Duke - Guitar 1</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar2.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar2.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar2.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar2.png" alt="Rocking Duke guitar sticker variant 2 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar2.pdf">Rocking Duke - Guitar 2</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar3.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar3.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar3.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar3.png" alt="Rocking Duke guitar sticker variant 3 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar3.pdf">Rocking Duke - Guitar 3</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar4.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar4.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar4.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar4.png" alt="Rocking Duke guitar sticker variant 4 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar4.pdf">Rocking Duke - Guitar 4</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar5.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar5.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar5.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar5.png" alt="Rocking Duke guitar sticker variant 5 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar5.pdf">Rocking Duke - Guitar 5</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar6.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar6.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar6.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar6.png" alt="Rocking Duke guitar sticker variant 6 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar6.pdf">Rocking Duke - Guitar 6</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_bass1.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_bass1.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_bass1.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_bass1.png" alt="Rocking Duke bass guitar sticker variant 1 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_bass1.pdf">Rocking Duke - Bass 1</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_bass2.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_bass2.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_bass2.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_bass2.png" alt="Rocking Duke bass guitar sticker variant 2 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_bass2.pdf">Rocking Duke - Bass 2</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar7.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar7.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar7.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar7.png" alt="Rocking Duke guitar sticker variant 7 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar7.pdf">Rocking Duke - Guitar 7</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar8.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar8.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar8.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar8.png" alt="Rocking Duke guitar sticker variant 8 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar8.pdf">Rocking Duke - Guitar 8</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar9.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar9.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar9.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar9.png" alt="Rocking Duke guitar sticker variant 9 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar9.pdf">Rocking Duke - Guitar 9</a></h4>
   </div>
   <div class="width-3-12 width-6-12-m contrib-block">
-    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar10.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar10.png"></a>
+    <a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar10.pdf"><img src="{{site.baseurl}}/assets/images/stickers/stickers_rockingduke_guitar10.png" alt="Rocking Duke guitar sticker variant 10 preview"></a>
     <h4><a href="{{site.baseurl}}/assets/stickers/stickers_rockingduke_guitar10.pdf">Rocking Duke - Guitar 10</a></h4>
   </div>
 </div>

--- a/_includes/support-help-band.html
+++ b/_includes/support-help-band.html
@@ -3,31 +3,31 @@
     <h3>Getting Help from the Community</h3>
   </div>
   <div class="width-4-12 width-12-12-m help-block">
-    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-documentation.svg">
-    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-documentation-dark.svg">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-documentation.svg" alt="">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-documentation-dark.svg" alt="">
     <h4>Documentation</h4>
     <p>We have a lot of documentation. Be sure to check our <a href="{{site.baseurl}}/get-started/">Getting started page</a>, and all our <a href="{{site.baseurl}}/guides/">guides</a>. Also check out our <a href="{{site.baseurl}}/faq/">FAQ section</a> and <a href="https://www.youtube.com/playlist?list=PLsM3ZE5tGAVbMz1LJqc8L5LpnfxPPKloO" target="blank">Quarkus Tips Playlist</a>.</p>
   </div>
   <div class="width-4-12 width-12-12-m help-block">
-    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-stackoverflow.svg">
-    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-stackoverflow-dark.svg">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-stackoverflow.svg" alt="">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-stackoverflow-dark.svg" alt="">
     <h4>Stack Overflow</h4>
     <p>Ask your questions on <a href="https://stackoverflow.com/questions/tagged/quarkus" target="blank">Stack Overflow</a>. After the documentation, it’s probably the best place to look for answers. We actively monitor the <a href="https://stackoverflow.com/questions/tagged/quarkus" target="blank">Quarkus tag</a>.</p>
   </div>
   <div class="width-4-12 width-12-12-m help-block">
-    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-discussion.svg">
-    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-discussion-dark.svg">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-discussion.svg" alt="">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-discussion-dark.svg" alt="">
    <h4>Discussions and Collaboration</h4>
     <p>Check out our <a href="https://github.com/quarkusio/quarkus/discussions" target="blank">GitHub Discussions</a> collaboration area to interact with other Quarkus users and developers.</p>
   </div>
   <div class="width-4-12 width-12-12-m help-block">
-    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-callcalendar.svg">
-    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-callcalendar-dark.svg">
+    <img class="light-only" src="{{site.baseurl}}/assets/images/icons/icon-callcalendar.svg" alt="">
+    <img class="dark-only" src="{{site.baseurl}}/assets/images/icons/icon-callcalendar-dark.svg" alt="">
     <h4>Community Call</h4>
     <p>We host a biweekly Quarkus Community Call at 2PM (Paris time) to discuss technical topics and project updates. To attend, <a href="https://calendar.google.com/calendar/embed?src=935090aaae38be35eda437d018782b7827f3770f7a0344013677acd861570b20%40group.calendar.google.com&ctz=Europe%2FParis" target="blank">view the calendar</a> or <a href="https://calendar.google.com/calendar/ical/935090aaae38be35eda437d018782b7827f3770f7a0344013677acd861570b20%40group.calendar.google.com/public/basic.ics">subscribe (iCal)</a> to the calendar so you don't miss one. The calls are posted to Youtube you can view the <a href="https://www.youtube.com/playlist?list=PLsM3ZE5tGAVZ_rG48SFUFpEyTYGai0YLw" target="blank">Community Call Playlist</a> to access all of the calls.</p>
   </div>
   <div class="width-4-12 width-12-12-m help-block">
-    <img src="{{site.baseurl}}/assets/images/icons/icon-development.svg">
+    <img src="{{site.baseurl}}/assets/images/icons/icon-development.svg" alt="">
     <h4>Quarkus Development</h4>
     <p>Discuss the development of Quarkus with the team in the <a href="mailto:quarkus-dev+subscribe@googlegroups.com">development mailing list </a> or by <a href="https://quarkusio.zulipchat.com/" target="blank">Zulip Chat</a>.</p>
   </div>

--- a/_includes/userstories-band.html
+++ b/_includes/userstories-band.html
@@ -9,7 +9,7 @@
         <a href="{{site.baseurl}}{{ post.url }}"></a>
         <div>
           {% if post.thumbnailimage %}
-            <img src="{{ post.thumbnailimage }}">
+            <img src="{{ post.thumbnailimage }}" alt="{{ post.title }}">
           {% endif %}          
           <p class="title">{{ post.title }}</p>
           <div class="description">

--- a/_includes/worldtour-graphics.html
+++ b/_includes/worldtour-graphics.html
@@ -5,19 +5,19 @@
       <h3 class="mt-0">World Tour Logos</h3>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_2024.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_2024.png" alt="Quarkus World Tour 2024 logo">
       <p class="mt-0">Primary World Tour Logo with Year</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_primary.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_primary.png" alt="Quarkus World Tour 2024 logo – primary color variant">
       <p class="mt-0">Secondary World Tour Logo Primary</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_secondary.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_secondary.png" alt="Quarkus World Tour 2024 logo – secondary color variant">
       <p class="mt-0">Secondary World Tour Icon Element</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_combined.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/worldtourlogo2024_combined.png" alt="Quarkus World Tour 2024 logo – combined color variant">
       <p class="mt-0">Secondary World Tour Combined</p>
     </div>
   </div>
@@ -30,57 +30,57 @@
       <h4 class="mt-0">X Post Images (sized at 1024x512 pixels)</h4>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_willrock.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_willrock.png" alt="Quarkus World Tour X post graphic – Will Rock variant">
       <p class="mt-0">X Post Image: "The QWT will rock your JUG!"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_rockingduke.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_rockingduke.png" alt="Quarkus World Tour X post graphic – Rocking Duke variant">
       <p class="mt-0">X Post Image: Rocking Duke</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_iscoming.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_iscoming.png" alt="Quarkus World Tour X post graphic – Is Coming variant">
       <p class="mt-0">X Post Image: "Is Coming"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_arch.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Twitter_1024x512_arch.png" alt="Quarkus World Tour X post graphic – QWT logo variant">
       <p class="mt-0">X Post Image: QTW logo</p>
     </div>
     <div class="width-12-12 width-12-12-m">
       <h4 class="mt-0">Facebook Post Images (sized at 1200x628 pixels)</h4>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_willrock.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_willrock.png" alt="Quarkus World Tour Facebook post graphic – Will Rock variant">
       <p class="mt-0">Facebook Post Image: "The QWT will rock your JUG!"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_rockingduke.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_rockingduke.png" alt="Quarkus World Tour Facebook post graphic – Rocking Duke variant">
       <p class="mt-0">Facebook Post Image: Rocking Duke</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_iscoming.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_iscoming.png" alt="Quarkus World Tour Facebook post graphic – Is Coming variant">
       <p class="mt-0">Facebook Post Image: "Is Coming"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_arch.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_Facebook_1200x628_arch.png" alt="Quarkus World Tour Facebook post graphic – QWT logo variant">
       <p class="mt-0">Facebook Post Image: QTW logo</p>
     </div>
     <div class="width-12-12 width-12-12-m">
       <h4 class="mt-0">Meetup Post Images (sized at 1200x675 pixels)</h4>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_willrock.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_willrock.png" alt="Quarkus World Tour Meetup post graphic – Will Rock variant">
       <p class="mt-0">Meetup Post Image: "The QWT will rock your JUG!"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_rockingduke.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_rockingduke.png" alt="Quarkus World Tour Meetup post graphic – Rocking Duke variant">
       <p class="mt-0">Meetup Post Image: Rocking Duke</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_iscoming.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_iscoming.png" alt="Quarkus World Tour Meetup post graphic – Is Coming variant">
       <p class="mt-0">Meetup Post Image: "Is Coming"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_arch.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_meetup_1200x675_arch.png" alt="Quarkus World Tour Meetup post graphic – QWT logo variant">
       <p class="mt-0">Meetup Post Image: QTW logo</p>
     </div>
 
@@ -88,19 +88,19 @@
       <h4 class="mt-0">Linkedin Post Images (sized at 1104x736 pixels)</h4>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_willrock.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_willrock.png" alt="Quarkus World Tour LinkedIn post graphic – Will Rock variant">
       <p class="mt-0">Linkedin Post Image: "The QWT will rock your JUG!"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_rockingdude.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_rockingdude.png" alt="Quarkus World Tour LinkedIn post graphic – Rocking Duke variant">
       <p class="mt-0">Linkedin Post Image: Rocking Duke</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_iscoming.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_iscoming.png" alt="Quarkus World Tour LinkedIn post graphic – Is Coming variant">
       <p class="mt-0">Facebook Post Image: "Is Coming"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_arch.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_LinkedIn_1104x736_arch.png" alt="Quarkus World Tour LinkedIn post graphic – QWT logo variant">
       <p class="mt-0">Linkedin Post Image: QTW logo</p>
     </div>
 
@@ -108,19 +108,19 @@
       <h4 class="mt-0">Mastadon Post Images (sized at 1280x1280 pixels)</h4>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_willrock.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_willrock.png" alt="Quarkus World Tour Mastodon post graphic – Will Rock variant">
       <p class="mt-0">Mastadon Post Image: "The QWT will rock your JUG!"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_rockingdude.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_rockingdude.png" alt="Quarkus World Tour Mastodon post graphic – Rocking Duke variant">
       <p class="mt-0">Mastadon Post Image: Rocking Duke</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_iscoming.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_iscoming.png" alt="Quarkus World Tour Mastodon post graphic – Is Coming variant">
       <p class="mt-0">Facebook Post Image: "Is Coming"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_arch.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_mastadon_1280x1280_arch.png" alt="Quarkus World Tour Mastodon post graphic – QWT logo variant">
       <p class="mt-0">Mastadon Post Image: QTW logo</p>
     </div>
 
@@ -128,19 +128,19 @@
       <h4 class="mt-0">Threads Post Images (sized at 1080x1080 pixels)</h4>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_willrock.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_willrock.png" alt="Quarkus World Tour Threads post graphic – Will Rock variant">
       <p class="mt-0">Threads Post Image: "The QWT will rock your JUG!"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_rockingdude.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_rockingdude.png" alt="Quarkus World Tour Threads post graphic – Rocking Duke variant">
       <p class="mt-0">Threads Post Image: Rocking Duke</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_iscoming.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_iscoming.png" alt="Quarkus World Tour Threads post graphic – Is Coming variant">
       <p class="mt-0">Facebook Post Image: "Is Coming"</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_arch.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/social/QWT_social_threads_1080x1080_arch.png" alt="Quarkus World Tour Threads post graphic – QWT logo variant">
       <p class="mt-0">Threads Post Image: QTW logo</p>
     </div>
 
@@ -159,15 +159,15 @@
     </div>
 
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_baselight.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_baselight.png" alt="Quarkus World Tour slide background – light base">
       <p class="mt-0">Base Content Light</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_basedark.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_basedark.png" alt="Quarkus World Tour slide background – dark base">
       <p class="mt-0">Base Content Dark</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_basegradient.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_basegradient.png" alt="Quarkus World Tour slide background – gradient base">
       <p class="mt-0">Base Content Gradient</p>
     </div>
 
@@ -176,43 +176,43 @@
       <p>These should be used as the first slide of your presentation.</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide1_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide1_title.png" alt="Quarkus World Tour title slide 1 background – Guitar">
       <p class="mt-0">Title Slide - Guitar</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide2_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide2_title.png" alt="Quarkus World Tour title slide 2 background – Stage Lights">
       <p class="mt-0">Title Slide - Stage Lights</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide3_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide3_title.png" alt="Quarkus World Tour title slide 3 background – Crowd Surfing">
       <p class="mt-0">Title Slide - Crowd Surfing</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide4_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide4_title.png" alt="Quarkus World Tour title slide 4 background – Drum Kit">
       <p class="mt-0">Title Slide - Drum Kit</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide5_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide5_title.png" alt="Quarkus World Tour title slide 5 background – Guitar Neck">
       <p class="mt-0">Title Slide - Guitar Neck</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide6_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide6_title.png" alt="Quarkus World Tour title slide 6 background – Guitarist on Stage">
       <p class="mt-0">Title Slide - Guitarist on Stage</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide7_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide7_title.png" alt="Quarkus World Tour title slide 7 background – Speaker Wall">
       <p class="mt-0">Title Slide - Speaker Wall</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide8_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide8_title.png" alt="Quarkus World Tour title slide 8 background – Gradient">
       <p class="mt-0">Title Slide - Gradient</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide9_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide9_title.png" alt="Quarkus World Tour title slide 9 background – Disco">
       <p class="mt-0">Title Slide - Disco</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide10_title.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide10_title.png" alt="Quarkus World Tour title slide 10 background – DJ">
       <p class="mt-0">Title Slide - DJ</p>
     </div>
 
@@ -222,43 +222,43 @@
     </div>
 
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide1.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide1.png" alt="Quarkus World Tour callout slide 1 background – Guitar">
       <p class="mt-0">Callout Slide - Guitar</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide2.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide2.png" alt="Quarkus World Tour callout slide 2 background – Stage Lights">
       <p class="mt-0">Callout Slide - Stage Lights</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide3.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide3.png" alt="Quarkus World Tour callout slide 3 background – Crowd Surfing">
       <p class="mt-0">Callout Slide - Crowd Surfing</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide4.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide4.png" alt="Quarkus World Tour callout slide 4 background – Drum Kit">
       <p class="mt-0">Callout Slide - Drum Kit</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide5.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide5.png" alt="Quarkus World Tour callout slide 5 background – Guitar Neck">
       <p class="mt-0">Callout Slide - Guitar Neck</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide6.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide6.png" alt="Quarkus World Tour callout slide 6 background – Guitarist on Stage">
       <p class="mt-0">Callout Slide - Guitarist on Stage</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide7.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide7.png" alt="Quarkus World Tour callout slide 7 background – Speaker Wall">
       <p class="mt-0">Callout Slide - Speaker Wall</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide8.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide8.png" alt="Quarkus World Tour callout slide 8 background – Gradient">
       <p class="mt-0">Callout Slide - Gradient</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide9.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide9.png" alt="Quarkus World Tour callout slide 9 background – Disco">
       <p class="mt-0">Callout Slide - Disco</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide10.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_bkg_slide10.png" alt="Quarkus World Tour callout slide 10 background – DJ">
       <p class="mt-0">Callout Slide - DJ</p>
     </div>
     <div class="width-12-12 width-12-12-m">
@@ -267,15 +267,15 @@
     </div>
 
     <div class="width-3-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_element_QA.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_element_QA.png" alt="Quarkus World Tour Q&amp;A slide element">
       <p class="mt-0">"Q&A" graphic</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img class="bkg-grey" src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_element_rockon.png" >
+      <img class="bkg-grey" src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_element_rockon.png" alt="Quarkus World Tour Rock On slide element">
       <p class="mt-0">"Rock On!" graphic</p>
     </div>
     <div class="width-3-12 width-12-12-m">
-      <img class="bkg-grey" src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_element_quarkuslogowhite.png">
+      <img class="bkg-grey" src="{{site.baseurl}}/assets/images/worldtour/2024/slidebkg/worldtour_element_quarkuslogowhite.png" alt="Quarkus logo white slide element">
       <p class="mt-0">White Quarkus Logo graphic</p>
     </div> 
   </div>

--- a/_includes/worldtour-hero.html
+++ b/_includes/worldtour-hero.html
@@ -1,3 +1,3 @@
 <div class="full-width-imgbkg black">
-      <img src="{{site.baseurl}}/assets/images/worldtour/hero_worldtour.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/hero_worldtour.png" alt="Quarkus World Tour hero banner">
 </div>

--- a/_includes/worldtour.html
+++ b/_includes/worldtour.html
@@ -13,7 +13,7 @@
       <p>Keep rocking the Java world!</p>
     </div>
     <div class="width-6-12 width-12-12-m">
-      <img src="{{site.baseurl}}/assets/images/worldtour/worldtour_swag.png">
+      <img src="{{site.baseurl}}/assets/images/worldtour/worldtour_swag.png" alt="Quarkus World Tour swag items">
         <h3>Want a tour stop at your JUG?</h3>
         <p>Interested in having the Quarkus Tour come through your local Java User Group? Contact us today to get more details and make it happen.</p>
       <a href="https://github.com/quarkusio/quarkus/discussions" class="button-cta">Get a tour stop</a>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -21,7 +21,7 @@ layout: base
   <div class="grid__item width-9-12 width-12-12-m">
     <h2 class="title byline-wrapper">
       {% if author_data.emailhash %}
-      <img class="headshot" src="https://www.gravatar.com/avatar/{{ author_data.emailhash }}">
+      <img class="headshot" src="https://www.gravatar.com/avatar/{{ author_data.emailhash }}" alt="{{ author_data.name }} avatar">
       {% endif %}
       <p class="byline">
         {{ author_data.name }} {% if author_data.twitter %}(<a href="https://twitter.com/{{ author_data.twitter }}">@{{ author_data.twitter }}</a>){% endif %}
@@ -66,7 +66,7 @@ layout: base
           {% for author_key in authors_clean %}
             {% assign author = site.data.authors[author_key] %}
             {% if author.emailhash %}
-              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}" alt="{{ author.name }} avatar">
             {% endif %}
             <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>
             {% unless forloop.last %}, {% endunless %}

--- a/_layouts/feature.html
+++ b/_layouts/feature.html
@@ -7,8 +7,8 @@ layout: base
 <div class="full-width-bg component">
     <div class="grid-wrapper">
         <div class="width-3-12 width-12-12-m">
-            <img class="light-only" src="{{site.baseurl}}/{{ page.icon-light }}"/>
-            <img class="dark-only" src="{{site.baseurl}}/{{ page.icon-dark }}"/>
+            <img class="light-only" src="{{site.baseurl}}/{{ page.icon-light }}" alt="{{ page.title }} icon"/>
+            <img class="dark-only" src="{{site.baseurl}}/{{ page.icon-dark }}" alt="{{ page.title }} icon"/>
         </div>
         <div class="width-9-12 width-12-12-m">
             <p class="intropara">{{ page.intro }}</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,7 +37,7 @@ layout: base
                 {% assign author_key = author_key_raw | strip %}
                 {% assign author = site.data.authors[author_key] %}
                 {% if author.emailhash %}
-                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+                  <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}" alt="{{ author.name }} avatar">
                 {% endif %}
                   <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>
                   {% unless forloop.last %}, {% endunless %}

--- a/_layouts/quarkus2.html
+++ b/_layouts/quarkus2.html
@@ -11,12 +11,12 @@ layout: base
           <h2>Framework Efficiency</h2>
           <p>Quarkus makes Java supersonic, subatomic with fast startup times and low memory footprint. This release continues that mission with an upgrade to <a href="https://vertx.io/blog/whats-new-in-vert-x-4/" target="_blank">Vert.x 4</a> to improve the user experience and performance.</p>
         </div>
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/frameworkefficiency.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/frameworkefficiency.png" alt="Quarkus framework efficiency illustration"> </div>
       </div>
     </div>
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/developerservices.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/developerservices.png" alt="Quarkus developer services illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Developer Productivity</h2>
           <p>One of the founding principles of Quarkus is to bring joy to Java developers through a combination of tools, libraries, extensions, and more. This release continues that mission by making developers more efficient with the new continuous testing capability.</p>
@@ -29,12 +29,12 @@ layout: base
           <h2>Kube-Native</h2>
           <p>Quarkus enables Java developers to create applications that are easily deployed and maintained on Kubernetes. This release includes support for <a href="https://projects.eclipse.org/projects/technology.microprofile/releases/4.0" target="_blank">Eclipse Microprofile 4</a>.</p>
         </div>
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/kubenative.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/kubenative.png" alt="Quarkus Kubernetes-native illustration"> </div>
       </div>
     </div>
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/communitystandards.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/communitystandards.png" alt="Quarkus community and standards illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Community & Standards</h2>
           <p>Quarkus starts and ends with the community. This is a milestone release in the maturity of the project with over 470 contributors adding to its success. Starting with 2.0, JDK 11 will now be the minimal version.</p>
@@ -48,7 +48,7 @@ layout: base
         <h2>Migrating to 2.0</h2>
         <p>The Quarkus community has created a <a href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0" target="_blank">Migration Guide 2.0</a> guide to make it easy for you to take advantage of all these great features.</p>
       </div>
-      <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/migration.png"> </div>
+      <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus2/migration.png" alt="Quarkus migration guide illustration"> </div>
     </div>
     <h2>Release Notes</h2>
     <p>For more in-depth dive into the details of the 2.0 release, <a href="https://quarkus.io/blog/quarkus-2-0-0-final-released/" target="_blank">check out the Quarkus 2.0 Release Notes</a></p>

--- a/_layouts/quarkus3.html
+++ b/_layouts/quarkus3.html
@@ -7,7 +7,7 @@ layout: base
   <div class="component-wrapper highlights-alternating-images-band">
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/frameworkefficiency.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/frameworkefficiency.png" alt="Quarkus framework efficiency illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Performance & Efficiency</h2>
           <p>Quarkus makes Java supersonic and subatomic, with fast startup times, low memory footprint, and a small disk footprint. This release continues to improve the Quarkus framework's performance and efficiency.</p>
@@ -20,7 +20,7 @@ layout: base
     </div>
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/developerservices.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/developerservices.png" alt="Quarkus developer services illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Developer Productivity</h2>
           <p>One of the founding principles of Quarkus is to bring joy to Java developers by creating a frictionless experience through a combination of tools, libraries, extensions, and more. This release continues that mission by making developers more efficient with new tools and services such as Dev UI, Quarkus CLI, and PACT contract testing.</p>
@@ -38,7 +38,7 @@ layout: base
     </div>
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/kubenative.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/kubenative.png" alt="Quarkus Kubernetes-native illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Kubernetes-Native</h2>
           <p>Quarkus enables Java developers to create performant, easily deployable, and maintainable applications on Kubernetes. This release includes a number of impactful Kubernetes-native features including new Dev Services for Kubernetes deployments.</p>
@@ -49,7 +49,7 @@ layout: base
     </div>
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/communitystandards.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/communitystandards.png" alt="Quarkus community and standards illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Community & Standards</h2>
           <p>Quarkus starts and ends with the community which includes a vast ecosystem of 400+ extensions that includes support for popular Java APIs and standards. This release continues that mission with new features and standards support.</p>
@@ -64,7 +64,7 @@ layout: base
     </div>
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/longtermsupport.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/longtermsupport.png" alt="Quarkus long-term support illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Long-term Support (LTS)</h2>
           <p>The community asked, so we’ve delivered. Starting with Quarkus 3.2, we introduced the first Quarkus LTS version. Learn more about the <a href="https://quarkus.io/blog/quarkus-3-20-0-released/">3.20 LTS release</a> and about our <a href="https://quarkus.io/blog/lts-releases/">LTS policies</a>.</p>
@@ -73,7 +73,7 @@ layout: base
     </div>
     <div class="width-12-12 highlights-alternating-inline-block">
       <div class="grid-wrapper">
-        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/migration.png"> </div>
+        <div class="width-4-12 width-12-12-m block-image"> <img src="{{site.baseurl}}/assets/images/quarkus3/migration.png" alt="Quarkus migration guide illustration"> </div>
         <div class="width-8-12 width-12-12-m block-content">
           <h2>Migrating to 3.0 is super easy</h2>
           <p>We want to make the migration to Quarkus 3 seamless for our users. With that in mind, we have created a <a href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0">migration guide</a> as well as tooling to facilitate this process.</p>

--- a/_layouts/tag-archive.html
+++ b/_layouts/tag-archive.html
@@ -45,7 +45,7 @@ layout: base
           {% for author_key in authors_clean %}
             {% assign author = site.data.authors[author_key] %}
             {% if author.emailhash %}
-              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}">
+              <img class="headshot" src="https://www.gravatar.com/avatar/{{ author.emailhash }}" alt="{{ author.name }} avatar">
             {% endif %}
               <a href="{{ site.baseurl }}/author/{{ author_key }}">{{ author.name }}</a>
               {% unless forloop.last %}, {% endunless %}


### PR DESCRIPTION
Based on the lighthouse report on website performance, I've used Bob to help find and correct missing alt tag elements.

1) Some blank alt tags are blank so they will be skipped by screen readers. This will prevent redundancy in the reader... " "Developer Joy icon, Developer Joy" as the heading immediately duplicates the alt.

2) Some of the changes affect includes that aren't currently in use. I haven't removed them as they maybe the basis for future content.

