### PR TITLE
Preserve herodevs_eol field in release sync script

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -179,6 +179,7 @@ releases:
     latest_patch: "3.20.6.2"
     latest_patch_date: 2026-06-17
     rhbq_eol: 2027-06-30
+    herodevs_eol: nes
 
   - version: "3.19"
     release_date: 2025-02-26
@@ -329,6 +330,7 @@ releases:
     lts: false
     latest_patch: "2.16.12.Final"
     latest_patch_date: 2023-10-17
+    herodevs_eol: nes
 
   - version: "2.15"
     release_date: 2022-12-14

--- a/tools/releases-sync/README.md
+++ b/tools/releases-sync/README.md
@@ -23,7 +23,7 @@ Keeps `_data/releases.yaml` patch versions current by fetching from the GitHub A
 - `lts` - Whether this is an LTS release
 - `eol_date` - End of life date
 - `link` - Blog post link
-- `rhbq_eol`, `ibm_eol` - Commercial EOL dates
+- `rhbq_eol`, `ibm_eol`, `herodevs_eol` - Commercial EOL dates (herodevs_eol can be a date or string like "nes")
 - `upcoming` - For releases not yet published
 
 ## Running locally

--- a/tools/releases-sync/main.java
+++ b/tools/releases-sync/main.java
@@ -183,6 +183,20 @@ public class main implements Callable<Integer> {
         release.rhbqEol = parseDate(releaseMap.get("rhbq_eol"));
         release.ibmEol = parseDate(releaseMap.get("ibm_eol"));
 
+        // Parse herodevs_eol - can be a date or string like "nes"
+        Object herodevsEolValue = releaseMap.get("herodevs_eol");
+        if (herodevsEolValue instanceof String) {
+            String strValue = (String) herodevsEolValue;
+            // Try to parse as date first, if it fails keep as string
+            try {
+                release.herodevsEol = LocalDate.parse(strValue);
+            } catch (Exception e) {
+                release.herodevsEol = strValue;  // Keep as string (e.g., "nes")
+            }
+        } else {
+            release.herodevsEol = parseDate(herodevsEolValue);
+        }
+
         return release;
     }
 
@@ -663,6 +677,7 @@ public class main implements Callable<Integer> {
             release.link = existing.link;
             release.rhbqEol = existing.rhbqEol;
             release.ibmEol = existing.ibmEol;
+            release.herodevsEol = existing.herodevsEol;
         } else {
             release.lts = false;
         }
@@ -920,6 +935,14 @@ public class main implements Callable<Integer> {
             map.put("ibm_eol", new DateScalar(toDateStr(release.ibmEol)));
         }
 
+        if (release.herodevsEol != null) {
+            if (release.herodevsEol instanceof LocalDate) {
+                map.put("herodevs_eol", new DateScalar(toDateStr((LocalDate) release.herodevsEol)));
+            } else if (release.herodevsEol instanceof String) {
+                map.put("herodevs_eol", release.herodevsEol);  // Keep as string (e.g., "nes")
+            }
+        }
+
         return map;
     }
 
@@ -942,6 +965,7 @@ public class main implements Callable<Integer> {
         public String link;
         public LocalDate rhbqEol;
         public LocalDate ibmEol;
+        public Object herodevsEol;  // Can be a date or string like "nes"
         public Boolean upcoming;
     }
 


### PR DESCRIPTION
The automated release sync script was dropping `herodevs_eol` fields from releases.yaml because it only knew about `rhbq_eol` and `ibm_eol`.

Changes:
- Add herodevsEol field to Release class (supports both dates and strings like "nes")
- Parse herodevs_eol in parseRelease() with flexible type handling
- Preserve herodevs_eol when merging existing releases in createProcessedRelease()
- Write herodevs_eol back to YAML in releaseToMap()
- Update README.md to document herodevs_eol as a manually-edited field

This ensures that when maintainers add `herodevs_eol: nes` to specific versions, those markers survive automated sync runs.

Fixes the issue where herodevs_eol fields added in commit 9b67b6335 were immediately removed by the next automated sync (commit ac0ccdc08).
