### PR TITLE
Auto inject extension status note if guides forget the include

### DIFF
--- a/_plugins/asciidoctor-extension.rb
+++ b/_plugins/asciidoctor-extension.rb
@@ -181,6 +181,22 @@ Extensions.register do
 
         label_block = create_pass_block doc, label_html, {}
         doc.blocks.insert(0, label_block)
+
+        # Inject the extension-status note if the guide has not already included it.
+        # This ensures fragment links to #extension-status-note always work.
+        unless doc.find_by(id: 'extension-status-note').any?
+          includes_dir = File.join(doc.base_dir, '_includes')
+          note_file = File.join(includes_dir, 'extension-status.adoc')
+          if File.exist?(note_file)
+            note_source = File.read(note_file)
+            # Prepend the anchor before converting to ensure it's included in the output
+            note_source_with_anchor = "[[extension-status-note]]\n" + note_source
+            # Convert to HTML, then insert as a pass block
+            note_html = Asciidoctor.convert(note_source_with_anchor, safe: :unsafe, attributes: { 'extension-status' => status })
+            note_block = create_pass_block doc, note_html, {}
+            doc.blocks.insert(1, note_block)
+          end
+        end
       end
       doc
     end

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessor.java
@@ -1,10 +1,19 @@
 package io.quarkus.tools.migration.asciidoc;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.Treeprocessor;
 
 public class ExtensionStatusTreeprocessor extends Treeprocessor {
@@ -37,6 +46,58 @@ public class ExtensionStatusTreeprocessor extends Treeprocessor {
         Block labelBlock = createBlock(document, "pass", labelHtml, new HashMap<>());
         document.getBlocks().add(0, labelBlock);
 
+        // Inject the extension-status note if the guide has not already included
+        // _includes/extension-status.adoc (which provides the [[extension-status-note]] anchor).
+        List<StructuralNode> existing = document.findBy(Map.of("id", "extension-status-note"));
+        if (existing == null || existing.isEmpty()) {
+            // Only inject when the caller explicitly set a base dir. Options.BASEDIR is absent
+            // when no base dir was provided (Asciidoctor does not default it in the options map).
+            Object baseDirOpt = document.getOptions().get(Options.BASEDIR);
+            if (baseDirOpt != null) {
+                injectNoteFromIncludeFile(document, status, Paths.get(baseDirOpt.toString()));
+            }
+        }
+
         return document;
+    }
+
+    /**
+     * Reads {@code _includes/extension-status.adoc} from {@code baseDir},
+     * converts it to HTML using a fresh Asciidoctor instance (avoiding re-entrancy
+     * with the outer treeprocessor), and inserts the result as a pass block at position 1.
+     *
+     * <p>The note content lives in exactly one place on disk ({@code _includes/extension-status.adoc});
+     * this method is the DRY bridge between the treeprocessor and that file.</p>
+     */
+    private void injectNoteFromIncludeFile(Document document, String status, Path baseDir) {
+        Path noteFile = baseDir.resolve("_includes").resolve("extension-status.adoc");
+        if (!Files.isRegularFile(noteFile)) {
+            return;
+        }
+
+        try {
+            String noteSource = Files.readString(noteFile);
+            // Prepend the anchor before converting to ensure it's included in the output.
+            // This allows the include file to remain unchanged in the guides repo.
+            String noteSourceWithAnchor = "[[extension-status-note]]\n" + noteSource;
+
+            // Use a fresh Asciidoctor instance without the extension registry so that
+            // converting the note file does not re-trigger this treeprocessor.
+            // We convert to an HTML string and wrap it in a pass block — no cross-runtime
+            // AST nodes are injected into the outer document.
+            String noteHtml;
+            try (Asciidoctor inner = Asciidoctor.Factory.create()) {
+                noteHtml = inner.convert(noteSourceWithAnchor,
+                        Options.builder()
+                                .attributes(Attributes.builder()
+                                        .attribute("extension-status", status)
+                                        .build())
+                                .build());
+            }
+            Block noteBlock = createBlock(document, "pass", noteHtml, new HashMap<>());
+            document.getBlocks().add(1, noteBlock);
+        } catch (IOException e) {
+            // Non-fatal: fall back to just the label with a broken anchor
+        }
     }
 }

