### PR TITLE
Use unconditional regex for canonical URL version prefix stripping

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -46,11 +46,7 @@
   <meta property="og:title" content="{{ page.title }}{{ page_title_version_suffix }}" />
   <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
   <meta property="og:image" content="{{ '/assets/images/quarkus_card.png' | prepend: site.url }}" />
-  {% if page.layout == 'guides' or page.layout == 'guides-index'  %}
-    {%assign canonical_url = page.url | replace_regex: '^/version/[^/]+', '' %}
-  {% else %}
-    {%assign canonical_url = page.url %}
-  {% endif %}
+  {%assign canonical_url = page.url | replace_regex: '^/version/[^/]+', '' %}
   <link rel="canonical" href="{{ canonical_url | prepend: site.url }}">
   <link rel="shortcut icon" type="image/png" href="{{ "/favicon.ico" | prepend: site.baseurl }}" >
   <link rel="stylesheet" href="/guides/stylesheet/config.css" />


### PR DESCRIPTION
In an ideal world, https://github.com/quarkiverse/quarkus-roq/issues/1080 would be present and this wouldn't be needed. 

However, I'm not sure what we're doing is very clean. We're using the layout to work out how to determine the canonical url, but layout and url should be sort of orthogonal. 

The replace_regex '^/version/[^/]+' is a no-op on non-versioned URLs, so the if/else checking page.layout is unnecessary. Removing it also fixes the Roq migration: guide pages inherit layout from collection config rather than frontmatter, so page.data.layout is null after conversion (https://github.com/quarkiverse/quarkus-roq/issues/1080).

The URL-based approach is more correct than the original: the intent is "strip version prefix from canonical URLs of versioned pages", which is a URL property, not a layout property. The guards-index layout check was dead code — no page uses that layout.

To verify this, Claude suggests 

> Visit a versioned guide like /version/main/guides/getting-started, view
>   source, and check the <link rel="canonical"> tag. It should point to
>   /guides/getting-started (no /version/main/ prefix). Then spot-check a
>   non-versioned page like /guides/getting-started directly — its canonical
>   should be unchanged.
