### PR TITLE
Strengthen tags test and fix tagging regression

### DIFF
--- a/_includes/blog-band.html
+++ b/_includes/blog-band.html
@@ -68,7 +68,8 @@
     <h3 class="tags-label">Tags</h3>
     {% assign tag_keys = "" | split: "" %}
     {% for stats in site.tags %}
-     {% assign tag_keys = tag_keys | push: stats[0] | downcase %}
+     {% assign tag_lower = stats[0] | downcase %}
+     {% assign tag_keys = tag_keys | push: tag_lower %}
     {% endfor %}
     {% assign tag_words = tag_keys | uniq | sort %}
     {% for tag in tag_words %}

--- a/src/test/java/io/quarkusio/TagTest.java
+++ b/src/test/java/io/quarkusio/TagTest.java
@@ -63,8 +63,9 @@ public class TagTest extends BrowserTest {
         assertEquals("Tags", tagsLabel.first().textContent().trim());
 
         var sidebarTagLinks = page.locator(".tags-label").locator("xpath=..").locator("a[href*='/blog/tag/']");
-        assertTrue(sidebarTagLinks.count() > 0,
-                "Expected tag links in the sidebar");
+        int tagCount = sidebarTagLinks.count();
+        assertTrue(tagCount > 1, "Expected more than one tag link in the sidebar, but found " + tagCount
+                                       + ". If only 1 tag is shown, the tag list is likely being collapsed to a single string.");
     }
 
     @Test


### PR DESCRIPTION
Oops. 
<img width="343" height="275" alt="image" src="https://github.com/user-attachments/assets/1215af58-f984-4f79-8b1b-8759fe1fb7d6" />

http://quarkus.io/blog has regressed, caused by my fix to the duplicate tags. What's extra annoying is it's working fine in Roq, so this is a very temporary fix, and getting Roq to tolerate my broken fix syntax was quite hard work.  Liquid applies filters left-to-right: push returns the array, then downcase is applied to the array (not the element), which stringifies and collapses it. The fix is to downcase the tag name first in a separate variable, then push it.

I wouldn't bother fixing since I hope to cut over soon, except that (a) it's doesn't look great and (b) I want to ship the strengthened test. 