--- a/src/test/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessorTest.java
+++ b/src/test/java/io/quarkus/tools/migration/asciidoc/ExtensionStatusTreeprocessorTest.java
@@ -3,11 +3,16 @@ package io.quarkus.tools.migration.asciidoc;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -29,6 +34,12 @@ class ExtensionStatusTreeprocessorTest {
 
     private String convert(String adoc) {
         return asciidoctor.convert(adoc, Options.builder().build());
+    }
+
+    private String convertWithBaseDir(String adoc, Path baseDir) {
+        return asciidoctor.convert(adoc, Options.builder()
+                .baseDir(baseDir.toFile())
+                .build());
     }
 
     @ParameterizedTest
@@ -69,5 +80,93 @@ class ExtensionStatusTreeprocessorTest {
         int labelIndex = html.indexOf("status-label");
         int contentIndex = html.indexOf("Guide");
         assertTrue(labelIndex < contentIndex);
+    }
+
+    // --- Note injection tests (require an _includes/extension-status.adoc on disk) ---
+
+    @Test
+    void injectsNoteWhenIncludeFilePresent(@TempDir Path baseDir) throws IOException {
+        writeExtensionStatusInclude(baseDir);
+        String html = convertWithBaseDir(":extension-status: experimental\n\n== Guide\n\nContent.", baseDir);
+        assertTrue(html.contains("id=\"extension-status-note\""),
+                "Should inject the extension-status-note anchor from the include file");
+        assertTrue(html.contains("experimental"),
+                "Note should mention the status");
+    }
+
+    @Test
+    void noteAppearsAfterLabel(@TempDir Path baseDir) throws IOException {
+        writeExtensionStatusInclude(baseDir);
+        String html = convertWithBaseDir(":extension-status: preview\n\n== Guide\n\nContent.", baseDir);
+        int labelIndex = html.indexOf("status-label");
+        int noteIndex = html.indexOf("extension-status-note");
+        assertTrue(labelIndex >= 0, "Label should be present");
+        assertTrue(noteIndex >= 0, "Note should be present");
+        assertTrue(labelIndex < noteIndex, "Label should appear before the note");
+    }
+
+    @Test
+    void doesNotDuplicateNoteWhenAlreadyPresent(@TempDir Path baseDir) throws IOException {
+        writeExtensionStatusInclude(baseDir);
+        // Simulate a guide that manually includes the file: embed the anchor inline
+        String adoc = ":extension-status: stable\n\n== Guide\n\nContent.\n\n" +
+                "[[extension-status-note]]\nNOTE: Already included.";
+        String html = convertWithBaseDir(adoc, baseDir);
+        // The anchor id should appear exactly once — the treeprocessor must not inject a second copy.
+        // (The label's href="#extension-status-note" also contains the string but is not the id attribute.)
+        int count = 0;
+        int idx = 0;
+        String marker = "id=\"extension-status-note\"";
+        while ((idx = html.indexOf(marker, idx)) != -1) {
+            count++;
+            idx += marker.length();
+        }
+        assertTrue(count == 1, "extension-status-note anchor id should appear exactly once, found: " + count);
+    }
+
+    @Test
+    void noNoteInjectedWhenIncludeFileMissing() {
+        // No baseDir set — the note anchor (id=) should not be injected.
+        // The label's href="#extension-status-note" is always present; we only check for the anchor id.
+        String html = convert(":extension-status: deprecated\n\n== Guide\n\nContent.");
+        assertFalse(html.contains("id=\"extension-status-note\""),
+                "Without the include file on disk, no note anchor id should be injected");
+    }
+
+    /**
+     * Writes the real extension-status.adoc content into {@code baseDir/_includes/}.
+     * The content matches what's in the guides repo (no [[extension-status-note]] anchor).
+     * The treeprocessor injects the anchor programmatically when converting.
+     */
+    private static void writeExtensionStatusInclude(Path baseDir) throws IOException {
+        Path includesDir = baseDir.resolve("_includes");
+        Files.createDirectories(includesDir);
+        Files.writeString(includesDir.resolve("extension-status.adoc"), """
+                ifdef::extension-status[]
+                [NOTE]
+                ====
+                This technology is considered {extension-status}.
+
+                ifeval::["\\{extension-status}" == "experimental"]
+                In _experimental_ mode, early feedback is requested to mature the idea.
+                There is no guarantee of stability nor long term presence in the platform until the solution matures.
+                Feedback is welcome on our https://groups.google.com/d/forum/quarkus-dev[mailing list] or as issues in our https://github.com/quarkusio/quarkus/issues[GitHub issue tracker].
+                endif::[]
+                ifeval::["\\{extension-status}" == "preview"]
+                In _preview_, backward compatibility and presence in the ecosystem is not guaranteed.
+                Specific improvements might require changing configuration or APIs, and plans to become _stable_ are under way.
+                Feedback is welcome on our https://groups.google.com/d/forum/quarkus-dev[mailing list] or as issues in our https://github.com/quarkusio/quarkus/issues[GitHub issue tracker].
+                endif::[]
+                ifeval::["\\{extension-status}" == "stable"]
+                Being _stable_, backward compatibility and presence in the ecosystem are taken very seriously.
+                endif::[]
+                ifeval::["\\{extension-status}" == "deprecated"]
+                Being _deprecated_ means that this extension is likely to be replaced or removed in a future version of Quarkus.
+                endif::[]
+
+                For a full list of possible statuses, check our https://quarkus.io/faq/#what-are-the-extension-statuses[FAQ entry].
+                ====
+                endif::extension-status[]
+                """);
     }
 }


