### PR TITLE
Deduplicate blog tag sidebar by downcasing before uniq|sort

### DIFF
--- a/_includes/blog-band.html
+++ b/_includes/blog-band.html
@@ -66,11 +66,13 @@
     <a href="{{site.baseurl}}/feed.xml"><i class="fas fa-rss-square"></i></a>
    </div>
     <h3 class="tags-label">Tags</h3>
-    {% assign tag_words = site.tags | sort %}
-    {% for stats in tag_words %}
-     {% assign tag = stats | first %}
-     {% assign posts = stats | last %}
-     <a href="{{site.baseurl}}/blog/tag/{{tag | downcase | replace: '.', '-' }}">{{ tag | downcase }}</a></br>
+    {% assign tag_keys = "" | split: "" %}
+    {% for stats in site.tags %}
+     {% assign tag_keys = tag_keys | push: stats[0] | downcase %}
+    {% endfor %}
+    {% assign tag_words = tag_keys | uniq | sort %}
+    {% for tag in tag_words %}
+     <a href="{{site.baseurl}}/blog/tag/{{tag | replace: '.', '-' }}">{{ tag }}</a></br>
     {% endfor %}
   </div>
 </div>

--- a/src/test/java/io/quarkusio/TagTest.java
+++ b/src/test/java/io/quarkusio/TagTest.java
@@ -1,5 +1,9 @@
 package io.quarkusio;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -124,6 +128,27 @@ public class TagTest extends BrowserTest {
                 "Navigating to tag link should reach a page with a heading, not a 404");
         assertTrue(heading.first().textContent().contains("Tagged posts"),
                 "Tag page heading should say 'Tagged posts'");
+    }
+
+    @Test
+    void blogSidebarTagsHaveNoDuplicates() {
+        page.navigate(baseUrl + BLOG_PATH);
+        var sidebarTagLinks = page.locator(".tags-label").locator("xpath=..").locator("a[href*='/blog/tag/']");
+        int count = sidebarTagLinks.count();
+        assertTrue(count > 0, "Expected at least one tag in the sidebar");
+
+        List<String> tagTexts = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            tagTexts.add(sidebarTagLinks.nth(i).textContent().trim().toLowerCase());
+        }
+
+        List<String> duplicates = tagTexts.stream()
+                .filter(t -> Collections.frequency(tagTexts, t) > 1)
+                .distinct()
+                .toList();
+
+        assertTrue(duplicates.isEmpty(),
+                "Sidebar contains duplicate tags (case-insensitive): " + duplicates);
     }
 
     @Test


### PR DESCRIPTION
Resolves #2852. 

Jerome Tama spotted that the converted quarkus.io had some duplicate tags on the /blogs site, caused by upper case tags in some articles. (We'd had dead links on the front page for similar reasons, but those were fixed.)

Then I realised the main site has the same issue, just with slightly different ordering of tags, so it's less obvious. I've added a test, which failed, and then implemented a fix. I may need to re-fix on the Roq side, but we'll see. 