### PR TITLE
Link crawling: Do not strip trailing slashes before visiting pages

### DIFF
--- a/src/test/java/io/quarkusio/LinkCrawlerTest.java
+++ b/src/test/java/io/quarkusio/LinkCrawlerTest.java
@@ -182,7 +182,8 @@ public class LinkCrawlerTest extends BrowserTest {
             }
             idlePolls = 0;
 
-            if (!visited.add(currentUrl)) {
+            String normalizedUrl = normalize(currentUrl);
+            if (!visited.add(normalizedUrl)) {
                 continue;
             }
             crawledCount.incrementAndGet();
@@ -198,7 +199,7 @@ public class LinkCrawlerTest extends BrowserTest {
                 if (checkInternal) {
                     BrokenLink probe = probeWithHttp(currentUrl);
                     if (probe != null) {
-                        brokenLinks.put(currentUrl, new BrokenLink(probe.status, probe.statusText, referrers.get(currentUrl)));
+                        brokenLinks.put(currentUrl, new BrokenLink(probe.status, probe.statusText, referrers.get(normalizedUrl)));
                     }
                 }
                 continue;
@@ -207,7 +208,7 @@ public class LinkCrawlerTest extends BrowserTest {
             int status = response.status();
             if (status >= 400) {
                 if (checkInternal) {
-                    brokenLinks.put(currentUrl, new BrokenLink(status, response.statusText(), referrers.get(currentUrl)));
+                    brokenLinks.put(currentUrl, new BrokenLink(status, response.statusText(), referrers.get(normalizedUrl)));
                 }
                 continue;
             }
@@ -215,7 +216,7 @@ public class LinkCrawlerTest extends BrowserTest {
             // In incremental mode, only extract links from seed pages (the
             // changed pages). Non-seed pages are visited only to verify their
             // status — a depth-1 check from each changed page.
-            if (incrementalMode && !seedUrls.contains(currentUrl)) {
+            if (incrementalMode && !seedUrls.contains(normalizedUrl)) {
                 continue;
             }
 
@@ -273,7 +274,7 @@ public class LinkCrawlerTest extends BrowserTest {
                 if (resolved.internal) {
                     String normalized = normalize(resolved.url);
                     if (!visited.contains(normalized) && !isExcluded(normalized, excludePaths)) {
-                        queue.add(normalized);
+                        queue.add(resolved.url);
                         referrers.putIfAbsent(normalized, currentUrl);
                     }
                 } else if (checkExternal && checkedExternal.add(resolved.url)) {


### PR DESCRIPTION
We still want to normalise links when deciding what has been visited, but normalising links *before* visiting can cause all sorts of problems. Every web server handles trailing slashes differently; GitHub tends to normalise them and accept with- and without slashes. The podman site has some problems at the moment with dead links because links only work in one of the with-slash-without-slash without slash variants. In dev mode, Quarkus (Vertx, really) also has issues serving pages without the trailing slash (https://github.com/quarkusio/quarkus/issues/41245). That means Roq has problems serving pages without trailing slashes in dev mode (https://github.com/quarkiverse/quarkus-roq/issues/1173). Given that, the LinkCrawlerTest shouldn't be removing slashes off of otherwise-correct links. 

This only affects dev mode, not prod mode, and only the tests, not actual browsing. It mostly affects 62 newsletter links. 