### PR DESCRIPTION
#2713, our test for dead fragment links, can't be merged yet because some links are still dead: 

```

[ERROR] Failures: 
[ERROR]   LinkCrawlerTest.crawlAndCheckFragmentAnchors:95 Found 10 broken fragment anchor(s):
  http://localhost:8090/guides#q=spring
       linked from: http://localhost:8090/spring/migrate
  http://localhost:8090/guides/container-image#s2i
       linked from: http://localhost:8090/guides/deploying-to-kubernetes
  http://localhost:8090/guides/deploying-to-kubernetes#duration-note-anchor-quarkus-kubernetes-client_quarkus-kubernetes-client
       linked from: http://localhost:8090/guides/deploying-to-kubernetes
  http://localhost:8090/guides/deploying-to-kubernetes#duration-note-anchor-quarkus-kubernetes_quarkus-knative
       linked from: http://localhost:8090/guides/deploying-to-kubernetes
  http://localhost:8090/guides/deploying-to-kubernetes#duration-note-anchor-quarkus-kubernetes_quarkus-kubernetes
       linked from: http://localhost:8090/guides/deploying-to-kubernetes
  http://localhost:8090/guides/deploying-to-kubernetes#duration-note-anchor-quarkus-kubernetes_quarkus-openshift
       linked from: http://localhost:8090/guides/deploying-to-kubernetes
  http://localhost:8090/guides/funqy#extension-status-note
       linked from: http://localhost:8090/guides/funqy
  http://localhost:8090/guides/opentelemetry#disable-all-or-parts-of-the-opentelemetry-extension
       linked from: http://localhost:8090/guides/telemetry-opentracing-to-otel-tutorial
  http://localhost:8090/guides/update-quarkus#extension-status-note
       linked from: http://localhost:8090/guides/update-quarkus
  http://localhost:8090/support#enterprise-support
       linked from: http://localhost:8090/releases
```

I thought I'd fixed all the guides dead links with https://github.com/quarkusio/quarkus/pull/55413, but when 3.38 was released, the latest guides were still failing. 

Analysis suggested that some guides forget to include `extension-status.adoc`, even though they put in an extension status. I could fix this in every guide with the problem, but that would be a lot of backports to get everything right. Instead, I've added some automagic, which auto-includes if an extension has a `:extension-status:` but doesn't include the adoc file.

Magic does have drawbacks, so I'm happy if people push back and think we should fix at source. 

##  Root Cause Analysis

  Before July 13, 2026:
  - Guides (like funqy.adoc) had :extension-status: preview
  - Ruby treeprocessor created a label with href="#extension-status-note"
  - Guides did NOT include _includes/extension-status.adoc
  - Result: BROKEN LINK - clicking the label led to #extension-status-note which didn't exist

  July 13, 2026 - PR 55413 merged:
  - Added `[[extension-status-note]]` anchor to extension-status.adoc in quarkus repo
  - Expected this to fix the problem

  But the problem persisted because:
  - Guides like funqy.adoc still don't manually include::_includes/extension-status.adoc[]
  - They only set :extension-status: preview
  - Just having the anchor in the file doesn't help if the file isn't included!
  - The ifdef::extension-status[] in extension-status.adoc means it only renders when included AND when the attribute is
  set

  August 3, 2026 - CI run failed:
  - Test detected broken #extension-status-note links in funqy and update-quarkus guides
  - PR 55413 didn't actually fix the problem because the file still wasn't being included

  August 4, 2026 - This PR
  - Added auto-injection logic to Ruby (and Java) treeprocessor
  - Now when a guide has `:extension-status:` but doesn't include the file, the treeprocessor:
    a. Reads `_includes/extension-status.adoc`
    b. Prepends the anchor (semi-redundant + defensive, it's already in the file for the latest versions – but not for older ones)
    c. Converts to HTML with the status attribute
    d. Injects as a pass block
