### PR TITLE
Be more specific about which versions herodevs supports

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -164,6 +164,7 @@ releases:
     latest_patch: "3.20.6.2"
     latest_patch_date: 2026-06-17
     rhbq_eol: 2027-06-30
+    herodevs_eol: nes
 
   - version: "3.19"
     release_date: 2025-02-26
@@ -314,6 +315,7 @@ releases:
     lts: false
     latest_patch: "2.16.12"
     latest_patch_date: 2023-10-17
+    herodevs_eol: nes
 
   - version: "2.15"
     release_date: 2022-12-14

--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -20,11 +20,11 @@ support_providers:
     url: "https://www.ibm.com/products/enterprise-build-of-quarkus"
   herodevs:
     name: "HeroDevs Never-Ending Support"
-    url: "https://www.herodevs.com/support/quarkus-nes"
+    url: "https://www.herodevs.com/support/nes-for-quarkus"
 
 eol_support:
   - name: "HeroDevs Never-Ending Support (NES)"
-    url: "https://www.herodevs.com/support/quarkus-nes"
+    url: "https://www.herodevs.com/support/nes-for-quarkus"
     description: >
       HeroDevs provides continued security patches and compliance
       support for EOL Quarkus versions, bridging the gap while

--- a/_includes/releases-table-band.html
+++ b/_includes/releases-table-band.html
@@ -56,6 +56,7 @@
                         {% assign eol_str = release.eol_date | date: '%Y-%m-%d' %}
                         {% assign rhbq_active = false %}
                         {% assign ibm_active = false %}
+                        {% assign herodevs_active = false %}
                         {% if release.rhbq_eol %}
                             {% assign rhbq_eol_str = release.rhbq_eol | date: '%Y-%m-%d' %}
                             {% if rhbq_eol_str > today %}{% assign rhbq_active = true %}{% endif %}
@@ -63,6 +64,9 @@
                         {% if release.ibm_eol %}
                             {% assign ibm_eol_str = release.ibm_eol | date: '%Y-%m-%d' %}
                             {% if ibm_eol_str > today %}{% assign ibm_active = true %}{% endif %}
+                        {% endif %}
+                        {% if release.herodevs_eol %}
+                        {% assign herodevs_active = true %}
                         {% endif %}
                         <tr class="release-row{% if release.upcoming %} release-upcoming{% elsif release.eol_date == nil %} release-active{% endif %}{% if release.lts %} release-lts{% endif %}" data-eol="{{ eol_str }}"{% if rhbq_active or ibm_active %} data-supported="true"{% endif %}>
                             <td>
@@ -111,10 +115,8 @@
                                 {% if ibm_active %}
                                 <a href="{{ site.data.releases.support_providers.ibm.url }}" class="release-support-badge ibm">IBM</a>
                                 {% endif %}
-                                {% if release.eol_date %}
-                                    {% unless eol_str > today %}
+                                {% if herodevs_active %}
                                 <a href="{{ site.data.releases.support_providers.herodevs.url }}" class="release-support-badge herodevs">HeroDevs</a>
-                                    {% endunless %}
                                 {% endif %}
                             </td>
                             <td>


### PR DESCRIPTION
https://www.herodevs.com/support/nes-for-quarkus shows that HeroDevs support 2.16 and 3.20, not all versions. I've updated the /releases table (and backing data) to reflect this. I've also updated the link, which was a guess (and a wrong guess), to the new one. 

https://quarkus-website-pr-2865-preview.surge.sh/releases/ shows the new page. the change is most visible when 'hide all releases' is unticked (I did a ridiculous zoom here to show it): 
<img width="2192" height="992" alt="image" src="https://github.com/user-attachments/assets/5a21a8bc-fffe-4077-8cfd-235fc5dfa716" />
