### PR TITLE
Trivial: Improve pom name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkusio</groupId>
-    <artifactId>quarkusio-website-tests</artifactId>
+    <artifactId>quarkusio-website</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>Quarkus.io - E2E Tests</name>
+    <name>Quarkus.io</name>
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.release>21</maven.compiler.release>


### PR DESCRIPTION
I keep getting confused by the artifact id in our pom. It makes sense now, since it's only tests, but as soon as we add Roq, it makes no sense at all. I've updated to something which makes sense now and post-conversion. 