### PR TITLE
fix_asciidoc_syntaxerror

### DIFF
--- a/_posts/2026-05-12-quarkus-insights-247-agentic-orchestration.adoc
+++ b/_posts/2026-05-12-quarkus-insights-247-agentic-orchestration.adoc
@@ -9,7 +9,7 @@ author: jcobb
 
 This summary was generated using AI, reviewed by humans - https://youtube.com/live/oX2GP7D28DE[watch the video] for the full story.
 
-= Quarkus Insights #247: Agentic Orchestration with LangChain4j and Kubernetes
+== Quarkus Insights #247: Agentic Orchestration with LangChain4j and Kubernetes
 
 In episode 247 of Quarkus Insights, https://www.linkedin.com/in/javajon/[Jonathan Johnson], an independent software architect and adjunct professor at https://www.trincoll.edu/[Trinity College] (Connecticut), shared his innovative work on distributed agentic AI systems running on https://kubernetes.io/[Kubernetes] with https://quarkus.io/[Quarkus] and https://docs.langchain4j.dev/[LangChain4j].
 

--- a/_posts/2026-05-19-quarkus-insights-248-ddd-hexagonal-architecture.adoc
+++ b/_posts/2026-05-19-quarkus-insights-248-ddd-hexagonal-architecture.adoc
@@ -9,7 +9,7 @@ author: jcobb
 
 This summary was generated using AI, reviewed by humans - https://youtube.com/live/2PnZ1zzuWn0[watch the video] for the full story.
 
-= Quarkus Insights #248: Introduction to Domain-Driven Design and Hexagonal Architecture
+== Quarkus Insights #248: Introduction to Domain-Driven Design and Hexagonal Architecture
 
 In episode 248 of Quarkus Insights, https://www.linkedin.com/in/jeremyrdavis/[Jeremy Davis], a Solutions Architect with extensive experience in the JBoss ecosystem, provided an in-depth introduction to https://martinfowler.com/bliki/DomainDrivenDesign.html[Domain-Driven Design (DDD)] and Hexagonal Architecture using https://quarkus.io/[Quarkus].
 

--- a/_posts/2026-06-08-quarkus-insights-250-quarkus-data.adoc
+++ b/_posts/2026-06-08-quarkus-insights-250-quarkus-data.adoc
@@ -9,7 +9,7 @@ author: jcobb
 
 This summary was generated using AI, reviewed by humans - https://youtube.com/live/E_5rSjAD-k0[watch the video] for the full story.
 
-= Quarkus Insights #250: What''s New with Quarkus Data
+== Quarkus Insights #250: What''s New with Quarkus Data
 
 Episode 250 of Quarkus Insights focused on one of the longer-running efforts in the Quarkus data layer: the work formerly known as “Panache 2”, then “Panache Next”, and now Quarkus Data. Stephane Épardaud joined the show to explain why the rename matters, what problems this new API is trying to solve, and how it brings together ideas from https://jakarta.ee/specifications/data/[Jakarta Data], https://hibernate.org/orm/[Hibernate ORM], https://hibernate.org/reactive/[Hibernate Reactive], and eventually https://www.mongodb.com/[MongoDB] under a more consistent programming model.
 

--- a/_posts/2026-06-16-quarkus-insights-251-semeru-openj9.adoc
+++ b/_posts/2026-06-16-quarkus-insights-251-semeru-openj9.adoc
@@ -9,7 +9,7 @@ author: jcobb
 
 This summary was generated using AI, reviewed by humans - https://youtube.com/live/ql0wK79DxtY[watch the video] for the full story.
 
-= Quarkus Insights #251: Faster Startup with IBM Semeru Runtimes and OpenJ9
+== Quarkus Insights #251: Faster Startup with IBM Semeru Runtimes and OpenJ9
 
 Episode 251 of Quarkus Insights explored how developers can achieve faster startup times and reduced memory footprint by using https://developer.ibm.com/languages/java/semeru-runtimes/[IBM Semeru Runtimes] with Quarkus. Mark Stoodley, Chief Architect for Java at IBM and project co-lead for https://www.eclipse.org/openj9/[Eclipse OpenJ9], joined the show to explain the technology behind these performance improvements and how Quarkus has made it trivially easy to take advantage of them.
 

--- a/_posts/2026-06-23-quarkus-insights-252-performance-engineering-lessons.adoc
+++ b/_posts/2026-06-23-quarkus-insights-252-performance-engineering-lessons.adoc
@@ -9,7 +9,7 @@ author: jcobb
 
 This summary was generated using AI, reviewed by humans - https://youtube.com/live/pYp5blcqujM[watch the video] for the full story.
 
-= Quarkus Insights #252: Performance Engineering Lessons from the Trenches
+== Quarkus Insights #252: Performance Engineering Lessons from the Trenches
 
 Episode 252 of Quarkus Insights featured Francesco Nigro, a performance engineer on the Red Hat App Services performance team, who shared a concentrated set of lessons drawn from years of low-level profiling and benchmarking work — most recently in the context of the https://github.com/quarkusio/spring-quarkus-perf-comparison[Quarkus vs Spring Boot performance benchmark].
 

--- a/_posts/2026-06-30-quarkus-insights-253-build-analytics.adoc
+++ b/_posts/2026-06-30-quarkus-insights-253-build-analytics.adoc
@@ -9,7 +9,7 @@ author: jcobb
 
 This summary was generated using AI, reviewed by humans - https://youtube.com/live/VXly6egPSTs[watch the video] for the full story.
 
-= Quarkus Insights #253: What the Build Analytics Tell Us About the Quarkus Community
+== Quarkus Insights #253: What the Build Analytics Tell Us About the Quarkus Community
 
 Episode 253 of Quarkus Insights took a different angle from the usual technical deep-dives. Bruno Baptista and Max Rydahl Andersen presented a year-over-year analysis of the opt-in build analytics data that Quarkus has been collecting from the community, comparing May 2025 to May 2026. The result was a snapshot of how the Quarkus developer community is evolving — which OS developers use, how fast they are adopting new Java versions, which extensions are growing fastest, and where in the world Quarkus is being built.
 


### PR DESCRIPTION
Every failing post has a level-0 section heading (= — a document title) inside the post body, which AsciiDoc only allows when doctype: book. In Jekyll blog posts the front matter title: field already provides the document title — the = heading inside the body is redundant and invalid.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
