### PR TITLE
Also tolerate single quotes and no quotes in redirect test

### DIFF
--- a/src/test/java/io/quarkusio/RedirectTest.java
+++ b/src/test/java/io/quarkusio/RedirectTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class RedirectTest extends BrowserTest {
 
     private static final Pattern META_REFRESH = Pattern.compile(
-            "<meta\\s+http-equiv=['\"]refresh['\"]\\s+content=['\"]0;\\s*url=([^'\"]+)['\"]",
+            "<meta\\s+http-equiv=['\"]refresh['\"]\\s+content=['\"]0;\\s*url='?([^'\"]+)'?['\"]",
             Pattern.CASE_INSENSITIVE);
 
     @Override


### PR DESCRIPTION
The existing test is a bit too prescriptive. Spec says it should be unquoted, and the current roq implementation (as of 2.1.6) uses single quotes.