### PR TITLE
Add adoc attributes override so dev mode guide xref links (and link tests) work

### DIFF
--- a/content/guides/_attributes-local.adoc
+++ b/content/guides/_attributes-local.adoc
@@ -5,4 +5,7 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: /guides/images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /guides/
+:relfilesuffix: /
 // end::xref-attributes[]

--- a/content/versions/2.13/guides/_attributes-local.adoc
+++ b/content/versions/2.13/guides/_attributes-local.adoc
@@ -5,6 +5,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/2.13/
+:relfilesuffix: /
 :create-app-stream: 2.13
 :create-cli-stream: 2.13
 // end::xref-attributes[]

--- a/content/versions/2.16/guides/_attributes-local.adoc
+++ b/content/versions/2.16/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/2.16/
+:relfilesuffix: /
 :create-app-stream: 2.16
 :create-cli-stream: {create-app-stream}
 // end::xref-attributes[]

--- a/content/versions/3.15/guides/_attributes-local.adoc
+++ b/content/versions/3.15/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/3.15/
+:relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.15 https://github.com/quarkusio/quarkus-quickstarts.git
 :quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/3.15.zip

--- a/content/versions/3.2/guides/_attributes-local.adoc
+++ b/content/versions/3.2/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/3.2/
+:relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.2 https://github.com/quarkusio/quarkus-quickstarts.git
 :quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/3.2.zip

--- a/content/versions/3.20/guides/_attributes-local.adoc
+++ b/content/versions/3.20/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/3.20/
+:relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.20 https://github.com/quarkusio/quarkus-quickstarts.git
 :quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/3.20.zip

--- a/content/versions/3.27/guides/_attributes-local.adoc
+++ b/content/versions/3.27/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/3.27/
+:relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.27 https://github.com/quarkusio/quarkus-quickstarts.git
 :quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/3.27.zip

--- a/content/versions/3.33/guides/_attributes-local.adoc
+++ b/content/versions/3.33/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/3.33/
+:relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.33 https://github.com/quarkusio/quarkus-quickstarts.git
 :quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/3.33.zip

--- a/content/versions/3.34/guides/_attributes-local.adoc
+++ b/content/versions/3.34/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/3.34/
+:relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.34 https://github.com/quarkusio/quarkus-quickstarts.git
 :quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/3.34.zip

--- a/content/versions/3.8/guides/_attributes-local.adoc
+++ b/content/versions/3.8/guides/_attributes-local.adoc
@@ -4,6 +4,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/3.8/
+:relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.8 https://github.com/quarkusio/quarkus-quickstarts.git
 :quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/3.8.zip

--- a/content/versions/main/guides/_attributes-local.adoc
+++ b/content/versions/main/guides/_attributes-local.adoc
@@ -5,6 +5,9 @@
 :code-examples: {generated-dir}/examples
 :imagesdir: ./images
 :includes: ./_includes
+// TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
+:relfileprefix: /version/main/
+:relfilesuffix: /
 :quarkus-platform-groupid: io.quarkus
 //
 :quickstarts-clone-url: -b development https://github.com/quarkusio/quarkus-quickstarts.git


### PR DESCRIPTION
In dev mode, some xref guides links don't work. This also makes the link validation test fail in dev mode. See https://github.com/quarkiverse/quarkus-roq/pull/1158 for more discussion.

I think the nicest fix for this is in Roq, but we can work around it locally. 