### PR TITLE
Fix deploy CI: Mirror across site detection changes to the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           else
             echo "jekyll=false" >> $GITHUB_OUTPUT
           fi
-          if [ -d "src/main" ]; then
+          if [ -f "config/application.properties" ]; then
             echo "roq=true" >> $GITHUB_OUTPUT
             echo "site_dir=target/roq" >> $GITHUB_OUTPUT
           else
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'
-        run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run
+        run: QUARKUS_ROQ_GENERATOR_BATCH=true QUARKUS_PROFILE=only-latest-guides mvn -B package quarkus:run -DskipTests
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v4.0.1


### PR DESCRIPTION
#2849 broke CI, which confused me, since I obviously tested it. Turns out I changed build.yml to tolerate Java source code in a Jekyll project, but forgot to mirror my changes to deploy.yml, which isn't exercised by PRs.