### PR TITLE
Switch to Java 21 for syncing doc from main

### DIFF
--- a/.github/workflows/sync-main-doc.yml
+++ b/.github/workflows/sync-main-doc.yml
@@ -31,11 +31,11 @@ jobs:
           repository: quarkusio/quarkus
           path: .quarkus-main-repository
 
-      - name: Install JDK 17
+      - name: Install JDK 21
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Get Date
         id: get-date
         run: |


### PR DESCRIPTION
** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc **
