### PR TITLE
AI visibility improvements to the robots.txt file and add llms.txt file

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,23 @@
+# Quarkus — llms.txt
+# AI Indexing & Training Policy
+
+## About
+Quarkus is a Kubernetes-native Java framework tailored for GraalVM and HotSpot,
+crafted from best-of-breed Java libraries and standards. It offers fast boot times,
+low memory footprint, and developer-joy features such as live coding.
+
+## Permissions
+This site's content is publicly available under open licenses. We welcome AI crawlers
+to index, cite, and use our documentation, guides, blog posts, and reference material.
+
+## Priority URLs
+- https://quarkus.io/
+- https://quarkus.io/guides/
+- https://quarkus.io/get-started/
+- https://quarkus.io/blog/
+- https://quarkus.io/about/
+- https://quarkus.io/faq/
+- https://quarkus.io/ai-overview/
+
+## Contact
+https://github.com/quarkusio/quarkus/issues

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,33 @@
 User-agent: *
 Disallow: /version/
+
+# Sitemap
+Sitemap: https://quarkus.io/sitemap.xml
+
+# AI Search & Citation Bots — explicitly allowed
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+# AI content policy
+LLMs: https://quarkus.io/llms.txt


### PR DESCRIPTION
### Improve AI crawler visibility via robots.txt and llms.txt
### Summary
Improves AI search engine and LLM citation visibility by expanding robots.txt with explicit bot directives and introducing a new llms.txt file following the emerging llms.txt standard.

**Changes**
robots.txt — two lines → 27 lines:

Added Sitemap: `https://quarkus.io/sitemap.xml `so all crawlers can discover site content from a single known location
Added explicit `Allow:` / entries for 8 major AI crawlers: OAI-SearchBot (ChatGPT), GPTBot (OpenAI training), Claude-SearchBot, ClaudeBot (Anthropic), PerplexityBot, Google-Extended, meta-externalagent, and cohere-ai
Added LLMs: `https://quarkus.io/llms.txt` pointer for LLM-aware clients
`llms.txt` — new file at site root:

Follows the llms.txt specification, a purpose-built standard for declaring AI indexing policy
Includes a brief Quarkus description, an explicit opt-in statement welcoming AI indexing and citation, and a curated list of high-value URLs (guides, blog, get-started, FAQ, AI overview)

### Motivation
The previous robots.txt relied entirely on the User-agent: `*` wildcard, giving no explicit signal to AI crawlers. As ChatGPT, Claude, Perplexity, and Gemini increasingly drive developer traffic, explicitly allowing their crawlers ensures Quarkus documentation surfaces in AI-generated answers and citations. No content is restricted beyond the existing `/version/ `disallow.