### PR TITLE
Fix duplicate tags and dead links on front page caused by missing downcase

### DIFF
--- a/_includes/recent-posts-band.html
+++ b/_includes/recent-posts-band.html
@@ -13,7 +13,7 @@
             <p class="datetag margin-tb-sm">
               {{ post.date | date: '%B %d, %Y' }} &nbsp;&nbsp;&nbsp;Tags:
               {% for tag in post.tags %}
-                <a href="{{ site.baseurl }}/blog/tag/{{ tag }}">{{ tag }}</a> 
+                <a href="{{ site.baseurl }}/blog/tag/{{ tag | downcase | replace: '.', '-' }}">{{ tag | downcase }}</a>
               {% endfor %}
             </p>
 


### PR DESCRIPTION
Another one caught by https://github.com/quarkusio/quarkusio.github.io/pull/2713. @insectengine caught the problem independently, I think from looking at the lighthouse reports, so I think it affects our SEO or accessibility scores. 

On the homepage at the moment, because some blogs use tags like AI or LLM, there are dead links right on the front page:

<img width="392" height="235" alt="image" src="https://github.com/user-attachments/assets/0e81e6fa-e492-4ca3-aa6a-c844f7bbf209" />


Clicking on AI takes you to a 404. On the blog page, it's lower case:
<img width="830" height="340" alt="image" src="https://github.com/user-attachments/assets/04e74269-f64d-4f97-a80e-b6ddd9c358cd" />
