### PR TITLE
Fix title band css contrast on /blog

### DIFF
--- a/_sass/quarkus.scss
+++ b/_sass/quarkus.scss
@@ -967,6 +967,7 @@ li {
     padding-bottom: 1rem;
     }
 
+    color: $white;
     H1, H3 {
     color: $white;
     }


### PR DESCRIPTION
This is a slightly strange one. The lighthouse analysis found an accessibility issue on /blog for the Roq blog, but not Jekyll. The css is the same, so Claude and I are both a bit perplexed about why lighthouse is scoring it differently, but we suspect something about inheritance or order (roq css is bundled, jekyll is not).

 The CSS has a  contrast problem (`.title-band` inherits #121212 from `* { color: var(--main-text-color); `} against dark background). It doesn't affect anything because we always use `h1` or `h3`, and those do have the text color set – but of course that's a bit fragile to reply on.

What's different between the two sites:
- Jekyll: Uses Sass asset pipeline → produces /assets/css/main.css
- Roq: Uses Quarkus Web Bundler → produces /static/bundle/app-POD47DLG.css

The bundlers compile the same SCSS differently, resulting in:
- Jekyll's CSS: .title-band doesn't trigger contrast violation
- Roq's CSS: .title-band triggers contrast violation



Possible reasons:
1. Different CSS rule ordering (cascade)
2. Different handling of CSS custom properties
3. Different optimization/minification
4. Different specificity calculations

I don't think there's anything to fix in Roq and I don't think there's any harm in fixing the issue across the board in quarkusio. 