### PR TITLE
Restore all config page by avoiding premature conversion of blocks

### DIFF
--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
@@ -58,13 +58,17 @@ public class ConfigTableTreeprocessor extends Treeprocessor {
 
             if (table.hasRole("searchable") && table.getParent() instanceof StructuralNode parent) {
                 List<StructuralNode> siblings = parent.getBlocks();
-                int tableIndex = siblings.indexOf(table);
-                if (tableIndex >= 0) {
+				int tableIndex = logicalIndexOf( siblings, table );
+                if (tableIndex > 0) {
+                    StructuralNode caption = siblings.get(tableIndex - 1);
+                    String captionContent = caption.getContent() != null
+                            ? caption.getContent().toString()
+                            : "";
                     searchFieldId++;
-                    Block searchBlock = createBlock(parent, "paragraph",
-                            " <input type=\"search\" id=\"config-search-%d\" placeholder=\"FILTER CONFIGURATION\" disabled>".formatted(searchFieldId),
+                    Block newCaption = createBlock(parent, "paragraph",
+                            captionContent + " <input type=\"search\" id=\"config-search-%d\" placeholder=\"FILTER CONFIGURATION\" disabled>".formatted(searchFieldId),
                             new HashMap<>());
-                    siblings.add(tableIndex, searchBlock);
+                    siblings.set(tableIndex - 1, newCaption);
                 }
             }
         }
@@ -75,6 +79,29 @@ public class ConfigTableTreeprocessor extends Treeprocessor {
 
         return document;
     }
+
+	/**
+	 * Returns the <em>logical</em> (0-based) index of {@code node} within {@code blocks}, or -1 if absent.
+	 *
+	 * <p>This works around an AsciidoctorJ/JRuby bridge behaviour. When a document has a header, the parser
+	 * shifts the header off the body block list, leaving the underlying {@code RubyArray} with a non-zero
+	 * internal {@code begin} offset. JRuby's {@code RubyArray.indexOf} returns a {@code begin}-relative
+	 * index, whereas {@code get}/{@code set}/{@code remove}/{@code add} all use (0-based) indices.
+	 *
+	 * <p>The JRuby method causing this (returns the {@code begin}-relative {@code i}) is at:
+	 * <a href="https://github.com/jruby/jruby/blob/9.4.14.0/core/src/main/java/org/jruby/RubyArray.java#L5839-L5852">
+	 */
+	private int logicalIndexOf(List<StructuralNode> blocks, StructuralNode node) {
+		if ( blocks.isEmpty() ) {
+			return -1;
+		}
+		int physical = blocks.indexOf( node );
+		if ( physical < 0 ) {
+			return -1;
+		}
+		int begin = blocks.indexOf( blocks.get( 0 ) );
+		return physical - begin;
+	}
 
     private boolean isCollapsible(StructuralNode desc) {
         List<StructuralNode> blocks = desc.getBlocks();

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
@@ -34,7 +34,7 @@ public class ConfigTableTreeprocessor extends Treeprocessor {
                 if (row.getCells().isEmpty()) {
                     continue;
                 }
-                Cell firstCell = row.getCells().get(0);
+                Cell firstCell = row.getCells().getFirst();
                 Document innerDoc = firstCell.getInnerDocument();
                 if (innerDoc == null) {
                     continue;
@@ -99,7 +99,7 @@ public class ConfigTableTreeprocessor extends Treeprocessor {
 		if ( physical < 0 ) {
 			return -1;
 		}
-		int begin = blocks.indexOf( blocks.get( 0 ) );
+		int begin = blocks.indexOf( blocks.getFirst());
 		return physical - begin;
 	}
 
@@ -109,10 +109,8 @@ public class ConfigTableTreeprocessor extends Treeprocessor {
             return true;
         }
         if (blocks.size() == 1) {
-            Object content = blocks.get(0).getContent();
-            if (content != null && !content.toString().startsWith("Environment variable: ")) {
-                return true;
-            }
+            Object content = blocks.getFirst().getContent();
+            return content!=null && !content.toString().startsWith("Environment variable: ");
         }
         return false;
     }

--- a/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
+++ b/src/main/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessor.java
@@ -59,16 +59,12 @@ public class ConfigTableTreeprocessor extends Treeprocessor {
             if (table.hasRole("searchable") && table.getParent() instanceof StructuralNode parent) {
                 List<StructuralNode> siblings = parent.getBlocks();
                 int tableIndex = siblings.indexOf(table);
-                if (tableIndex > 0) {
-                    StructuralNode caption = siblings.get(tableIndex - 1);
-                    String captionContent = caption.getContent() != null
-                            ? caption.getContent().toString()
-                            : "";
+                if (tableIndex >= 0) {
                     searchFieldId++;
-                    Block newCaption = createBlock(parent, "paragraph",
-                            captionContent + " <input type=\"search\" id=\"config-search-%d\" placeholder=\"FILTER CONFIGURATION\" disabled>".formatted(searchFieldId),
+                    Block searchBlock = createBlock(parent, "paragraph",
+                            " <input type=\"search\" id=\"config-search-%d\" placeholder=\"FILTER CONFIGURATION\" disabled>".formatted(searchFieldId),
                             new HashMap<>());
-                    siblings.set(tableIndex - 1, newCaption);
+                    siblings.add(tableIndex, searchBlock);
                 }
             }
         }

--- a/src/test/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessorTest.java
+++ b/src/test/java/io/quarkus/tools/migration/asciidoc/ConfigTableTreeprocessorTest.java
@@ -141,6 +141,24 @@ class ConfigTableTreeprocessorTest {
     }
 
     @Test
+    void searchableTableRendersViaDocConvert() {
+        // Roq uses asciidoctor.load() + doc.convert(), not asciidoctor.convert().
+        // Calling getContent() on a sibling block during tree processing can
+        // trigger premature conversion that causes doc.convert() to silently
+        // drop the table. This test uses the same code path as Roq.
+        var doc = asciidoctor.load(CONFIG_TABLE, Options.builder()
+                .attributes(Attributes.builder()
+                        .attribute("add-copy-button-to-config-props", "true")
+                        .attribute("add-copy-button-to-env-var", "true")
+                        .build())
+                .build());
+        String html = doc.convert();
+        assertTrue(html.contains("<table"), "Table should be present in doc.convert() output");
+        assertTrue(html.contains("FILTER CONFIGURATION"), "Search input should be present");
+        assertTrue(html.contains("quarkus.redis.hosts"), "Config property content should be present");
+    }
+
+    @Test
     void noConfigTableLeavesDocumentUnchanged() {
         String html = convert("== Just a heading\n\nSome text.");
         assertFalse(html.contains("configuration-reference"));

--- a/src/test/java/io/quarkusio/AllConfigPageTest.java
+++ b/src/test/java/io/quarkusio/AllConfigPageTest.java
@@ -1,0 +1,34 @@
+package io.quarkusio;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AllConfigPageTest extends BrowserTest {
+
+    @Test
+    void allConfigPageReturns200() {
+        Response response = page.navigate(baseUrl + "/guides/all-config");
+        assertNotNull(response, "No response for /guides/all-config");
+        assertEquals(200, response.status(),
+                "Expected 200 for /guides/all-config but got " + response.status());
+    }
+
+    @Test
+    void allConfigPageHasSubstantialConfigTableContent() {
+        page.navigate(baseUrl + "/guides/all-config");
+
+        Locator tables = page.locator("table.configuration-reference");
+        assertTrue(tables.count() > 0,
+                "Expected at least one configuration-reference table on /guides/all-config. "
+                        + "The include of quarkus-all-config.adoc may not have resolved "
+                        + "(check that the generated-dir attribute points to a valid path).");
+
+        int rowCount = page.locator("table.configuration-reference tr").count();
+        assertTrue(rowCount >= 10,
+                "Expected substantial config table content on /guides/all-config but found only "
+                        + rowCount + " row(s). The config table content may be missing.");
+    }
+}

--- a/src/test/java/io/quarkusio/AsciidocConversionTest.java
+++ b/src/test/java/io/quarkusio/AsciidocConversionTest.java
@@ -1,0 +1,93 @@
+package io.quarkusio;
+
+import org.asciidoctor.*;
+import org.asciidoctor.ast.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AsciidocConversionTest {
+
+    private static Document loadDoc(String input) {
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        return asciidoctor.load(input, Options.builder()
+                .safe(SafeMode.SAFE)
+                .backend("html5")
+                .attributes(Attributes.builder()
+                        .attribute("noheader@", "")
+                        .attribute("icons", "font")
+                        .build())
+                .build());
+    }
+
+    @Test
+    void searchableConfigTableWithDescriptionBlockRenders() {
+        String input = """
+                = All configuration options
+
+                [.configuration-legend]
+                icon:lock[title=Fixed at build time] Configuration property fixed at build time
+
+                [.configuration-reference.searchable, cols="80,.^10,.^10"]
+                |===
+
+                h|Property
+                h|Type
+                h|Default
+
+                a|icon:lock[title=Fixed at build time] `quarkus.test.prop`
+
+                [.description]
+                --
+                A test property description that is long enough to be collapsible.
+                It has multiple lines of content to trigger the collapsible behavior.
+                --
+                |string
+                |`test`
+
+                |===
+                """;
+
+        String result = loadDoc(input).convert();
+
+        assertTrue(result.contains("<table"),
+                "A searchable configuration-reference table with .description blocks "
+                        + "should render. This is the pattern used by /guides/all-config.");
+        assertTrue(result.contains("quarkus.test.prop"),
+                "Config property content should be present in the rendered table");
+    }
+
+    @Test
+    void singleLineDescriptionIsNotCollapsible() {
+        String input = """
+                = Test
+
+                [.configuration-reference.searchable, cols="80,.^10,.^10"]
+                |===
+
+                h|Property
+                h|Type
+                h|Default
+
+                a|`quarkus.test.timeout`
+
+                [.description]
+                --
+                Environment variable: `QUARKUS_TEST_TIMEOUT`
+                --
+                |int
+                |`10`
+
+                |===
+                """;
+
+        String result = loadDoc(input).convert();
+
+        assertTrue(result.contains("<table"),
+                "Table with non-collapsible description should render");
+        assertTrue(result.contains("conf-non-collapsible-desc-"),
+                "Non-collapsible description should get a non-collapsible ID");
+        assertFalse(result.contains("description-decoration"),
+                "Non-collapsible description should not get a chevron decoration");
+    }
+}


### PR DESCRIPTION
This is kind of subtle, and I'm relying on Claude for diagnosis here. But I *have* verified manually, and added new tests for the all-config page, since it seems like the kind of thing that could go wrong. 

The problem happened on ConfigTableTreeprocessor, which is a Java replacement Marko and I wrote for some of the Ruby Asciidoc plugins. The search input injection code called `caption.getContent()` to read the legend paragraph's HTML. In AsciidoctorJ, this triggers premature conversion of the parent block's content, which causes `Document.convert()` (used by Roq's rendering pipeline) to skip the table  entirely. The table is silently dropped from the output.

The bug requires two conditions:
  1. Table has `.searchable` role (triggers the search input injection path)
  2. Table cells have `[.description]` blocks (triggers the collapsible row
     processing)

This is the combination used by /guides/all-config. I've checked and that combination doesn't seem to happen anywhere else.

To fix it, in ConfigTableTreeprocessor.java , instead of calling `caption.getContent()` and replacing the caption block, we insert the search input as a new sibling block  before the table. This avoids the premature conversion side effect.

I also added the tests I thought I'd added already:

1. AllConfigPageTest.java — Browser test that navigates to /guides/all-config and asserts it returns 200 and has a decent number of config table rows. This  is the test gap that allowed the bug to ship.
2. AsciidocConversionTest.java — Unit-level regression test that reproduces the exact bug: loads a searchable config-reference table with .description  blocks via doc.convert() and asserts the table HTML is present.