### PR TITLE
Fix transcription error in name in Insights blog

### DIFF
--- a/_posts/2026-08-03-quarkus-insights-255-faster-leaner-predictable-quarkus.adoc
+++ b/_posts/2026-08-03-quarkus-insights-255-faster-leaner-predictable-quarkus.adoc
@@ -3,7 +3,7 @@ layout: post
 title: 'Quarkus Insights #255: Faster, Leaner, Predictable — Quarkus in the Real World'
 date: 2026-08-03
 tags: quarkus-insights
-synopsis: 'Alex Dish, CTO at BMW Romania, shares hard numbers from his real-world experiment benchmarking Quarkus against Spring Boot across startup time, memory footprint, Docker image size, and tail latency — then translates every measurement into cloud costs and developer impact.'
+synopsis: 'Alex Diniș, CTO at BMW Romania, shares hard numbers from his real-world experiment benchmarking Quarkus against Spring Boot across startup time, memory footprint, Docker image size, and tail latency — then translates every measurement into cloud costs and developer impact.'
 author: jcobb
 ---
 
@@ -11,7 +11,7 @@ This summary was generated using AI, reviewed by humans - https://youtube.com/li
 
 == Quarkus Insights #255: Faster, Leaner, Predictable — Quarkus in the Real World
 
-Alex Dish, currently holding the CTO role at the https://www.bmw.ro/ro/index.html[BMW Romania] IT hub, brings a refreshingly practical perspective to episode 255: instead of abstract benchmarks or hello-world demos, he built the same service twice — once with Spring Boot, once with Quarkus — complete with an embedded ML sentiment classifier, and then measured everything that matters in production. The result is a cheat sheet of real numbers and the cloud cost arithmetic behind them.
+Alex Diniș, currently holding the CTO role at the https://www.bmw.ro/ro/index.html[BMW Romania] IT hub, brings a refreshingly practical perspective to episode 255: instead of abstract benchmarks or hello-world demos, he built the same service twice — once with Spring Boot, once with Quarkus — complete with an embedded ML sentiment classifier, and then measured everything that matters in production. The result is a cheat sheet of real numbers and the cloud cost arithmetic behind them.
 
 ++++
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BWr3NXgMQds" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
Not sure how I missed that when reviewing, it jumped out at me this morning.