### PR TITLE
Add Roq-compatible Java classes to replicate Jekyll plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           else
             echo "jekyll=false" >> $GITHUB_OUTPUT
           fi
-          if [ -d "src/main" ]; then
+          if [ -f "config/application.properties" ]; then
             echo "roq=true" >> $GITHUB_OUTPUT
             echo "site_dir=target/roq" >> $GITHUB_OUTPUT
           else

--- a/pom.xml
+++ b/pom.xml
@@ -10,24 +10,75 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>6.1.2</version>
-            <scope>test</scope>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq</artifactId>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
-            <groupId>com.microsoft.playwright</groupId>
-            <artifactId>playwright</artifactId>
-            <version>1.61.0</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq-testing</artifactId>
+            <version>2.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq-plugin-aliases</artifactId>
+            <version>2.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq-plugin-tagging</artifactId>
+            <version>2.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.roq</groupId>
+            <artifactId>quarkus-roq-plugin-asciidoc-jruby</artifactId>
+            <version>2.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.playwright</groupId>
+            <artifactId>quarkus-playwright</artifactId>
+            <version>2.3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
@@ -40,10 +91,36 @@
                 <version>${surefire-plugin.version}</version>
                 <configuration>
                     <excludedGroups>e2e</excludedGroups>
+                    <argLine>@{argLine}</argLine>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <argLine>@{argLine}</argLine>
+                    <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>e2e</id>
@@ -58,6 +135,19 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+                <skipITs>false</skipITs>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigPropertyCopyButtonInlineMacroProcessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigPropertyCopyButtonInlineMacroProcessor.java
@@ -1,0 +1,24 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Name;
+
+@Name("config_property_copy_button")
+public class ConfigPropertyCopyButtonInlineMacroProcessor extends InlineMacroProcessor {
+
+    @Override
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        String html = """
+                <button class="btn-copy fa fa-clipboard inline-btn-copy"\
+                 data-clipboard-action="copy"\
+                 data-clipboard-text='%s'\
+                 title="Copy to clipboard"\
+                 do-not-collapse="true"></button>""".formatted(target);
+        return createPhraseNode(parent, "quoted", html, attributes, new HashMap<>(Map.of("subs", ":none")));
+    }
+}

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTablePostprocessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTablePostprocessor.java
@@ -1,0 +1,50 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.Postprocessor;
+
+public class ConfigTablePostprocessor extends Postprocessor {
+
+    @Override
+    public String process(Document document, String output) {
+        Object maxIdObj = document.getAttribute("quarkus-config-max-row-id");
+        if (maxIdObj == null) {
+            return output;
+        }
+        int maxId = Integer.parseInt(maxIdObj.toString());
+
+        StringBuilder sb = new StringBuilder(output);
+
+        for (int id = 1; id <= maxId; id++) {
+            String cssClass = "";
+            if (id > 30) {
+                cssClass = " row-hidden";
+            }
+            if (id % 2 == 1) {
+                cssClass += " odd";
+            }
+
+            String collapsibleMarker = "id=\"conf-collapsible-desc-" + id + "\"";
+            int descIdx = sb.indexOf(collapsibleMarker);
+            if (descIdx >= 0) {
+                int rowIdx = sb.lastIndexOf("<tr>", descIdx);
+                if (rowIdx >= 0) {
+                    sb.replace(rowIdx, rowIdx + 4,
+                            "<tr class=\"row-collapsible row-collapsed row-with-desc" + cssClass + "\">");
+                }
+            } else {
+                String nonCollapsibleMarker = "id=\"conf-non-collapsible-desc-" + id + "\"";
+                descIdx = sb.indexOf(nonCollapsibleMarker);
+                if (descIdx >= 0 && !cssClass.isBlank()) {
+                    int rowIdx = sb.lastIndexOf("<tr>", descIdx);
+                    if (rowIdx >= 0) {
+                        sb.replace(rowIdx, rowIdx + 4,
+                                "<tr class=\"" + cssClass.trim() + "\">");
+                    }
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
@@ -1,0 +1,107 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.asciidoctor.ast.Block;
+import org.asciidoctor.ast.Cell;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.Row;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.Table;
+import org.asciidoctor.extension.Treeprocessor;
+
+public class ConfigTableTreeprocessor extends Treeprocessor {
+
+    @Override
+    public Document process(Document document) {
+        int rowId = 0;
+        int searchFieldId = 0;
+
+        List<StructuralNode> tables = document.findBy(Map.of("context", ":table"));
+        for (StructuralNode node : tables) {
+            if (!(node instanceof Table table)) {
+                continue;
+            }
+            if (!table.hasRole("configuration-reference")) {
+                continue;
+            }
+
+            table.addRole("configuration-reference-all-rows");
+
+            for (Row row : table.getBody()) {
+                if (row.getCells().isEmpty()) {
+                    continue;
+                }
+                Cell firstCell = row.getCells().get(0);
+                Document innerDoc = firstCell.getInnerDocument();
+                if (innerDoc == null) {
+                    continue;
+                }
+
+                for (StructuralNode block : findByRole(innerDoc, "description")) {
+                    rowId++;
+                    if (isCollapsible(block)) {
+                        block.setId("conf-collapsible-desc-" + rowId);
+                        block.addRole("description-collapsed");
+                        Block btnBlock = createBlock(innerDoc, "paragraph",
+                                "<i class=\"fa fa-chevron-down\"></i><span>Show more</span>",
+                                new HashMap<>());
+                        btnBlock.addRole("description-decoration");
+                        innerDoc.getBlocks().add(btnBlock);
+                    } else {
+                        block.setId("conf-non-collapsible-desc-" + rowId);
+                    }
+                }
+            }
+
+            if (table.hasRole("searchable") && table.getParent() instanceof StructuralNode parent) {
+                List<StructuralNode> siblings = parent.getBlocks();
+                int tableIndex = siblings.indexOf(table);
+                if (tableIndex > 0) {
+                    StructuralNode caption = siblings.get(tableIndex - 1);
+                    String captionContent = caption.getContent() != null
+                            ? caption.getContent().toString()
+                            : "";
+                    searchFieldId++;
+                    Block newCaption = createBlock(parent, "paragraph",
+                            captionContent + " <input type=\"search\" id=\"config-search-%d\" placeholder=\"FILTER CONFIGURATION\" disabled>".formatted(searchFieldId),
+                            new HashMap<>());
+                    siblings.set(tableIndex - 1, newCaption);
+                }
+            }
+        }
+
+        if (rowId > 0) {
+            document.setAttribute("quarkus-config-max-row-id", rowId, true);
+        }
+
+        return document;
+    }
+
+    private boolean isCollapsible(StructuralNode desc) {
+        List<StructuralNode> blocks = desc.getBlocks();
+        if (blocks.size() > 1) {
+            return true;
+        }
+        if (blocks.size() == 1) {
+            Object content = blocks.get(0).getContent();
+            if (content != null && !content.toString().startsWith("Environment variable: ")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<StructuralNode> findByRole(StructuralNode parent, String role) {
+        List<StructuralNode> result = new java.util.ArrayList<>();
+        for (StructuralNode block : parent.getBlocks()) {
+            if (block.hasRole(role)) {
+                result.add(block);
+            }
+            result.addAll(findByRole(block, role));
+        }
+        return result;
+    }
+}

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/EnvVarCopyButtonInlineMacroProcessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/EnvVarCopyButtonInlineMacroProcessor.java
@@ -1,0 +1,26 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Name;
+
+@Name("env_var_with_copy_button")
+public class EnvVarCopyButtonInlineMacroProcessor extends InlineMacroProcessor {
+
+    @Override
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        int id = parent.getDocument().getAndIncrementCounter("env-var-id");
+        String html = """
+                <code id="env-var-%1$d">%2$s</code>\
+                <button class="btn-copy fa fa-clipboard inline-btn-copy"\
+                 data-clipboard-action="copy"\
+                 data-clipboard-target="#env-var-%1$d"\
+                 title="Copy to clipboard"\
+                 do-not-collapse="true"></button>""".formatted(id, target);
+        return createPhraseNode(parent, "quoted", html, attributes, new HashMap<>(Map.of("subs", ":none")));
+    }
+}

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessor.java
@@ -1,0 +1,42 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.asciidoctor.ast.Block;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.Treeprocessor;
+
+public class ExtensionStatusTreeprocessor extends Treeprocessor {
+
+    private static final Map<String, String> TOOLTIPS = Map.of(
+            "experimental", "This extension requests early feedback to mature the idea",
+            "preview", "This extension's backward compatibility and presence in the ecosystem is not guaranteed",
+            "stable",
+            "This extension's backward compatibility and presence in the ecosystem are taken very seriously",
+            "deprecated", "This extension is likely to be replaced or removed in a future version");
+
+    @Override
+    public Document process(Document document) {
+        Object statusObj = document.getAttribute("extension-status");
+        if (statusObj == null) {
+            return document;
+        }
+
+        String status = statusObj.toString().trim();
+        if (status.isEmpty()) {
+            return document;
+        }
+
+        String tooltip = TOOLTIPS.getOrDefault(status, "");
+        String labelHtml = """
+                <a class="status-label status-%1$s"\
+                 title="%2$s"\
+                 href="#extension-status-note">%1$s</a>""".formatted(status, tooltip);
+
+        Block labelBlock = createBlock(document, "pass", labelHtml, new HashMap<>());
+        document.getBlocks().add(0, labelBlock);
+
+        return document;
+    }
+}

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/QuarkusExtensionRegistry.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/QuarkusExtensionRegistry.java
@@ -1,0 +1,18 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.jruby.extension.spi.ExtensionRegistry;
+
+public class QuarkusExtensionRegistry implements ExtensionRegistry {
+
+    @Override
+    public void register(Asciidoctor asciidoctor) {
+        asciidoctor.javaExtensionRegistry()
+                .inlineMacro(new TooltipInlineMacroProcessor())
+                .inlineMacro(new EnvVarCopyButtonInlineMacroProcessor())
+                .inlineMacro(new ConfigPropertyCopyButtonInlineMacroProcessor())
+                .treeprocessor(new ConfigTableTreeprocessor())
+                .postprocessor(new ConfigTablePostprocessor())
+                .treeprocessor(new ExtensionStatusTreeprocessor());
+    }
+}

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/TooltipInlineMacroProcessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/TooltipInlineMacroProcessor.java
@@ -1,0 +1,32 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.asciidoctor.ast.ContentModel;
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Name;
+
+@Name("tooltip")
+@ContentModel(ContentModel.RAW)
+public class TooltipInlineMacroProcessor extends InlineMacroProcessor {
+
+    @Override
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        String text = Objects.toString(attributes.get("text"), "");
+        String html;
+        if (text.isEmpty()) {
+            html = "<code>" + target + "</code>";
+        } else {
+            html = """
+                    <span class="asciidoc-tooltip-wrapper">\
+                    <code>%s</code>\
+                    <span class="asciidoc-tooltip">%s</span>\
+                    </span>""".formatted(target, text);
+        }
+        return createPhraseNode(parent, "quoted", html, attributes, new HashMap<>(Map.of("subs", ":none")));
+    }
+}

--- a/src/main/java/io/quarkus/tools/migration/search/ScriptMode.java
+++ b/src/main/java/io/quarkus/tools/migration/search/ScriptMode.java
@@ -1,0 +1,5 @@
+package io.quarkus.tools.migration.search;
+
+public enum ScriptMode {
+    DIRECT, CACHED;
+}

--- a/src/main/java/io/quarkus/tools/migration/search/SearchScriptDownloader.java
+++ b/src/main/java/io/quarkus/tools/migration/search/SearchScriptDownloader.java
@@ -1,0 +1,78 @@
+package io.quarkus.tools.migration.search;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+
+import io.quarkiverse.roq.generator.runtime.RoqSelection;
+import io.quarkiverse.roq.generator.runtime.SelectedPath;
+import io.quarkus.runtime.Startup;
+import io.quarkusio.search.config.SearchConfig;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Router;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Startup
+public class SearchScriptDownloader {
+
+    private static final Logger LOG = Logger.getLogger(SearchScriptDownloader.class);
+
+    // path is the URL the SSG generator fetches via HTTP from the running server
+    //  (the Vert.x route). outputPath is where it writes the response in target/roq/.
+    //  They're similar because the route is mounted at the same logical location the
+    //  file should end up — one has a leading / (URL), the other doesn't (relative
+    //  file path)
+    private static final String SCRIPT_PATH = "/assets/javascript/search-wc.js";
+    public static final String OUTPUT_PATH = "assets/javascript/search-wc.js";
+
+    @Inject
+    @Named("searchConfig")
+    SearchConfig searchConfig;
+
+    private volatile String scriptContent;
+
+    @PostConstruct
+    void downloadScript() {
+        if (searchConfig.scriptMode() != ScriptMode.DIRECT) {
+            String scriptUrl = searchConfig.host() + searchConfig.scriptPath();
+            try (InputStream in = URI.create(scriptUrl).toURL().openStream()) {
+                scriptContent = new String(in.readAllBytes())
+                        .replaceAll("//# sourceMappingURL=.*\\.map", "");
+                LOG.infof("Downloaded search script from %s (%d bytes)", scriptUrl, scriptContent.length());
+            } catch (IOException e) {
+                LOG.errorf(e, "Failed to download search script from %s", scriptUrl);
+            }
+        }
+    }
+
+    void registerRoute(@Observes Router router) {
+        if (scriptContent != null) {
+            router.route(SCRIPT_PATH).method(HttpMethod.GET).handler(rc -> rc.response()
+                            .putHeader("Content-Type", "application/javascript")
+                            .end(scriptContent));
+        }
+    }
+
+    @Produces
+    @Singleton
+    RoqSelection searchScriptSelection() {
+        if (searchConfig.scriptMode() != ScriptMode.DIRECT && scriptContent != null) {
+            return new RoqSelection(List.of(
+                    SelectedPath.builder()
+                            .path(SCRIPT_PATH)
+                            .outputPath(OUTPUT_PATH)
+                            .build()));
+        }
+        return new RoqSelection(List.of());
+    }
+}
+

--- a/src/main/java/io/quarkusio/search/config/SearchConfig.java
+++ b/src/main/java/io/quarkusio/search/config/SearchConfig.java
@@ -1,0 +1,56 @@
+package io.quarkusio.search.config;
+
+import io.quarkus.tools.migration.search.ScriptMode;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkusio.search")
+public interface SearchConfig {
+
+    /** The URL of the remote search service */
+    @WithDefault("https://search.quarkus.io")
+    String host();
+
+    /** The path to the search script (relative from the search.host) */
+    @WithDefault("/static/bundle/app.js")
+    String scriptPath();
+
+    /** The script mode is direct or cached. Cached means the search script is copied from the remote service. */
+    @WithDefault("cached")
+    ScriptMode scriptMode();
+
+    /** Where to copy the search script file for cached mode */
+    @WithDefault("assets/javascript/search-wc.js")
+    String cachedScriptFile();
+
+    /**
+     * The amount of time before we give up on a pending remote search and fall back to Javascript search.
+     * The search service itself is reasonably fast on a decent machine (with curl: ~100ms median, ~150ms 90th percentile).
+     * but it's slower on prod machines (with curl: ~200ms median, ~400ms 90th percentile),
+     * and prod network overhead makes it even worse (with curl from France: ~750ms median, ~1000ms 90th percentile),
+     * so we need a high timeout with some margin for varying network latency depending on browser location.
+     * Such a high timeout is acceptable since Javascript search is almost instantaneous,
+     * so when we hit the timeout the user won't experience much more delay.
+     * See also https://docs.google.com/spreadsheets/d/1w0tSfL-MKFArSrB-L8IX1pxmrhWmQyNgNwQRloG3cLk/edit#gid=456110917
+     */
+    @WithDefault("1500")
+    int initialTimeout();
+
+    /**
+     * When fetching more pages, a timeout would be very bad for UX
+     * since we would reset the whole page using Javascript --
+     * while the user is reading through it!
+     * This we set a higher timeout value, to make timeouts less likely.
+     */
+    @WithDefault("2500")
+    int moreTimeout();
+
+    /**
+     * The minimum number of characters before we run a full search.
+     * Below this:
+     * - if another filter is selected (e.g. categories), we run Javascript search
+     * - otherwise, we don't run search and just display all guides
+     */
+    @WithDefault("2")
+    int minChars();
+}

--- a/src/main/java/io/quarkusio/search/config/SearchConfigProducer.java
+++ b/src/main/java/io/quarkusio/search/config/SearchConfigProducer.java
@@ -1,0 +1,28 @@
+package io.quarkusio.search.config;
+
+import io.quarkus.arc.Unremovable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@ApplicationScoped
+@Unremovable
+public class SearchConfigProducer {
+
+    @Inject
+    Instance<SearchConfig> configInstance;
+
+    @Produces
+    @Named("searchConfig")
+    @Unremovable
+    public SearchConfig produceSearchConfig() {
+        for (Instance.Handle<SearchConfig> handle : configInstance.handles()) {
+            if (handle.getBean().getQualifiers().stream().noneMatch(q -> q instanceof Named)) {
+                return handle.get();
+            }
+        }
+        throw new IllegalStateException("SearchConfig not found");
+    }
+}

--- a/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+++ b/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
@@ -1,0 +1,1 @@
+io.quarkus.tools.migration.asciidoc.QuarkusExtensionRegistry

--- a/src/test/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessorTest.java
+++ b/src/test/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessorTest.java
@@ -1,0 +1,149 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ConfigTableTreeprocessorTest {
+
+    static Asciidoctor asciidoctor;
+
+    @BeforeAll
+    static void setup() {
+        asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry()
+                .treeprocessor(new ConfigTableTreeprocessor())
+                .postprocessor(new ConfigTablePostprocessor())
+                .inlineMacro(new ConfigPropertyCopyButtonInlineMacroProcessor())
+                .inlineMacro(new EnvVarCopyButtonInlineMacroProcessor());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        asciidoctor.close();
+    }
+
+    private String convert(String adoc) {
+        return asciidoctor.convert(adoc, Options.builder()
+                .attributes(Attributes.builder()
+                        .attribute("add-copy-button-to-config-props", "true")
+                        .attribute("add-copy-button-to-env-var", "true")
+                        .build())
+                .build());
+    }
+
+    static final String CONFIG_TABLE = """
+            [.configuration-legend]
+            Configuration property fixed at build time
+            [.configuration-reference.searchable, cols="80,.^10,.^10"]
+            |===
+
+            h|Configuration property
+            h|Type
+            h|Default
+
+            a|`quarkus.redis.hosts`
+            config_property_copy_button:quarkus.redis.hosts[]
+
+            [.description]
+            --
+            The redis hosts to use while connecting to the redis server.
+
+            Environment variable: env_var_with_copy_button:QUARKUS_REDIS_HOSTS[]
+            --
+            |string
+            |`localhost:6379`
+
+            a|`quarkus.redis.timeout`
+
+            [.description]
+            --
+            Environment variable: env_var_with_copy_button:QUARKUS_REDIS_TIMEOUT[]
+            --
+            |int
+            |`10`
+
+            |===
+            """;
+
+    @Test
+    void addsAllRowsClassToTable() {
+        String html = convert(CONFIG_TABLE);
+        assertTrue(html.contains("configuration-reference-all-rows"));
+    }
+
+    @Test
+    void collapsibleDescriptionGetsId() {
+        String html = convert(CONFIG_TABLE);
+        assertTrue(html.contains("conf-collapsible-desc-"));
+    }
+
+    @Test
+    void collapsibleDescriptionGetsDecoration() {
+        String html = convert(CONFIG_TABLE);
+        assertTrue(html.contains("description-decoration"));
+        assertTrue(html.contains("fa fa-chevron-down"));
+        assertTrue(html.contains("Show more"));
+    }
+
+    @Test
+    void nonCollapsibleDescriptionGetsNonCollapsibleId() {
+        String html = convert(CONFIG_TABLE);
+        assertTrue(html.contains("conf-non-collapsible-desc-"));
+    }
+
+    @Test
+    void collapsibleRowGetsRowClasses() {
+        String html = convert(CONFIG_TABLE);
+        assertTrue(html.contains("row-collapsible"));
+        assertTrue(html.contains("row-collapsed"));
+    }
+
+    @Test
+    void searchInputInjected() {
+        String html = convert(CONFIG_TABLE);
+        assertTrue(html.contains("FILTER CONFIGURATION"));
+        assertTrue(html.contains("type=\"search\""));
+    }
+
+    @Test
+    void nonSearchableTableHasNoSearchInput() {
+        String adoc = """
+                [.configuration-reference, cols="80,.^10,.^10"]
+                |===
+
+                h|Property
+                h|Type
+                h|Default
+
+                a|`quarkus.test`
+
+                [.description]
+                --
+                A simple property.
+
+                Environment variable: env_var_with_copy_button:QUARKUS_TEST[]
+                --
+                |string
+                |
+
+                |===
+                """;
+        String html = convert(adoc);
+        assertFalse(html.contains("FILTER CONFIGURATION"));
+        assertTrue(html.contains("configuration-reference-all-rows"));
+    }
+
+    @Test
+    void noConfigTableLeavesDocumentUnchanged() {
+        String html = convert("== Just a heading\n\nSome text.");
+        assertFalse(html.contains("configuration-reference"));
+        assertFalse(html.contains("row-collapsible"));
+    }
+}

--- a/src/test/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessorTest.java
+++ b/src/test/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessorTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ExtensionStatusTreeprocessorTest {
+
+    static Asciidoctor asciidoctor;
+
+    @BeforeAll
+    static void setup() {
+        asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry()
+                .treeprocessor(new ExtensionStatusTreeprocessor());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        asciidoctor.close();
+    }
+
+    private String convert(String adoc) {
+        return asciidoctor.convert(adoc, Options.builder().build());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "stable, status-stable",
+            "preview, status-preview",
+            "experimental, status-experimental",
+            "deprecated, status-deprecated"
+    })
+    void insertsStatusLabel(String status, String cssClass) {
+        String html = convert(":extension-status: " + status + "\n\n== My Guide\n\nSome content.");
+        assertTrue(html.contains("class=\"status-label " + cssClass + "\""));
+        assertTrue(html.contains(">" + status + "</a>"));
+        assertTrue(html.contains("href=\"#extension-status-note\""));
+    }
+
+    @Test
+    void stableHasCorrectTooltip() {
+        String html = convert(":extension-status: stable\n\n== Guide\n\nContent.");
+        assertTrue(html.contains("title=\"This extension's backward compatibility"));
+    }
+
+    @Test
+    void previewHasCorrectTooltip() {
+        String html = convert(":extension-status: preview\n\n== Guide\n\nContent.");
+        assertTrue(html.contains("title=\"This extension's backward compatibility and presence in the ecosystem is not guaranteed\""));
+    }
+
+    @Test
+    void noStatusAttributeLeavesDocumentUnchanged() {
+        String html = convert("== Guide\n\nContent.");
+        assertFalse(html.contains("status-label"));
+    }
+
+    @Test
+    void labelAppearsBeforeContent() {
+        String html = convert(":extension-status: stable\n\n== Guide\n\nContent.");
+        int labelIndex = html.indexOf("status-label");
+        int contentIndex = html.indexOf("Guide");
+        assertTrue(labelIndex < contentIndex);
+    }
+}

--- a/src/test/java/io/quarkus/tools/migration/asciidoc/InlineMacroProcessorTest.java
+++ b/src/test/java/io/quarkus/tools/migration/asciidoc/InlineMacroProcessorTest.java
@@ -1,0 +1,113 @@
+package io.quarkus.tools.migration.asciidoc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class InlineMacroProcessorTest {
+
+    static Asciidoctor asciidoctor;
+
+    @BeforeAll
+    static void setup() {
+        asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry()
+                .inlineMacro(new TooltipInlineMacroProcessor())
+                .inlineMacro(new EnvVarCopyButtonInlineMacroProcessor())
+                .inlineMacro(new ConfigPropertyCopyButtonInlineMacroProcessor());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        asciidoctor.close();
+    }
+
+    private String convert(String adoc) {
+        return asciidoctor.convert(adoc, Options.builder().build());
+    }
+
+    @Nested
+    class Tooltip {
+
+        @Test
+        void withDescription() {
+            String html = convert("tooltip:MY_CONST[A description]");
+            assertTrue(html.contains("<span class=\"asciidoc-tooltip-wrapper\">"));
+            assertTrue(html.contains("<code>MY_CONST</code>"));
+            assertTrue(html.contains("<span class=\"asciidoc-tooltip\">A description</span>"));
+        }
+
+        @Test
+        void withoutDescription() {
+            String html = convert("tooltip:MY_CONST[]");
+            assertTrue(html.contains("<code>MY_CONST</code>"));
+            assertFalse(html.contains("asciidoc-tooltip-wrapper"));
+        }
+
+        @Test
+        void withSpecialCharacters() {
+            String html = convert("tooltip:THIRD_CONSTANT[Test sentence with spaces]");
+            assertTrue(html.contains("<span class=\"asciidoc-tooltip-wrapper\">"));
+            assertTrue(html.contains("<code>THIRD_CONSTANT</code>"));
+            assertTrue(html.contains("Test sentence with spaces"));
+        }
+
+        @Test
+        void multipleInDocument() {
+            String html = convert("tooltip:A[desc A] and tooltip:B[desc B]");
+            assertTrue(html.contains("<code>A</code>"));
+            assertTrue(html.contains("<code>B</code>"));
+        }
+    }
+
+    @Nested
+    class EnvVarCopyButton {
+
+        @Test
+        void producesCodeAndButton() {
+            String html = convert("env_var_with_copy_button:QUARKUS_REDIS_HOSTS[]");
+            assertTrue(html.contains("<code id=\"env-var-"));
+            assertTrue(html.contains(">QUARKUS_REDIS_HOSTS</code>"));
+            assertTrue(html.contains("data-clipboard-target=\"#env-var-"));
+            assertTrue(html.contains("btn-copy"));
+        }
+
+        @Test
+        void incrementsIds() {
+            String html = convert(
+                    "env_var_with_copy_button:FIRST[] and env_var_with_copy_button:SECOND[]");
+            assertTrue(html.contains("env-var-1"));
+            assertTrue(html.contains("env-var-2"));
+        }
+
+        @Test
+        void buttonHasDoNotCollapseAttribute() {
+            String html = convert("env_var_with_copy_button:VAR[]");
+            assertTrue(html.contains("do-not-collapse=\"true\""));
+        }
+    }
+
+    @Nested
+    class ConfigPropertyCopyButton {
+
+        @Test
+        void producesButtonWithClipboardText() {
+            String html = convert("config_property_copy_button:quarkus.redis.hosts[]");
+            assertTrue(html.contains("data-clipboard-text='quarkus.redis.hosts'"));
+            assertTrue(html.contains("btn-copy"));
+            assertTrue(html.contains("fa-clipboard"));
+        }
+
+        @Test
+        void buttonHasDoNotCollapseAttribute() {
+            String html = convert("config_property_copy_button:quarkus.test[]");
+            assertTrue(html.contains("do-not-collapse=\"true\""));
+        }
+    }
+}


### PR DESCRIPTION
Most of the quarkus.io site can be converted using scripts, but converting the Jekyll plugins to Roq is really hard to do. Claude's first attempts at scripts were basically a script that hardcoded in the new Java file and output it. :) 

The plugins also don't change much, so I think it's best to do the conversion as a one-off. I think we're close enough to cutting over now that we can risk the dual-maintenance of having both sets of code in the repo. The Java code is harmless, but also not being exercised at the moment. (I know it does work, because I have tests wrapping a lot of the function, and I've also visually verified in https://quarkus-website-pr-2683-preview.surge.sh/). 

Roq doesn't have a formal plugin mechanism, and instead, code just goes into the src folder. This code replicates 
- https://github.com/quarkusio/quarkusio.github.io/blob/main/_plugins/asciidoctor-extension.rb
- https://github.com/quarkusio/quarkusio.github.io/blob/main/_plugins/copy-search-wc.rb

The regex filter and strings plugins aren't needed, and the cname plugin is so standard I'm handling it in the converter. 

Asking @michalvavrik for a review since he's touched these classes most recently, although a review might need more knowledge of Asciidoctor-Java than any of us have. Also cc @marko-bekhta for awareness. 

Having the code in the repo in advance of the conversion doesn't _really_ change anything, but it makes it easier to review by not mixing it in with 42k changed files from the automated run. Although I guess the knowledge issue mentioned above still makes it hard to review. 