### PR TITLE
Use new property to resolve deprecation warnings

### DIFF
--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
+          client-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
           private-key: ${{ secrets.QUARKUS_PUSH_WEBSITE_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sync-main-doc.yml
+++ b/.github/workflows/sync-main-doc.yml
@@ -18,7 +18,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
+          client-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
           private-key: ${{ secrets.QUARKUS_PUSH_WEBSITE_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -24,7 +24,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
+          client-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
           private-key: ${{ secrets.QUARKUS_PUSH_WEBSITE_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sync-working-groups.yml
+++ b/.github/workflows/sync-working-groups.yml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
+          client-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
           private-key: ${{ secrets.QUARKUS_PUSH_WEBSITE_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/update-insights.yml
+++ b/.github/workflows/update-insights.yml
@@ -34,7 +34,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
+          client-id: ${{ secrets.QUARKUS_PUSH_WEBSITE_APP_ID }}
           private-key: ${{ secrets.QUARKUS_PUSH_WEBSITE_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
Every sync workflow is emitting deprecation warnings (except for sync-contributors, which is just broken).

The sync insights failure on this run is unrelated to this change.

```
build
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```