### PR TITLE
Correctly set profile for roq build and do not rely on mtime for site size reduction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'
-        run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run -DskipTests # for now, for parity, we need to stand up a test server to run tests
+        run: QUARKUS_ROQ_GENERATOR_BATCH=true QUARKUS_PROFILE=only-latest-guides mvn -B package quarkus:run -DskipTests
 
       - name: Compile tests
         run: mvn -B test-compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,12 @@ jobs:
           if [ -f "Gemfile" ]; then
             echo "jekyll=true" >> $GITHUB_OUTPUT
             echo "site_dir=_site" >> $GITHUB_OUTPUT
-            echo "statics_dir=." >> $GITHUB_OUTPUT
           else
             echo "jekyll=false" >> $GITHUB_OUTPUT
           fi
           if [ -d "src/main" ]; then
             echo "roq=true" >> $GITHUB_OUTPUT
             echo "site_dir=target/roq" >> $GITHUB_OUTPUT
-            echo "statics_dir=public" >> $GITHUB_OUTPUT
           else
             echo "roq=false" >> $GITHUB_OUTPUT
           fi
@@ -242,9 +240,33 @@ jobs:
       - name: Reduce the size of the website to be compatible with surge
         run: |
           SITE_DIR="${{ steps.detect.outputs.site_dir }}"
-          STATICS_DIR="${{ steps.detect.outputs.statics_dir }}"
-          find "$STATICS_DIR"/assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
-          find "$STATICS_DIR"/newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf "$SITE_DIR"/{} \;
+          # Keep only the 10 most recent newsletter editions (by number)
+          if [ -d "$SITE_DIR/newsletter" ]; then
+            ls -1 "$SITE_DIR/newsletter" | sort -n | head -n -10 | while read -r dir; do
+              rm -rf "$SITE_DIR/newsletter/$dir"
+            done
+          fi
+          # Remove post images only referenced by blog posts older than ~2 months.
+          # Uses filename dates instead of mtime (which breaks after file moves/migrations).
+          CUTOFF=$(date -d '50 days ago' +%Y-%m-%d)
+          RECENT_IMGS=$(mktemp)
+          OLD_IMGS=$(mktemp)
+          POSTS_DIR=content/posts
+          [ -d _posts ] && POSTS_DIR=_posts
+          for post in "$POSTS_DIR"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.adoc; do
+            POST_DATE=$(basename "$post" | grep -oP '^\d{4}-\d{2}-\d{2}')
+            [ -z "$POST_DATE" ] && continue
+            if [ "$POST_DATE" \> "$CUTOFF" ]; then
+              grep -oP 'images/posts/\K[^/\["\]]+' "$post" >> "$RECENT_IMGS" 2>/dev/null || true
+            else
+              grep -oP 'images/posts/\K[^/\["\]]+' "$post" >> "$OLD_IMGS" 2>/dev/null || true
+            fi
+          done
+          comm -23 <(sort -u "$OLD_IMGS") <(sort -u "$RECENT_IMGS") | while read -r imgdir;
+          do
+           rm -rf "$SITE_DIR/assets/images/posts/$imgdir"
+          done
+          rm -f "$RECENT_IMGS" "$OLD_IMGS"
           rm -rf "$SITE_DIR"/assets/stickers
           rm -rf "$SITE_DIR"/assets/images/worldtour/2023
           rm -rf "$SITE_DIR"/assets/images/worldtour/2024


### PR DESCRIPTION
Two more pieces of infra, pre-conversion. 

- I wasn't setting the profile in the roq case, and clearly should have been.
- Post-conversion, our method of finding old newsletters no longer works. We look for files that haven't changed recently, but *every* file gets moved around by the conversion, so then we try and publish previews that are too large. This will be an issue for several months after the conversion, so I've switched the logic to just use the newsletter number.

Old assets have a similar problem, so there it does crunchy parsing of filenames to extract dates.