### PR TITLE
Compute EOL dates for non-LTS releases missing them

### DIFF
--- a/tools/releases-sync/main.java
+++ b/tools/releases-sync/main.java
@@ -578,6 +578,26 @@ public class main implements Callable<Integer> {
         // Sort all releases by version (latest first)
         processedReleases.sort((a, b) -> compareVersions(b.version, a.version));
 
+        // Compute EOL dates for non-LTS releases that don't have one explicitly set.
+        // Policy: non-LTS releases are supported "until the next minor release",
+        // so EOL date = release date of the next higher minor version.
+        for (int i = 0; i < processedReleases.size(); i++) {
+            Release release = processedReleases.get(i);
+            if (release.hasExplicitEolDate || Boolean.TRUE.equals(release.upcoming)) {
+                continue;
+            }
+            if (Boolean.TRUE.equals(release.lts)) {
+                continue;
+            }
+            // Find the next higher version (previous index since sorted latest-first)
+            if (i > 0) {
+                Release nextRelease = processedReleases.get(i - 1);
+                if (nextRelease.releaseDate != null) {
+                    release.eolDate = nextRelease.releaseDate;
+                }
+            }
+        }
+
         // Build result
         ReleaseData result = new ReleaseData();
         result.policy = existingData.policy;


### PR DESCRIPTION
Follow-on (oops) to https://github.com/quarkusio/quarkusio.github.io/pull/2818. 

The release sync script was not setting eol_date for releases it discovered from GitHub that had no prior entry in releases.yaml (all 0.x and 1.x versions). I didn't spot this when I looked at the diff, because it was an sin of omission, not commission. :) 

This is really obvious for all the old releases it added (and it makes /releases look dumb when 'hide eol releases' is clicked and loads of ancient releases are still on the page). It would have become an issue anyway after we did a few releases.

Per the support policy, non-LTS releases are EOL when the next minor version is released, so the script derives the date automatically from the successor's release_date.

Dry run diff is in https://github.com/quarkusio/quarkusio.github.io/actions/runs/29248276451/job/86810366714. 

```
--- _data/releases.yaml (current)
+++ _data/releases.yaml (updated)
@@ -447,246 +447,287 @@
 
   - version: "1.13"
     release_date: 2021-03-30
+    eol_date: 2021-06-30
     lts: false
     latest_patch: "1.13.7.Final"
     latest_patch_date: 2021-06-09
 
   - version: "1.12"
     release_date: 2021-02-23
+    eol_date: 2021-03-30
     lts: false
     latest_patch: "1.12.2.Final"
     latest_patch_date: 2021-03-11
...
```
