### PR TITLE
Do not use alt syntax in wg sync, strengthen tests

### DIFF
--- a/_data/wg.yaml
+++ b/_data/wg.yaml
@@ -1,466 +1,1853 @@
 ---
 working-groups:
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      deliverable: {board.getDeliverable().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      deliverable: {board.getDeliverable().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      deliverable: {board.getDeliverable().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      deliverable: {board.getDeliverable().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-      discussion: {board.getDiscussionLink().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      deliverable: {board.getDeliverable().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      backports: {board.getBackportsGithubProject().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      deliverable: {board.getDeliverable().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
-      deliverable: {board.getDeliverable().raw}
-      point-of-contact: "{board.getPointOfContact().raw}"
-      proposal: {board.getProposal().raw}
-    - title: "{board.title}"
-      board-url: "{board.url}"
-      short-description: |
-        {board.shortDescription.trim()}
-      readme: |
-        {board.getIndentedReadme().raw}
-      status: {board.getBadgeText()}
-      lts: {board.isLTS()}
-      completed: {board.isCompleted()}
-      last-activity: {board.getLastActivityDate()}
-      last-update-date: {board.getLastUpdate().getUpdateDate()}
-      last-update: |
-        {board.getIndentedLastUpdate().raw}
+  - title: "Quarkus 4"
+    board-url: "https://github.com/orgs/quarkusio/projects/51"
+    short-description: |
+      The Quarkus 4 working group aims to coordinate and track all Quarkus 4-related development in a long-running effort.
+    readme: |
+      <h2>Objective</h2>
+      <p>This long‑running working group is dedicated to tracking development and ensuring a smooth rollout for Quarkus 4. It will serve as the central coordination point for feature tracking, release hygiene, migration guidance, and community alignment related to Quarkus 4.</p>
+      <h2>The Problem</h2>
+      <p>Quarkus 4 introduces significant shifts, including new Java 25 flags, architectural refinements, deprecations, and ecosystem changes. Without a focused group, efforts become fragmented, and downstream consumers (extensions, integrations, platform partners) may struggle to stay aligned.</p>
+      <h2>Proposed Solution</h2>
+      <p>Establish a designated WG to:</p>
+      <ul>
+      <li>Track all Quarkus 4‑related issues and PRs (using label triage/quarkus-4)</li>
+      <li>Maintain a GitHub project board for feature status, blockers, and timelines</li>
+      <li>Coordinate across teams (core, extensions, platform, tooling)</li>
+      <li>Surface migration considerations and flag impacts (e.g. new --add-opens needs, optimized defaults) - useful to create the migration guide and rules</li>
+      <li>Publish ADRs, migration guides, and summary docs</li>
+      </ul>
+      <h2>Definition of Done</h2>
+      <p>This WG will be considered complete when:</p>
+      <ul>
+      <li>Quarkus 4 GA is released (including the platform)</li>
+      <li>All major features are merged and tested</li>
+      <li>Migration documentation is publicly available</li>
+      </ul>
+      <h2>Organizing the Work</h2>
+      <p>Coordination via:</p>
+      <ul>
+      <li>GitHub Discussions: use design‑discussions category</li>
+      <li>Issues/PRs: label with <code>triage/quarkus-4</code></li>
+      <li>Project board to track status</li>
+      </ul>
+      <h2>Expected Timeline:</h2>
+      <p>This is a long-running WG, starting now and wrapping up post‑GA (~late Q2 2026). We’ll mark it as “done” upon the public release of Quarkus 4 GA.</p>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-24
+    last-update-date: 2026-06-29
+    last-update: |
+      Work on Quarkus 4 saw progress with CI rework for the 4.0 branch. The team improved the Event bus and updated Vert.x configuration, including `Buffer#getByteBuf` usage. We also revisited the default value for `quarkus.http.use-semicolon-as-query-param-delimiter`.
+      
+      (This status update was automatically generated using AI.)
+  - title: "Observability.Next"
+    board-url: "https://github.com/orgs/quarkusio/projects/42"
+    short-description: |
+      Observability.Next is a strategic initiative to modernize the observability stack within the Quarkus framework, aiming to streamline and enhance its ability to monitor and manage distributed systems.
+    readme: |
+      <h2>Overview</h2>
+      <p>Observability.Next is a strategic initiative to modernize the observability stack within the Quarkus framework, aiming to streamline and enhance its ability to monitor and manage distributed systems. Currently, Quarkus (3.16.x) leverages the following components for observability:
+      Metrics: Managed through <a href="https://micrometer.io/">Micrometer</a>, which supports multiple registries (e.g., Prometheus) to expose application metrics.
+      Tracing: Handled via the OpenTelemetry (OTEL) SDK, enabling distributed tracing data to be exported to an OTEL collector.
+      Logging: JBoss's LogManager with a handler forwarding logs with OTEL.</p>
+      <p>While OpenTelemetry is the industry standard for observability, both in protocol and format, the OTEL SDK has proven challenging to adapt due to its design for agent-based observability. In a framework like Quarkus, more granular and direct control over observability is required to monitor application performance, reliability, and user experience effectively.</p>
+      <p>Micrometer, the de-facto Java standard for metrics, has recently proposed an enhanced, global approach to observability with the new Observation API. Expanding Micrometer’s role in Quarkus’ observability stack represents an opportunity to simplify implementation and maintenance while preserving compatibility with leading observability tools.</p>
+      <h2>Objectives</h2>
+      <p>The Observability.Next initiative seeks to strengthen the integration of Micrometer’s evolving Observability API within Quarkus, aligning it with OpenTelemetry’s protocol standards. Key objectives include:</p>
+      <ul>
+      <li>Enhanced Observability Control: Implement a framework-native, Micrometer-centric approach to metrics, traces, and logs, ensuring developers have more refined control over observability components without the limitations of the OTEL SDK.</li>
+      <li>Broader Metrics and Tracing Compatibility: Continue exposing metrics to various registries, including Prometheus, while maintaining OTEL compatibility for metrics and tracing protocols.
+      Improved Performance and Reliability: Define and measure performance baselines of the current observability setup and compare them against the next-to-be Micrometer Observation API and OTEL bridge integration to ensure tangible performance and reliability improvements.
+      Continue to support components using Micrometer metrics API or Open * Telemetry SDK (like Pulsar)</li>
+      </ul>
+      <h2>Scope</h2>
+      <p>Observability.Next will unfold across multiple phases, each handled by specialised working groups. The scope of the initial working group will include:</p>
+      <ul>
+      <li>Micrometer Observation API Integration: Introduce and integrate Micrometer’s observability API as a foundational layer</li>
+      <li>Transformation to OTEL Protocols: Develop a mechanism to translate Micrometer-collected observations into OTEL-compatible metrics, traces, and logs, ensuring smooth interoperability with OTEL-based tools and collectors.</li>
+      <li>Performance Benchmarking: Establish a performance baseline for Quarkus’ current observability model, comparing it against the new Micrometer-based observability API and OTEL bridge to quantify gains and identify areas for further optimisation.</li>
+      </ul>
+      <h2>Expected Outcomes</h2>
+      <ul>
+      <li></li>
+      <li>Improved Developer Experience: More intuitive, refined control over observability for Quarkus developers, reducing complexity and overhead associated with setting up and maintaining observability.</li>
+      <li>Ecosystem Compatibility: Continued compatibility with existing observability tools such as Prometheus and OTEL collectors, ensuring interoperability with common enterprise monitoring solutions.</li>
+      <li>Less breakage due to the OTEL SDK</li>
+      <li>More control over the semantic convention in span and metric tags</li>
+      <li>Performance Gains: Potentially lower latency and resource consumption in observability operations, contributing to Quarkus’ goal of high-performance, cloud-native applications.</li>
+      </ul>
+      <p>Some concrete features we would get at the framework level:</p>
+      <ul>
+      <li>Instrument once, plug different frameworks later</li>
+      <li>Better support of scopes than the one we have today. See:
+      https://github.com/quarkusio/quarkus/issues/25102 and
+      https://github.com/quarkusio/quarkus/issues/37140</li>
+      <li>Auto-generate metrics documentation from source code instrumented with it.</li>
+      <li>A way to manage semantic conventions</li>
+      </ul>
+      <p>Users would benefit from:</p>
+      <ul>
+      <li>A way to manage their metrics schemas.</li>
+      <li>Yet a new framework is available if they want to use it.</li>
+      </ul>
+      <hr />
+      <ul>
+      <li>
+      <p>Point of contact: @brunobat
+      (@<strong>Bruno Baptista</strong>  on Zulip)</p>
+      </li>
+      <li>
+      <p>Proposal: https://github.com/quarkusio/quarkus/discussions/44423</p>
+      </li>
+      <li>
+      <p>Related Reading:</p>
+      <ul>
+      <li>Micrometer, Observation API and OpenTelemetry roadmap: https://groups.google.com/g/quarkus-dev/c/y5-ojIVsa_M/m/4wquJi4bBQAJ</li>
+      </ul>
+      </li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-23
+    last-update-date: 2026-06-29
+    last-update: |
+      The team resolved issues with OpenTelemetry context loss in blocking `@ConsumeEvent` messages and improved Vert.x event bus span correlation. We also addressed the `HttpServerMetricsTagsContributor` for connection resets. Current efforts focus on OpenTelemetry declarative configuration, propagating OTel trace context, and exploring observability guidance with AI.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@brunobat"
+    proposal: https://github.com/quarkusio/quarkus/discussions/44423
+  - title: "Quarkus Data"
+    board-url: "https://github.com/orgs/quarkusio/projects/50"
+    short-description: |
+      The primary objective of this working group is to develop the next version of Panache, now known as Quarkus Data.
+    readme: |
+      <h1>Objective</h1>
+      <p>The main objective of this working group is to bring forth the next version of Panache.</p>
+      <h1>The Problem</h1>
+      <p>Panache is great for many things, but over time, we realised the following limitations:</p>
+      <ul>
+      <li>We have three distinct versions: Hibernate ORM, Hibernate Reactive and Mongo (blocking and reactive)</li>
+      <li>It is impossible to use the same entities with Hibernate ORM and Hibernate Reactive</li>
+      <li>Stateless sessions are not supported</li>
+      <li>Hibernate Processor annotations, and Jakarta Data are not supported</li>
+      <li>We have triplicate types such as <code>Sort</code> and <code>Order</code> between Panache, ORM and Jakarta Data</li>
+      <li>We have two ways to place entity query operations : on the entity itself, or in repositories</li>
+      <li>Entity query operations require type-system hacks which makes them less type-safe than we want with <code>var</code> and <code>for-each</code> and especially with reactive operations.</li>
+      </ul>
+      <h1>The proposed Solution</h1>
+      <p>We propose a new Panache version that will solve all these issues:</p>
+      <ul>
+      <li>Unify all variants in a single module, supporting blocking, reactive, stateless and stateful sessions</li>
+      <li>Provide an entity toplevel class for each 4 modes of operation, yet allow access to the other modes</li>
+      <li>Move all entity query operations from the entity class to the repository class</li>
+      <li>Provide a repository toplevel class for each 4 modes of operation, yet allow access to the other modes</li>
+      <li>Provide easy access to any type of repository by placing them as nested interfaces in the entity class, via a generated accessor on the entity metamodel class</li>
+      <li>Provide out of the box accessors for the 4 modes of operation repositories on the entity metamodel class</li>
+      <li>Support Jakarta Data and Hibernate Processor type-safe annotations</li>
+      <li>Optional: Support of Mongo via the coming ORM JDBC support</li>
+      <li>Optional: provide JD repository type alternatives for the missing three modes</li>
+      <li>Optional: provide a way to convert Panache 1 to Panache.Next</li>
+      </ul>
+      <h1>Definition of Done</h1>
+      <ul>
+      <li>Deliver the new Panache extension as a <code>stable</code> state (after preview/experimental versions for feedback)</li>
+      <li>Tests</li>
+      <li>Documentation</li>
+      <li>Codestart</li>
+      <li>REST Data with Panache support</li>
+      <li>Renarde support</li>
+      <li>Quarkus Insights</li>
+      </ul>
+      <h1>Scope of Work</h1>
+      <p>It is currently out of scope to retrofit this with the existing Panache modules. This will be a new module with no backward compatibility (although most type-unsafe operations will continue as-is, so you will be familiar with them).</p>
+      <h1>Organizing the Work</h1>
+      <h2>Communication and Transparency:</h2>
+      <p>This will be done via GitHub issues on the Quarkus core project.</p>
+      <h2>Expected Timeline:</h2>
+      <p>Most of the R&amp;D and design work has been completed over the last two years. Now remains the task of merging, documenting, testing, and tweaking it until it's complete.</p>
+      <ul>
+      <li>Point of contact: @FroMage  (@<strong>Stephane Epardaud</strong>  on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/48949</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Panache.2ENext/with/529258261">Zulip</a></li>
+      <li>Deliverable: <a href="https://quarkus.io/blog/hibernate-panache-next/">Blog Post</a></li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-23
+    last-update-date: 2026-06-29
+    last-update: |
+      The team resolved issues with `AutoId` and `@Transactional` in Hibernate Reactive Panache, also addressing duplicate feature name conflicts. Our focus now turns to redesigning core data operations, fleshing out shortcut types, and integrating with Spring Data extensions.
+      
+      (This status update was automatically generated using AI.)
+    deliverable: <a rel="nofollow" href="https://quarkus.io/blog/hibernate-panache-next/">Blog Post</a>
+    point-of-contact: "@FroMage  (@<strong>Stephane Epardaud</strong>  on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/48949
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Panache.2ENext/with/529258261
+  - title: "Quarkus 4"
+    board-url: "https://github.com/orgs/quarkusio/projects/51"
+    short-description: |
+      The Quarkus 4 working group aims to coordinate and track all Quarkus 4-related development in a long-running effort.
+    readme: |
+      <h2>Objective</h2>
+      <p>This long‑running working group is dedicated to tracking development and ensuring a smooth rollout for Quarkus 4. It will serve as the central coordination point for feature tracking, release hygiene, migration guidance, and community alignment related to Quarkus 4.</p>
+      <h2>The Problem</h2>
+      <p>Quarkus 4 introduces significant shifts, including new Java 25 flags, architectural refinements, deprecations, and ecosystem changes. Without a focused group, efforts become fragmented, and downstream consumers (extensions, integrations, platform partners) may struggle to stay aligned.</p>
+      <h2>Proposed Solution</h2>
+      <p>Establish a designated WG to:</p>
+      <ul>
+      <li>Track all Quarkus 4‑related issues and PRs (using label triage/quarkus-4)</li>
+      <li>Maintain a GitHub project board for feature status, blockers, and timelines</li>
+      <li>Coordinate across teams (core, extensions, platform, tooling)</li>
+      <li>Surface migration considerations and flag impacts (e.g. new --add-opens needs, optimized defaults) - useful to create the migration guide and rules</li>
+      <li>Publish ADRs, migration guides, and summary docs</li>
+      </ul>
+      <h2>Definition of Done</h2>
+      <p>This WG will be considered complete when:</p>
+      <ul>
+      <li>Quarkus 4 GA is released (including the platform)</li>
+      <li>All major features are merged and tested</li>
+      <li>Migration documentation is publicly available</li>
+      </ul>
+      <h2>Organizing the Work</h2>
+      <p>Coordination via:</p>
+      <ul>
+      <li>GitHub Discussions: use design‑discussions category</li>
+      <li>Issues/PRs: label with <code>triage/quarkus-4</code></li>
+      <li>Project board to track status</li>
+      </ul>
+      <h2>Expected Timeline:</h2>
+      <p>This is a long-running WG, starting now and wrapping up post‑GA (~late Q2 2026). We’ll mark it as “done” upon the public release of Quarkus 4 GA.</p>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-22
+    last-update-date: 2026-06-29
+    last-update: |
+      Work on Quarkus 4 saw progress with CI rework for the 4.0 branch. The team improved the Event bus and updated Vert.x configuration, including `Buffer#getByteBuf` usage. We also revisited the default value for `quarkus.http.use-semicolon-as-query-param-delimiter`.
+      
+      (This status update was automatically generated using AI.)
+  - title: "Convert quarkus.io to Roq"
+    board-url: "https://github.com/orgs/quarkusio/projects/79"
+    short-description: |
+      The main objective of this working group is to convert our Jekyll-based website to one built on Roq. A side-effect may be a more generalised set of tools and docs for others to use to convert their sites.
+    readme: |
+      <h2>Objective:</h2>
+      <p>The main objective of this working group is to convert our Jekyll-based website to a Roq-based one.</p>
+      <h2>The Problem</h2>
+      <p>Although Quarkus promotes a Quarkus-based static site generator, our own website uses a Ruby-based one. As well as being reputationally awkward (why aren't we eating our own dog food?), the Ruby-based generator has several practical limitations:</p>
+      <ul>
+      <li>It is difficult for the Java experts in the Quarkus team to make changes to the Ruby site code to add dynamic features. This means many enhancements get ruled out at the design stage.</li>
+      <li>The site build is temperamental. Local Ruby installations can break, and even the container-based build can break.</li>
+      </ul>
+      <h2>The proposed Solution</h2>
+      <p>Add support for Roq for the range of features used on quarkus.io, and add migration scripts to convert Jekyll to Quarkus. Once these are done, the quarkus.io site can be converted to Roq.</p>
+      <h2>Definition of Done</h2>
+      <p>This working group is complete when the live quarkus.io site is based on Roq.</p>
+      <h2>Scope of Work</h2>
+      <p>Visual changes to the website are outside the scope of this work. Conversion of some of the smaller satellite sites, such as https://quarkiverse.io/, could be in scope to act as prototypes. It is assumed that the quarkus.io contents that use asciidoc will continue to do so.</p>
+      <h2>Organizing the Work</h2>
+      <p>Issues will be split between the https://github.com/quarkusio/quarkusio.github.io and https://github.com/quarkiverse/quarkus-roq repositories. Zulip will be used for coordination.</p>
+      <h2>Expected Timeline:</h2>
+      <p>I expect about six months to be a suitable timescale.</p>
+      <p>As always, we will aim for an incremental delivery, although the final switch will be a big bang.</p>
+      <ul>
+      <li>Support building Roq sites in quarkus.io preview</li>
+      <li>Develop conversion scripts</li>
+      <li>Maintain a long-running PR, with scripts</li>
+      <li>Fill functionality gaps in Roq</li>
+      <li>(possibly) Split site and and ship some sub-sections as Roq, some as Jekyll</li>
+      </ul>
+      <h2>Potential Outcomes &amp; Deliverables</h2>
+      <p>The deliverables of this working group include:</p>
+      <ul>
+      <li>An easy-to-build, high-quality, dog-fooded website</li>
+      <li>Technical improvements to Roq to support the range of features required for a site as complex as quarkus.io</li>
+      <li>A set of documentation and scripts that will help other people do Jekyll to Roq conversions</li>
+      </ul>
+      <h2>Detailed implementation plan</h2>
+      <ul>
+      <li>[X] Sanitisation of quarkus.io</li>
+      <li>[X] Write tests</li>
+      <li>[X] Write converter</li>
+      <li>[X] All tests passing on converted site
+      <ul>
+      <li>Smoke tests</li>
+      <li>Links tests</li>
+      <li>Lighthouse scores</li>
+      </ul>
+      </li>
+      <li>[X] Docs + design teams validate dev workflow</li>
+      <li>[ ] Merge <a href="https://github.com/quarkusio/quarkusio.github.io/pull/2683">PR</a> to switch main site</li>
+      <li>[ ] Quick post merge updates
+      <ul>
+      <li>“This site is built with Jekyll” …</li>
+      <li>Readmes and contributing guides</li>
+      <li>Update guides sync scripts in quarkus repo</li>
+      </ul>
+      </li>
+      <li>[ ] Translation: Migrate translated websites and merge</li>
+      <li>[ ] Final tidying
+      <ul>
+      <li>Switch to @RoqAndRoll for testing</li>
+      <li>Switch to directories-for-pages structure</li>
+      <li>Use Roq-idiomatic data instead of _data</li>
+      </ul>
+      </li>
+      <li>[ ] Release converter as part of Roq</li>
+      </ul>
+      <ul>
+      <li>Point of contact: @holly-cummins and @ia3andy</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/53541</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev">Zulip</a>)</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-21
+    last-update-date: 2026-07-21
+    last-update: |
+      Community call recording: https://youtu.be/RaQlgXXHVr8
+      
+      All tests are passing, manual validation finds no problems, and I think we are close to cutting over the quarkus.io site.
+    point-of-contact: "@holly-cummins and @ia3andy"
+    proposal: https://github.com/quarkusio/quarkus/discussions/53541
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev
+  - title: "Dev Services Lifecycle"
+    board-url: "https://github.com/orgs/quarkusio/projects/49"
+    short-description: |
+      This working group will define and implement a consistent and configurable lifecycle model for Dev Services. It will shift the startup to the correct phase, enable optional reuse across dev and test modes, and clarify teardown and sharing behavior. The goal is to improve the developer experience.
+    readme: |
+      <p>This working group was formed to address long-standing inconsistencies and pain points in the Dev Services lifecycle within Quarkus. Dev Services are essential for simplifying local development and testing by automatically provisioning runtime dependencies (e.g., databases, message brokers), but their current lifecycle behavior leads to confusion and inefficiencies. Most notably, they are started during the augmentation phase, which conflicts with their inherently runtime-oriented nature and causes issues with newer efforts such as the test classloading revamp.</p>
+      <p>The primary goal of this group is to define and implement a consistent, runtime-aligned lifecycle model for Dev Services. This includes shifting their startup to a phase after augmentation but before the application begins execution, ensuring better alignment with the runtime environment. A critical focus will also be on enabling optional reuse of Dev Services across dev and test modes — including reuse between repeated test executions — to reduce startup time and improve the iterative development experience.</p>
+      <p>The group's scope covers several strategic areas: formalizing when and how Dev Services are started, reused, or stopped; defining rules for discoverability and sharing between profiles or processes; and avoiding resource leaks or accidental retention. It explicitly excludes broader orchestration features (such as service dependency graphs) and unrelated feature enhancements.</p>
+      <p>The working group will produce a set of deliverables to support the new model. These include one or more Architecture Decision Records (ADRs) describing the new lifecycle model, the implementation of lifecycle logic in Quarkus Core, and updates to both user-facing and contributor documentation. Additionally, enhancements to the Dev Services development model will make it easier for extension authors to adopt and follow the new lifecycle standards. A public communication effort (e.g., blog posts or demos) will also be used to showcase the improvements.</p>
+      <p>The new API is described here: https://quarkus.io/blog/new-dev-services-api/</p>
+      <ul>
+      <li>Point of contact: @holly-cummins (@<strong>Holly Cummins</strong>  on Zulip), @ozangunalp (@<strong>Ozan Günalp</strong> on Zulip )</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/47683</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev">Zulip</a>)</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-20
+    last-update-date: 2026-06-29
+    last-update: |
+      The group migrated observability to the new dev service model. We also addressed the `ObservabilityJsonRPCService` failure that occurred when the LGTM dev service was disabled.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@holly-cummins (@<strong>Holly Cummins</strong>  on Zulip), @ozangunalp (@<strong>Ozan Günalp</strong> on Zulip )"
+    proposal: https://github.com/quarkusio/quarkus/discussions/47683
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev
+  - title: "Modularity (JPMS) and JLink"
+    board-url: "https://github.com/orgs/quarkusio/projects/76"
+    short-description: |
+      Make Quarkus applications fully modular using JPMS (Java Platform Module System) and enable jlink as a first-class packaging strategy, producing smaller, faster, self-contained application images, with the long-term goal of making modular packaging the default and phasing out the legacy fast-jar lay
+    readme: |
+      <h2>Objective</h2>
+      <p>Make Quarkus applications fully modular using JPMS (Java Platform Module System) and enable <code>jlink</code> as a first-class packaging strategy, producing smaller, faster, self-contained application images, with the long-term goal of making modular packaging the default and phasing out the legacy fast-jar layout.</p>
+      <h2>The Problem</h2>
+      <h3>Class Loading Architecture Debt</h3>
+      <p>The Quarkus codebase contains between 15 and 20 class loader implementations, each with different behavior. These serve a variety of purposes, exposing hidden APIs, setting up execution environments for different launch modes, working around upstream issues, customizing parent delegation; but the ad hoc approach creates concurrency issues, virtual thread pinning, delegation bugs, and makes it nearly impossible to support JPMS properly.</p>
+      <h3>No JPMS Support</h3>
+      <p>Quarkus applications cannot take advantage of the Java Platform Module System. This means:</p>
+      <ul>
+      <li><strong>No module isolation</strong>: all application code, extensions, and dependencies share a flat classpath. There is no enforcement of encapsulation boundaries between artifacts at runtime.</li>
+      <li><strong>No <code>jlink</code> support</strong>: applications cannot use <code>jlink</code> to produce optimized, stripped-down JVM images containing only the modules actually needed, resulting in unnecessarily large deployments.</li>
+      <li><strong>No forward compatibility</strong>: future JDK features (FFM restrictions, Leyden AOT, serialization restrictions) increasingly assume or require JPMS. Without module support, Quarkus will face growing friction with each JDK release.</li>
+      <li><strong>Split packages and service loading issues</strong>: the current flat classpath tolerates split packages and uncontrolled service loading, which masks real dependency problems and makes the classpath fragile.</li>
+      </ul>
+      <h3>Packaging Inefficiency</h3>
+      <p>The current fast-jar packaging produces application images that are significantly larger than they need to be:</p>
+      <ul>
+      <li>Applications bundle the entire JDK (or require one to be pre-installed), even though most applications use a small fraction of JDK modules</li>
+      <li>No tree-shaking of unused JDK modules</li>
+      <li>Container images cannot effectively share JVM layers across different Quarkus applications</li>
+      <li>Image size comparison from prototype work shows: <strong>GraalVM native &lt; jlink (modular) &lt; fast-jar &lt; AOT</strong> — meaning jlink provides a substantial size improvement over fast-jar without the complexity and limitations of native compilation</li>
+      </ul>
+      <h3>No Optimized Container Layering</h3>
+      <p>A <code>jlink</code>-based modular image contains its own JVM, which allows container images to use a minimal base layer (no JDK required in the base). This opens the door to effective layer sharing across Quarkus applications running the same Quarkus version, the Quarkus core + JDK modules layer can be shared, with only the application layer differing. Today, this is not possible.</p>
+      <h2>The Proposed Solution</h2>
+      <h3>JPMS Modularization of Quarkus</h3>
+      <p>Systematically modularize the Quarkus codebase so that each dependency/artifact gets its own class loader and module:</p>
+      <ul>
+      <li>Artifacts with <code>module-info.java</code> are created as named modules</li>
+      <li>Other artifacts are created as unnamed modules with automatic module names</li>
+      <li>A modular class loader architecture (based on David's <code>modules3</code> prototype) replaces the current ad hoc class loaders</li>
+      <li>Each module has proper <code>exports</code>, <code>opens</code>, <code>requires</code>, <code>uses</code>, and <code>provides</code> declarations</li>
+      </ul>
+      <p><strong>Current prototype status:</strong> David's prototype (<code>dmlloyd/quarkus@modular</code> + <code>dmlloyd/modules3</code>) demonstrates this approach working. In the <code>getting-started</code> example, 39 out of 111 JARs are already modular. The remaining need automatic module names or full <code>module-info</code> files. Approximately 6-7 manual module patches are still required to start an application.</p>
+      <p><strong>Key challenges to resolve:</strong></p>
+      <ul>
+      <li>Split packages between artifacts (tracked in #44710, not as bad as it initially appears)</li>
+      <li>Generated classes at build time need a module home (#44657, more serious)</li>
+      <li>Service loading across module boundaries needs correct <code>uses</code>/<code>provides</code> declarations</li>
+      <li>Some artifacts will remain as unnamed modules until upstream projects add <code>module-info</code></li>
+      </ul>
+      <h3>JLink Packaging</h3>
+      <p>Introduce <code>jlink</code> as a packaging type for Quarkus applications:</p>
+      <ul>
+      <li>Produce a self-contained application image with only the JDK modules actually used</li>
+      <li>The image includes a custom JVM runtime, the modular application, and a launcher</li>
+      <li>No external JDK installation required to run the application</li>
+      <li>Performance is slightly better than fast-jar even without AOT (demonstrated in prototype)</li>
+      </ul>
+      <p><strong>Image layout:</strong></p>
+      <ul>
+      <li>A <code>jlink</code>-produced image is a directory containing <code>bin/</code> (launcher), <code>lib/</code> (JVM modules + application modules), and <code>conf/</code></li>
+      <li>The layout naturally supports container image layering: JVM + Quarkus core in a shared base layer, application modules in the top layer</li>
+      </ul>
+      <h3>Container Image Optimization</h3>
+      <p>Leverage the modular architecture for optimized container images:</p>
+      <ul>
+      <li><strong>Shared base layers</strong>: multiple Quarkus applications running the same Quarkus version share a common layer containing the JDK modules and Quarkus core, dramatically reducing per-application image size</li>
+      <li><strong>Minimal base image</strong>: since jlink embeds the JVM, containers can use a minimal base (e.g., <code>ubi-micro</code>, <code>scratch</code> or <code>distroless</code>) instead of a JDK base image</li>
+      <li><strong>AOT layering</strong>: AOT cache currently causes prohibitive image size bloat, but a layering strategy (AOT cache in a shared layer) may provide a partial solution; this needs investigation</li>
+      </ul>
+      <h3>Long-Term: Default Modular Packaging</h3>
+      <p>The long-term goal is to make modular packaging the default build and test mode, phasing out the legacy fast-jar layout:</p>
+      <ol>
+      <li>First, modular packaging exists as an opt-in alternative (<code>MODULAR</code> packaging type or dedicated extension)</li>
+      <li>Then, CI builds and tests run against both fast-jar and modular packaging</li>
+      <li>Eventually, modular packaging becomes the default, with fast-jar available as a fallback</li>
+      <li>Finally, fast-jar is deprecated and removed</li>
+      </ol>
+      <h3>Leyden / CDS Integration</h3>
+      <p>The modular architecture positions Quarkus well for Project Leyden:</p>
+      <ul>
+      <li>The Quarkus core and bootstrap layer is loaded by the system class loader, making it eligible for Leyden premain optimizations</li>
+      <li>A shared Leyden-trained layer (JDK modules + Quarkus core) could be reused across applications</li>
+      <li>Extension and user code in separate module layers can benefit from Leyden independently</li>
+      <li>Full Leyden integration is out of scope for this WG but the architecture should not preclude it</li>
+      </ul>
+      <h2>Definition of Done</h2>
+      <ul>
+      <li>[ ] Quarkus core modules have <code>module-info.java</code> descriptors (or automatic module names as an intermediate step)</li>
+      <li>[ ] Applications can be built with modular packaging (<code>jlink</code> output)</li>
+      <li>[ ] A <code>jlink</code>-packaged application starts and runs correctly (getting-started, REST, database scenarios)</li>
+      <li>[ ] No manual module patches required to start an application</li>
+      <li>[ ] Split package issues resolved for core Quarkus modules</li>
+      <li>[ ] Generated classes have a proper module home</li>
+      <li>[ ] Service loading works correctly across module boundaries</li>
+      <li>[ ] <code>jlink</code> image size is smaller than fast-jar for equivalent applications</li>
+      <li>[ ] Container image guide documents the layering strategy for modular images</li>
+      <li>[ ] Performance is on par with or better than fast-jar</li>
+      <li>[ ] Dev mode works with modular class loading</li>
+      <li>[ ] Extension developer guide for making extensions module-friendly</li>
+      </ul>
+      <h2>Scope of Work</h2>
+      <h3>In Scope</h3>
+      <ul>
+      <li>JPMS modularization of Quarkus core modules (<code>module-info.java</code> + automatic module names)</li>
+      <li>Modular class loader architecture (replacing ad hoc class loaders for the modular packaging path)</li>
+      <li><code>jlink</code> packaging type for Quarkus applications (name to be defined)</li>
+      <li>Resolving split packages and generated class module assignment</li>
+      <li>Service loading across module boundaries</li>
+      <li>Container image layering strategy for modular images</li>
+      <li>Dev mode support with modular class loading</li>
+      <li>Extension author guidance for module compatibility</li>
+      <li>Performance validation (startup time, memory, image size)</li>
+      </ul>
+      <h3>Out of Scope</h3>
+      <ul>
+      <li>Full rewrite of all 15-20 existing class loaders (incremental cleanup continues separately)</li>
+      <li>Test class loading rework (covered by a separate WG)</li>
+      <li>Project Leyden / CDS integration (parrallel work, but architecture should not preclude it)</li>
+      <li>Modularizing third-party dependencies (upstream responsibility; Quarkus handles them as unnamed/automatic modules)</li>
+      </ul>
+      <h2>Organizing the Work</h2>
+      <h3>Communication</h3>
+      <ul>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/53223</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-modularity/with/581640512">#wg-modularity</a></li>
+      <li>Point of contact: @dmlloyd</li>
+      </ul>
+      <h3>Existing Issues and Discussions</h3>
+      <ul>
+      <li><a href="https://github.com/quarkusio/quarkus/discussions/43749">#43749</a> — Class loading WG discussion</li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/43726">#43726</a> — Class loader cleanup umbrella</li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/44710">#44710</a> — Split packages</li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/44657">#44657</a> — Generated classes and modules</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-16
+    last-update-date: 2026-06-29
+    last-update: |
+      The team migrated JAR file writing to `smallrye-common` facilities and made several JLink adjustments. We also resolved a SmallRye and MicroProfile config version conflict that was impacting Java module builds. The focus now is on new `Archive` APIs in `smallrye-common-io` and refining manifest copying.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@dmlloyd"
+    proposal: https://github.com/quarkusio/quarkus/discussions/53223
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-modularity/with/581640512
+  - title: "Graceful Shutdown"
+    board-url: "https://github.com/orgs/quarkusio/projects/74"
+    short-description: |
+      Make Quarkus shutdown truly graceful by providing two complementary capabilities: (1) a mechanism for extensions to block incoming traffic and drain in-flight work to reach a quiescent state, integrated with readiness health checks, and (2) a well-ordered, phased shutdown API that gives extension de
+    readme: |
+      <h2>Objective</h2>
+      <p>Make Quarkus shutdown truly graceful by providing two complementary capabilities: (1) a mechanism for extensions to block incoming traffic and drain in-flight work to reach a quiescent state, integrated with readiness health checks, and (2) a well-ordered, phased shutdown API that gives extension developers clear control over when and how their shutdown logic executes.</p>
+      <h2>The Problem</h2>
+      <h3>No Quiescence Mechanism</h3>
+      <p>When a Quarkus application receives a shutdown signal, there is no standard way for extensions to transition gracefully from &quot;serving&quot; to &quot;draining&quot; to &quot;stopped.&quot; The core issue is the lack of a <strong>quiescence protocol</strong>, a coordinated mechanism where:</p>
+      <ol>
+      <li>The application signals it is no longer ready to accept new work (readiness probe goes unhealthy)</li>
+      <li>Incoming traffic is blocked at the ingress layer (load balancer, Kubernetes, service mesh)</li>
+      <li>In-flight requests, transactions, and background work are given time to complete</li>
+      <li>Only once the application reaches a quiescent state does actual resource teardown begin</li>
+      </ol>
+      <p>Today, each extension that wants to participate in graceful shutdown must implement this pattern ad hoc. Most don't. The result is interrupted HTTP requests, half-processed messages, aborted scheduled jobs, and data loss during rolling deployments.</p>
+      <p>The readiness health check (<code>/q/health/ready</code>, SmallRye Health, Kubernetes readiness probes) is the natural signal to orchestrators that an instance should stop receiving traffic, but the shutdown sequence does not integrate with it in a first-class way. Extensions cannot easily declare &quot;I am draining, mark me as not ready&quot; and have that reflected in the health check automatically.</p>
+      <h3>Confusing and Under-Documented Shutdown APIs</h3>
+      <p>Quarkus currently has <strong>three separate shutdown API layers</strong> with unclear boundaries:</p>
+      <ul>
+      <li>
+      <p><strong>Primordial API</strong> (<code>ShutdownContext</code>): <code>addShutdownTask(Runnable)</code> (reverse order) and <code>addLastShutdownTask(Runnable)</code>, used via <code>ShutdownContextBuildItem</code> at build time. The <code>addLastShutdownTask()</code> name is universally disliked (at least we reached a consensus).</p>
+      </li>
+      <li></li>
+      <li>
+      <p><strong>Graceful Shutdown API</strong> (<code>ShutdownListener</code>): <code>preShutdown(ShutdownNotification)</code> and <code>shutdown(ShutdownNotification)</code> with <code>done()</code> callback, used via <code>ShutdownListenerBuildItem</code>. Also exposes <code>@ShutdownDelayInitiated</code> which maps to <code>preShutdown</code>.</p>
+      </li>
+      <li>
+      <p><strong>CDI layer</strong>: <code>@Shutdown</code> (fires <code>ShutdownEvent</code> before ArC shutdown), <code>@BeforeDestroyed(ApplicationScoped.class)</code> (fired when ArC shuts down), <code>@PreDestroy</code> on beans/interceptors.</p>
+      </li>
+      </ul>
+      <p>There is no documentation explaining when to use which API. The actual shutdown sequence is only discoverable by reading the source code:</p>
+      <ol>
+      <li>
+      <p><strong>Graceful shutdown phase:</strong> <code>ShutdownListener#preShutdown()</code> → delay wait (if <code>quarkus.shutdown.delay-enabled=true</code>, duration = <code>quarkus.shutdown.delay</code>) → <code>ShutdownListener#shutdown()</code> → timeout wait</p>
+      </li>
+      <li>
+      <p><strong>Shutdown tasks phase:</strong> <code>ShutdownEvent</code> fired → ArC shutdown (<code>@BeforeDestroyed(ApplicationScoped.class)</code>, <code>@PreDestroy</code>)</p>
+      </li>
+      <li>
+      <p><strong>Last shutdown tasks phase:</strong> Tasks registered via <code>addLastShutdownTask()</code></p>
+      </li>
+      </ol>
+      <h3>No Cross-Extension Ordering</h3>
+      <p>There is no way to express that the shutdown logic from extension A should execute before or after the logic from extension B. Extensions shut down in an undefined order, which causes real issues; for example, a scheduler extension may try to complete a job that requires a datasource that has already been closed.</p>
+      <h3>No Debug/Tracing Tools</h3>
+      <p>There is no way to log, trace, or inspect the shutdown sequence at runtime. When shutdown hangs or misbehaves, developers have no tooling to identify which task is blocking or how tasks are ordered.</p>
+      <h3>Limited Extension Coverage</h3>
+      <p>Many extensions do not participate in graceful shutdown at all. For example, <code>quarkus-scheduler</code> does not drain running or scheduled jobs before shutdown, which can cause work to be interrupted.</p>
+      <h2>The Proposed Solution</h2>
+      <p>The work is organized around two complementary parts.</p>
+      <h3>Part 1: Pre-Shutdown Phase (Traffic Draining)</h3>
+      <p>Design and implement a standard protocol for extensions to participate in graceful traffic draining, allowing the application to reach a quiescent state before any ordering-sensitive teardown begins. This phase is independent of the dependency-ordered teardown in Part 2 — it runs first and is about stopping new work, not tearing down resources.</p>
+      <p><strong>Traffic blocking and readiness integration:</strong></p>
+      <ul>
+      <li>When shutdown is initiated, the application's readiness health check (<code>/q/health/ready</code>) immediately reports <code>DOWN</code>, signaling to Kubernetes / load balancers to stop routing new traffic</li>
+      <li>Extensions can register as &quot;drainable&quot; components, when shutdown begins, they stop accepting new work and drain in-flight work</li>
+      <li>A configurable drain timeout governs how long the system waits for quiescence before forcing teardown</li>
+      </ul>
+      <p><strong>Extension participation model:</strong></p>
+      <ul>
+      <li>Extensions declare their draining capability and report when they have reached quiescence (no in-flight work remaining)</li>
+      <li>The shutdown sequence waits for all drainable extensions to report quiescence (or for the drain timeout to expire) before proceeding to resource teardown</li>
+      <li>This replaces the current ad hoc pattern where extensions individually implement <code>ShutdownListener#preShutdown()</code> with a <code>done()</code> callback</li>
+      </ul>
+      <p><strong>Key integrations:</strong></p>
+      <ul>
+      <li>HTTP server: stop accepting new connections, finish in-flight requests</li>
+      <li>Quarkus Messaging: stop polling for new messages, finish processing in-flight messages</li>
+      <li>Scheduler: stop scheduling new jobs, wait for running jobs to complete</li>
+      <li>gRPC server: send GOAWAY, drain active RPCs</li>
+      <li>WebSocket: send close frames, wait for graceful close</li>
+      </ul>
+      <h3>Part 2: Dependency-Ordered Shutdown (and Startup) API</h3>
+      <p>The correct shutdown order is the reverse of the correct startup order. Today, Quarkus has no explicit startup ordering API (only build-time ordering via build items), and the shutdown ordering is ad hoc. This part of the work normalizes both.</p>
+      <p><strong>Dependency-oriented ordering:</strong></p>
+      <ul>
+      <li>Design a proper <strong>startup ordering API</strong> that is dependency-oriented, so extensions can declare what they depend on</li>
+      <li>Shutdown ordering is derived automatically as the <strong>reverse</strong> of the startup dependency graph — no separate shutdown ordering annotations needed</li>
+      <li>This is a partial ordering (a DAG), not a linear sequence — independent extensions can shut down concurrently (see concurrent shutdown below)</li>
+      <li>The ordering model should be type-based (like build items), not string-based, for consistency with Quarkus conventions</li>
+      </ul>
+      <p><strong>Clear API guidance:</strong></p>
+      <ul>
+      <li>Document which API to use for each scenario with a decision guide</li>
+      <li>Provide clear examples for extension developers and application developers</li>
+      <li>Clarify the relationship between the Primordial API, Graceful Shutdown API, and CDI layer</li>
+      </ul>
+      <p><strong>Concurrent shutdown investigation:</strong></p>
+      <ul>
+      <li>Coordinate with David's work on concurrent shutdown (running independent shutdown tasks in parallel)</li>
+      <li>Ensure concurrent execution respects phase boundaries and ordering constraints</li>
+      <li>Produce a recommendation on opt-in vs. automatic concurrency for independent tasks</li>
+      </ul>
+      <p><strong>Shutdown tracing and debugging:</strong></p>
+      <ul>
+      <li>Investigate JFR events for shutdown activities</li>
+      <li>Provide a debug mode that logs all shutdown tasks, their phase, ordering, and execution duration</li>
+      <li>Surface shutdown activity in Dev UI during development</li>
+      </ul>
+      <p><strong>API naming improvements:</strong></p>
+      <ul>
+      <li>Improve naming where possible (e.g., <code>addLastShutdownTask()</code>) within the Quarkus 4 breaking-change window</li>
+      </ul>
+      <h2>Definition of Done</h2>
+      <h3>Part 1: Pre-Shutdown</h3>
+      <ul>
+      <li>[ ] Extensions can register as drainable components and signal completion</li>
+      <li>[ ] Readiness health check automatically reports <code>DOWN</code> when shutdown is initiated</li>
+      <li>[ ] The pre-shutdown phase waits for all drainable extensions to complete (or drain timeout)</li>
+      <li>[ ] Graceful shutdown implemented for HTTP server, Reactive Messaging, <code>quarkus-scheduler</code>, gRPC, and WebSocket</li>
+      <li>[ ] Configurable drain timeout with clear behavior when exceeded</li>
+      </ul>
+      <h3>Part 2: Dependency-Ordered Shutdown</h3>
+      <ul>
+      <li>[ ] A dependency-oriented startup/shutdown ordering API exists (type-based, not string-based)</li>
+      <li>[ ] Shutdown order is automatically derived as the reverse of startup order</li>
+      <li>[ ] Shutdown sequence fully documented in the Quarkus guides with a clear diagram</li>
+      <li>[ ] Decision guide published: which shutdown API to use for each scenario</li>
+      <li>[ ] Shutdown activities can be traced/debugged (JFR events or equivalent)</li>
+      <li>[ ] Concurrent shutdown investigation completed with clear recommendation</li>
+      <li>[ ] Integration tests demonstrating correct shutdown ordering under load</li>
+      <li>[ ] Shutdown debug information available in Dev UI</li>
+      </ul>
+      <h2>Scope of Work</h2>
+      <h3>In Scope</h3>
+      <ul>
+      <li>Pre-shutdown phase: traffic blocking, drain signaling, readiness health check integration</li>
+      <li>Startup ordering API (dependency-oriented) — shutdown ordering derived as its reverse</li>
+      <li>Implementing graceful drain for key extensions (HTTP, Reactive Messaging, scheduler, gRPC, WebSocket)</li>
+      <li>Dependency-ordered shutdown with cross-extension ordering</li>
+      <li>API clarification, documentation, and decision guide</li>
+      <li>Shutdown debug/tracing tooling (JFR events investigation, debug logging)</li>
+      <li>Concurrent shutdown investigation and recommendation</li>
+      <li>API naming improvements where feasible in the Quarkus 4 window</li>
+      </ul>
+      <h3>Out of Scope</h3>
+      <ul>
+      <li>Merging <code>ShutdownContext</code> and <code>ShutdownListener</code> APIs</li>
+      <li>Cluster-wide coordinated shutdown (multi-instance orchestration)</li>
+      <li>Graceful startup (separate concern)</li>
+      </ul>
+      <h2>Organizing the Work</h2>
+      <h3>Communication</h3>
+      <ul>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/53206-</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-graceful-shutdown/with/581626831">wg-graceful-shutdown</a></li>
+      <li>Point of contact @mkouba, @ozangunalp</li>
+      </ul>
+      <h3>Timeline</h3>
+      <ul>
+      <li>Target: Quarkus 4 release cycle</li>
+      </ul>
+      <h3>Existing Issues</h3>
+      <ul>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/45946">#45946</a></li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/31072">#31072</a></li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/38119">#38119</a></li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/41233">#41233</a></li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/52389">#52389</a></li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/51327">#51327</a></li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/50475">#50475</a></li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/44894">#44894</a></li>
+      </ul>
+    status: staled
+    lts: false
+    completed: false
+    last-activity: 2026-08-12
+    last-update-date: 2026-05-26
+    last-update: |
+      The Graceful Shutdown team is looking into JFR events this week. We opened an issue to trace the shutdown sequence.
+      
+      (This status update was automatically generated using AI.)
+    proposal: https://github.com/quarkusio/quarkus/discussions/53206-
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-graceful-shutdown/with/581626831
+  - title: "Dev Star"
+    board-url: "https://github.com/orgs/quarkusio/projects/75"
+    short-description: |
+      Decompose and modernize the Quarkus developer tooling runtime (Dev UI, Dev MCP, Dev Shell, Dev Assistant) so that each component can operate independently, without requiring the full `vertx-http` web stack. This enables AI-powered developer assistance (via MCP) and terminal-based tooling (Dev Shell)
+    readme: |
+      <h2>Objective</h2>
+      <p>Decompose and modernize the Quarkus developer tooling runtime (Dev UI, Dev MCP, Dev Shell, Dev Assistant) so that each component can operate independently, without requiring the full <code>vertx-http</code> web stack. This enables AI-powered developer assistance (via MCP) and terminal-based tooling (Dev Shell) to work even when dev mode or the HTTP layer is broken, and lays the foundation for a unified &quot;Dev Star&quot; developer experience across all interaction surfaces.</p>
+      <p>Quarkus has always been a developer experience champion; live coding, Dev UI, Dev Services, and continuous testing set the standard for Java frameworks. Dev Star extends this effort into the AI era by focusing equally on <strong>AI experience (AIx)</strong>: making Quarkus the easiest framework for coding agents (Claude, Copilot, Gemini, etc.) to work with. By exposing the full power of Quarkus dev mode (configuration, build output, documentation, testing, error diagnostics) through MCP, and by providing agents with the right documentation for the specific extensions and APIs used in the application being built (via RAG over Quarkus Docs), coding agents can understand, build, and debug Quarkus applications as effectively as human developers using the Dev UI. Developer and AI experiences are two sides of the same coin: every improvement to one benefits the other.</p>
+      <h2>The Problem</h2>
+      <p>Today, the entire Quarkus developer tooling stack is tightly coupled to the Dev UI Runtime, which depends on <code>vertx-http</code>. This creates several problems:</p>
+      <ol>
+      <li>
+      <p><strong>Fragile dependency chain:</strong> Dev MCP and Dev Shell cannot function without the full HTTP stack running. If dev mode is broken (e.g., a compilation error prevents the application from starting), all developer tooling becomes unavailable — precisely when developers need help the most.</p>
+      </li>
+      <li>
+      <p><strong>No fallback for broken applications:</strong> There is no lightweight mechanism to provide application lifecycle information, documentation access, or workspace navigation when the Quarkus application cannot start. AI assistants connected via MCP are completely cut off.</p>
+      </li>
+      <li>
+      <p><strong>Monolithic runtime:</strong> The Dev UI Runtime bundles WebSocket transport, JsonRPC routing, MCP transport, and shell connectivity into a single unit. Extensions that only need JsonRPC services or MCP tools must still pull in the entire web stack.</p>
+      </li>
+      <li>
+      <p><strong>Limited AI integration surface:</strong> The Chappie WG established AI assistance capabilities, but the current architecture does not cleanly separate the AI runtime (Chappie Runtime + RAG over Quarkus Docs) from the transport layer, making it difficult to expose AI assistance through multiple channels (UI, MCP, Shell, stdio).</p>
+      </li>
+      <li>
+      <p><strong>Developer experience gaps:</strong> Several core developer workflows (continuous testing, hot reload, exception reporting, example projects, file navigation) have not been re-evaluated in the context of MCP and AI-assisted development. Features like tool filtering/search in MCP are missing.</p>
+      </li>
+      </ol>
+      <h2>The Proposed Solution</h2>
+      <h3>Architecture Decomposition</h3>
+      <p>Break the current monolithic Dev UI Runtime into four independent runtimes:</p>
+      <p>| Runtime                 | Transport       | Dependency                     | Purpose                                                               |
+      | ----------------------- | --------------- | ------------------------------ | --------------------------------------------------------------------- |
+      | <strong>Dev UI Runtime</strong>      | WebSocket       | <code>vertx-http</code>                   | Browser-based Dev UI (For Human)                                      |
+      | <strong>Dev JsonRPC Runtime</strong> | JsonRPCRouter   | CDI                            | Core routing layer for JsonRPC services; shared by Dev UI and Dev MCP |
+      | <strong>Dev MCP Runtime</strong>     | Streamable HTTP | CDI (no <code>vertx-http</code> required) | MCP server for AI agents (e.g., Claude, Copilot)                      |
+      | <strong>Dev Shell Runtime</strong>   | CDI-connected   | CDI (no <code>vertx-http</code> required) | Terminal-based developer interaction                                  |</p>
+      <p>The key architectural change is <strong>breaking the <code>vertx-http</code> dependency</strong> so that Dev MCP and Dev Shell can operate independently. The JsonRPC Router becomes a shared component connected via CDI, enabling extensions to expose <code>JsonRpcService</code> beans that are accessible from any runtime.</p>
+      <h3>Dev Assistant</h3>
+      <p>The Dev Assistant combines:</p>
+      <ul>
+      <li><strong>Chappie Runtime</strong>: AI interaction engine (successor to the Chappie WG)</li>
+      <li><strong>Quarkus Docs (RAG)</strong>: Retrieval-augmented generation over Quarkus documentation</li>
+      </ul>
+      <p>The Dev Assistant connects to the Dev Shell Runtime via CDI, and to the Dev UI Runtime via the existing JsonRPC path. This means AI assistance is available from the browser (Dev UI), the terminal (Dev Shell), and external AI tools (Dev MCP).</p>
+      <h3>Standalone stdio MCP Application</h3>
+      <p>A lightweight, standalone MCP application using <strong>stdio transport</strong> that provides:</p>
+      <ul>
+      <li>Application lifecycle information (build status, errors, configuration)</li>
+      <li>Quarkus documentation access</li>
+      <li>Workspace file navigation</li>
+      </ul>
+      <p>This stdio app operates <strong>outside</strong> dev mode, ensuring developers can get AI assistance even when the application is completely broken (compilation failures, missing dependencies, misconfiguration). It complements the in-process Dev MCP Runtime.</p>
+      <h3>Reconsider Dev* Features</h3>
+      <p>Re-evaluate existing developer features for the new architecture:</p>
+      <ul>
+      <li><strong>Dev Mode resilience</strong>: What works when dev mode is broken?</li>
+      <li><strong>Continuous Testing</strong>: Expose test status and controls via MCP tools</li>
+      <li><strong>Hot Reload</strong>: Trigger and monitor reloads from MCP/Shell</li>
+      <li><strong>Example Project</strong>: Generate example code via AI assistance</li>
+      <li><strong>Exception Reporting</strong> : Surface exceptions as MCP resources/tools</li>
+      <li><strong>Workspace Navigation</strong> : Find files and navigate project structure via MCP</li>
+      <li><strong>Tool Filter/Search</strong>: Enable discovery and filtering of available MCP tools</li>
+      <li><strong>Response Size Optimization</strong>: Reduce MCP response payload sizes to minimize context window consumption by coding agents; provide concise, structured responses rather than raw verbose output</li>
+      </ul>
+      <h3>Skills Investigation</h3>
+      <p>Investigate the concept of &quot;Skills&quot; (composable, higher-level developer actions built on top of MCP tools). The idea is to allow each extension to ship one or more Skills that describe how the extension is intended to be used, configured, and tested, along with best practices, common pitfalls, and troubleshooting guidance. Rather than requiring an AI agent to discover this knowledge through trial and error, Skills provide it upfront as structured, actionable context.</p>
+      <p><strong>Success criteria:</strong> define what a Skill is, how it differs from a raw MCP tool (tools <em>do</em> things; Skills <em>teach</em> how to do things well), and whether a Skills API adds meaningful value over direct tool composition by AI agents.</p>
+      <h2>Definition of Done</h2>
+      <ul>
+      <li>[ ] Dev MCP Runtime responds to the MCP <code>initialize</code> handshake without Dev UI or <code>vertx-http</code> running</li>
+      <li>[ ] Dev Shell Runtime starts and provides interactive developer commands without <code>vertx-http</code></li>
+      <li>[ ] Dev Assistant (Chappie + RAG) is accessible from Dev UI, Dev MCP, and Dev Shell</li>
+      <li>[ ] Clear design of the RAG pipeline: from documentation to the agent</li>
+      <li>[ ] Standalone stdio MCP app provides application lifecycle, docs, and workspace tools when dev mode is broken</li>
+      <li>[ ] Existing <code>JsonRpcService</code> extensions work across all runtimes without modification</li>
+      <li>[ ] Continuous testing status and controls are available via MCP tools</li>
+      <li>[ ] Exception information is surfaced as MCP resources</li>
+      <li>[ ] MCP tool discovery supports filtering and search</li>
+      <li>[ ] Architecture documented with clear extension author guidance</li>
+      <li>[ ] Integration tests verify that each runtime operates independently</li>
+      </ul>
+      <h2>Scope of Work</h2>
+      <h3>In Scope</h3>
+      <ul>
+      <li>Decompose Dev UI Runtime into four independent runtimes (Dev UI, Dev JsonRPC, Dev MCP, Dev Shell)</li>
+      <li>Break <code>vertx-http</code> dependency for Dev Shell</li>
+      <li>Implement Dev Assistant (Chappie Runtime + Quarkus Docs RAG) connected via CDI</li>
+      <li>Build standalone stdio MCP application for broken-dev-mode scenarios</li>
+      <li>Re-evaluate continuous testing, hot reload, exception reporting, and workspace navigation for MCP</li>
+      <li>Implement MCP tool filtering and search</li>
+      <li>Investigate Skills concept and define success criteria</li>
+      <li>Documentation for extension authors on the new architecture</li>
+      </ul>
+      <h3>Out of Scope</h3>
+      <ul>
+      <li>Production-mode MCP server (this is dev-mode tooling only)</li>
+      <li>Dev Shell is not part of this working group, a dedicated working group will be created.</li>
+      <li>Third-party AI provider integrations beyond MCP protocol support</li>
+      <li>IDE-specific plugins (VS Code, IntelliJ) — these consume MCP, not provide it</li>
+      </ul>
+      <h2>Organizing the Work</h2>
+      <h3>Communication</h3>
+      <ul>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-dev-star/with/581636141">wg-dev-star</a></li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/53093#discussioncomment-16271096</li>
+      <li>Point of Contact: @phillip-kruger</li>
+      </ul>
+      <h3>Timeline</h3>
+      <ul>
+      <li>Target: Quarkus 4 release cycle</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-08-12
+    last-update-date: 2026-06-29
+    last-update: |
+      The team added initial aesh extension support, along with AI skills for `quarkus-quartz`, `websockets-next`, and `config-yaml`. We also fixed Dev UI workspace scrolling and improved French translations. Current work involves refining Dev UI extension card text support and logging Dev MCP endpoint paths.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@phillip-kruger"
+    proposal: https://github.com/quarkusio/quarkus/discussions/53093#discussioncomment-16271096
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-dev-star/with/581636141
+  - title: "Agentic Foundation and LangChain4j Next"
+    board-url: "https://github.com/orgs/quarkiverse/projects/9"
+    short-description: |
+      This working group will explore and define the foundation of the next generation of AI-Infused and Agentic applications built with LangChain4j and Quarkus LangChain4j. The group will investigate core changes to the current programming model, improve dev exp, build stronger interoperability.
+    readme: |
+      <h3>1. Summary</h3>
+      <p>This working group will explore and define the foundation of the next generation of <strong>AI-Infused</strong> and <strong>Agentic applications</strong> built with LangChain4j and Quarkus LangChain4j. The group will investigate core changes to the current programming model, improve developer experience, build stronger interoperability mechanisms (especially around A2A), and define architectural separation of responsibilities (e.g., executor vs planner). The output will serve as the foundation for building resilient, scalable, and extensible AI-infused and agent systems on the Quarkus platform.</p>
+      <h3>2. Motivation</h3>
+      <p>While LangChain4j and Quarkus LangChain4j already provide strong foundations, building real-world agentic applications has revealed several pain points and architectural limitations. These range from ergonomic and modeling issues to missing runtime support for observability, visualization, memory management, and resilience.</p>
+      <p>This WG aims to:</p>
+      <ul>
+      <li>streamline the developer experience,</li>
+      <li>improve core primitives (invocations, workflows, A2A),</li>
+      <li>enable pluggable planning <em>engines</em> (like the built-in workflow constructs, supervisor…),</li>
+      <li>strengthen memory and context engineering support,</li>
+      <li>and provide around cost, observability, and correctness features</li>
+      </ul>
+      <h3>3. Scope</h3>
+      <p>This working group will cover the following areas:</p>
+      <p><strong>Developer Model Simplification</strong></p>
+      <ul>
+      <li>Eliminate redundancies in tool/function/agent definitions</li>
+      <li>Fix common friction points (e.g., outputName inconsistencies)</li>
+      <li>Explore alternatives to &quot;String&quot;-based keys (e.g., typesafe references, enums)</li>
+      </ul>
+      <p>⠀
+      <strong>Invocation Model Enhancements</strong></p>
+      <ul>
+      <li>Rename <code>AgentInvocation</code> to <code>Invocation</code> to enable invocations of regular methods/tools</li>
+      <li>Study retry, rollback (compensation), and durability mechanisms, especially in function calling, and whether these should be managed at the <em>planner</em> level or <em>execution</em> level</li>
+      <li>Improve human in the loop and agent conversation support</li>
+      </ul>
+      <p>⠀
+      <strong>A2A (Agent-to-Agent) Improvements</strong></p>
+      <ul>
+      <li>Automatic exposure of agents as A2A services</li>
+      <li>Declarative A2A clients</li>
+      <li>Studies how A2A agents can be integrated into applications (what are the patterns?)</li>
+      </ul>
+      <p>⠀
+      <strong>Architectural Refactoring</strong></p>
+      <ul>
+      <li>Apply Autonomic Reference Architecture: clear separation between operational/execution execution (observe, act, maintain state) and analytical planning (decide, select following invocation)</li>
+      <li>Design for pluggable planners (rules, workflows, LLM-based (supervisor))</li>
+      </ul>
+      <p>⠀
+      <strong>LangChain4j Core Improvements</strong></p>
+      <ul>
+      <li>Revamp the LangChain4j API to support non-blocking, asynchronous processing</li>
+      <li>Improve memory management (lifecycle, scoping, resource reuse, short-term/long-term memory) across tool/agent executions</li>
+      <li>Explore and improve support for Context Engineering:
+      <ul>
+      <li>Better control over prompt construction</li>
+      <li>Enhanced context injection at build/runtime</li>
+      <li>Modular strategies for short-term and long-term memory enrichment</li>
+      </ul>
+      </li>
+      </ul>
+      <p>⠀
+      <strong>Developer Experience &amp; Tooling</strong></p>
+      <ul>
+      <li>Quarkus Dev UI integration:
+      <ul>
+      <li>Visualize workflows</li>
+      <li>Trace agent invocations and tool calls</li>
+      </ul>
+      </li>
+      <li>Build-time validation for LangChain4j constructs (missing tools, bad metadata, etc.)</li>
+      <li>Evaluation harnesses and support for repeatable agent test scenarios</li>
+      </ul>
+      <p>⠀
+      <strong>Cost &amp; Observability</strong></p>
+      <ul>
+      <li>Track and optimize token usage</li>
+      <li>Condense tool result JSON</li>
+      <li>Estimate invocation cost during planning</li>
+      <li>Support tracing (OpenTelemetry), logging, and metric collection (Micrometer/OTEL bridge) - already quite advanced</li>
+      <li>Document techniques to control/minimize token usage, like <code>TokenWindowChatMemory</code> instead of <code>MessageWindowChatMemory</code>,
+      filter unnecessary MCP tools, select required tools dynamically via <code>AiServices.toolSelector</code> (to be implemented)</li>
+      </ul>
+      <p>⠀
+      <strong>Workflow Integration</strong></p>
+      <ul>
+      <li>Generalized interface to plug in workflow engines as a <em>planner</em></li>
+      <li>Coordination between agents and workflows (e.g., agent as a workflow step)
+      ⠀</li>
+      </ul>
+      <h3>4. Out of Scope</h3>
+      <p>This working group does <strong>not</strong> cover:</p>
+      <ul>
+      <li>UI/UX or frontend agent interfaces beyond Dev UI integration</li>
+      </ul>
+      <p>⠀</p>
+      <h3>5. Definition of Done</h3>
+      <p>The WG will be considered <strong>done</strong> when the following milestones are met:</p>
+      <ul>
+      <li>A simplified and more declarative developer model is available</li>
+      <li>The LangChain4j API supports non-blocking execution paths</li>
+      <li>At least one alternative planner (e.g., a workflow engine) can be plugged into the agentic runtime</li>
+      <li>Dev UI extension is available for invocation/workflow visualization</li>
+      <li>A2A support includes declarative clients and automatic exposure</li>
+      <li>Context engineering and memory management strategies are documented and implemented</li>
+      <li>Build-time validation and token usage observability are implemented</li>
+      <li>A reference set of patterns/examples demonstrates how to build production-grade agentic systems using the new model</li>
+      </ul>
+      <hr />
+      <ul>
+      <li>Point of Contacts: @cescoffier @dliubarskyi @geoand  @mariofusco</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Agentic.20Foundation.20and.20LangChain4j.20Next/with/547443137">Zulip</a></li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/50582</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-07-22
+    last-update-date: 2026-06-29
+    last-update: |
+      The group addressed an NPE with shared ChatMemory and fixed the agentic module in native mode. We also improved observability documentation for Quarkus Langfuse integration. These areas remain a key focus for the team.
+      
+      (This status update was automatically generated using AI.)
+    proposal: https://github.com/quarkusio/quarkus/discussions/50582
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Agentic.20Foundation.20and.20LangChain4j.20Next/with/547443137
+  - title: "Spring-Style Testing"
+    board-url: "https://github.com/orgs/quarkusio/projects/60"
+    short-description: |
+      Enable Spring developers to migrate to Quarkus with minimal friction by exploring and providing compatibility layers for the most common Spring testing patterns. So they don’t need to rewrite their existing tests.
+    readme: |
+      <h3>Problem Statement</h3>
+      <ul>
+      <li>Spring developers rely heavily on testing constructs like @SpringBootTest, MockMvc, TestRestTemplate, and slice-based testing.</li>
+      <li>Quarkus, while offering its own solid testing ecosystem (e.g., @QuarkusTest, RestAssured, and Continuous Testing), doesn’t align with Spring-style testing by default.</li>
+      <li>This mismatch forces developers to rewrite or adapt tests when switching to Quarkus.</li>
+      <li>Reducing this friction aligns with Quarkus’s goal of enabling Spring developers to migrate without starting from scratch.</li>
+      </ul>
+      <h3>Proposed Solution</h3>
+      <ol>
+      <li>Survey and identify the Spring testing APIs and techniques most widely used, across unit, controller (HTTP), and integration tests.</li>
+      <li>Map these to their closest equivalents in Quarkus testing infrastructure (e.g., @QuarkusTest, @QuarkusIntegrationTest, RestAssured).</li>
+      <li>Prototype mechanisms that allow Spring-style tests to run with minimal or no modifications in Quarkus (e.g., helper annotations, compatibility layer, quarkiverse library, tooling adaptation).</li>
+      <li>Define a realistic scope—supporting the most used constructs only (not all of Spring’s testing API).</li>
+      </ol>
+      <h3>Definition of Done</h3>
+      <p>The WG will be considered complete when the following are delivered:</p>
+      <ul>
+      <li>A prioritized list of Spring testing patterns (usage-informed).</li>
+      <li>A mapping document detailing how each pattern corresponds to Quarkus approaches.</li>
+      <li>A working prototype or POC illustrating compatibility (e.g., a mini-project demonstrating Spring tests running in Quarkus).</li>
+      <li>PRs to Quarkus implementing support or helper utilities.</li>
+      <li>A migration-style guide/documentation (“How to run your Spring tests in Quarkus”).</li>
+      <li>A community-facing artifact (e.g., blog post, talk, or demo).</li>
+      </ul>
+      <h3>Scope</h3>
+      <h3>In Scope</h3>
+      <ul>
+      <li>Inventory &amp; prioritization of widely-used Spring testing APIs (unit, HTTP controller, integration).</li>
+      <li>Feasibility analysis and prototyping for compatibility.</li>
+      <li>Documentation drafting and an example project.</li>
+      <li>Coordination and communication (issues, discussion threads, milestones).</li>
+      </ul>
+      <p>⠀</p>
+      <h3>Out of Scope</h3>
+      <ul>
+      <li>Full support for the entire Spring testing API surface; treating edge cases is not critical.</li>
+      <li>Deep re-architecting of Quarkus’s testing engine.</li>
+      <li>UI-level or highly niche Spring testing scenarios.</li>
+      </ul>
+      <hr />
+      <ul>
+      <li>Point of contact: @edeandrea, @aureamunoz , @mkouba</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Spring-Style.20Testing.20Compatibility.20for.20Quarkus/with/539471996">Zulip</a></li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/49964</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-07-20
+    last-update-date: 2026-06-29
+    last-update: |
+      Work focused on making the `@SpringBootTest` annotation functional. All related issues are now closed, and no new tasks were added during this period.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@edeandrea, @aureamunoz , @mkouba"
+    proposal: https://github.com/quarkusio/quarkus/discussions/49964
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Spring-Style.20Testing.20Compatibility.20for.20Quarkus/with/539471996
+  - title: "Binary Reproducibility"
+    board-url: "https://github.com/orgs/quarkusio/projects/82"
+    short-description: |
+      Ensure that Quarkus application builds are binary reproducible. That is, building the same source with the same toolchain produces bit-for-bit identical output.
+    readme: |
+      <h2>Objective</h2>
+      <p>Ensure that Quarkus application builds are binary reproducible. That is, building the same source with the same toolchain produces bit-for-bit identical output.</p>
+      <h2>The Problem</h2>
+      <p>Binary reproducibility (the property that building the same source code with the same tools produces identical artifacts) is a cornerstone of supply chain security and build trust. It allows independent parties to verify that a published binary was genuinely built from its claimed source, and it simplifies debugging, caching, and compliance audits.</p>
+      <p>Quarkus performs significant build-time work: it runs deployment processors, generates bytecode via recorders or Gizmo, and assembles the final application artifact. Each of these steps is a potential source of non-determinism. When iteration order over sets, maps, or annotation metadata is not stable, the generated JARs can differ between builds, even though the inputs are identical.</p>
+      <h3>Known sources of non-determinism</h3>
+      <p>Several sources of non-determinism have already been identified and fixed:</p>
+      <ul>
+      <li>Non-deterministic Jandex index creation: Jandex indices used during augmentation were not created in a deterministic order and so could not guarantee stable ordering, causing downstream build steps to process classes in varying order across builds.</li>
+      <li>Missing <code>hashCode()</code> in Jandex <code>ClassInfo</code>: the absence of a proper <code>hashCode()</code> implementation led to unpredictable behavior when <code>ClassInfo</code> instances were stored in hash-based collections, propagating non-determinism into any build step that iterated over such collections.</li>
+      <li>Unstable iteration in build steps: multiple extension processors used <code>HashMap</code> or <code>HashSet</code> where insertion order matters for bytecode generation, or used non-comparable <code>MultiBuildItem</code>s as an input to bytecode generation.</li>
+      <li>Non-deterministic bytecode generation: Gizmo function counters and recorder-generated bytecode could vary between augmentation runs.</li>
+      </ul>
+      <h2>The Proposed Solution</h2>
+      <h3>Finish fixing remaining sources of non-determinism</h3>
+      <p>Continue the work already in progress to identify and fix non-deterministic behavior in Quarkus core and extensions. This includes stabilizing bytecode generation, ensuring deterministic ordering in build items, and fixing any remaining issues in the augmentation pipeline.</p>
+      <h3>Establish reproducibility verification criteria</h3>
+      <p>Define what &quot;reproducible&quot; means in precise, testable terms for Quarkus applications. The criteria are conceptually obvious (same input -&gt; same output), but the details matter: which artifacts are compared, how dev-services-related bytecode is handled, what constitutes &quot;same toolchain&quot;, and how to account for legitimate differences (e.g., build timestamps in Maven metadata).</p>
+      <h3>Build automated reproducibility testing into CI</h3>
+      <p>Add CI infrastructure that performs reproducibility checks (building the same application multiple times and comparing the output) to catch regressions early. This is already underway with the reproducibility test mechanism introduced in #54420 and the proposed nightly CI workflow in #54895.</p>
+      <h3>Produce guidelines for extension developers</h3>
+      <p>Extensions contribute bytecode and resources to the final application. Extension authors need clear guidance on how to write build steps that preserve reproducibility: for example, using sorted collections, stable comparators, and deterministic code generation patterns. These guidelines will help both Quarkus core extensions and Quarkiverse extensions.</p>
+      <p>It is my personal belief that for the foreseeable future, we should be able to rely on stable iteration of <code>HashSet</code>s and <code>HashMap</code>s, even if these collections explicitly document that their iteration order is undefined, <em>provided that</em> the keys have deterministic <code>hashCode()</code>. They almost always have or can have; one class that is often used as a key and doesn't have deterministic <code>hashCode()</code> is <code>java.lang.Class</code>.</p>
+      <h2>Definition of Done</h2>
+      <ul>
+      <li>[ ] Quarkus core JVM-mode builds produce bit-for-bit identical application artifacts when built from the same source with the same JDK and Maven version</li>
+      <li>[ ] Automated reproducibility tests run in CI to prevent regressions</li>
+      <li>[ ] Existing Quarkus core extensions pass reproducibility checks</li>
+      <li>[ ] Reproducibility verification criteria and reproducibility guarantees are documented</li>
+      <li>[ ] Guidelines for extension developers on writing reproducible build steps are published</li>
+      </ul>
+      <h2>Scope of Work</h2>
+      <h3>In Scope</h3>
+      <ul>
+      <li>Fixing remaining sources of non-determinism in Quarkus core and extensions (JVM mode)</li>
+      <li>Defining reproducibility verification criteria and tooling</li>
+      <li>Documentation of guarantees and known limitations</li>
+      <li>Developer guidelines for writing reproducibility-safe extensions</li>
+      <li>CI infrastructure for automated reproducibility testing</li>
+      </ul>
+      <h3>Out of Scope (for now)</h3>
+      <ul>
+      <li>Gradle builds: the initial focus is on Maven-based builds. It is possible Gradle builds will be reproducible out of the box, or with very minor additional work, but this is currently unclear.</li>
+      <li>Native image reproducibility: GraalVM native image determinism is a separate and significantly more complex problem. It may be addressed in a follow-up working group, depending on progress.</li>
+      <li>Reproducible builds of Quarkus itself: making the Quarkus framework build reproducible is a separate effort.</li>
+      </ul>
+      <p>--</p>
+      <ul>
+      <li>Point of contact: @reaver585, @gsmet</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/54907</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Binary.20reproducibility">Zulip</a></li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-07-10
+    last-update-date: 2026-06-30
+    last-update: |
+      WG started.
+    point-of-contact: "@reaver585, @gsmet"
+    proposal: https://github.com/quarkusio/quarkus/discussions/54907
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Binary.20reproducibility
+  - title: "Test classloading"
+    board-url: "https://github.com/orgs/quarkusio/projects/30"
+    short-description: |
+      The goal of this working group is to rewrite Quarkus's test classloading, so that tests are run in the same classloader as the application under tests, and Quarkus extensions can do "Quarkus-y" manipulations of test classes.
+    readme: |
+      <p>At the moment, Quarkus tests are invoked using one classloader, and then executed in a different classloader. This mostly works well, but means some use cases don't work: extensions cannot manipulate test classes in the same way that they do normal application classes. For example, anything run via a JUnit @TestTemplate test case will see the un-transformed class.</p>
+      <p>It also means we have extra user-facing complexity, such as the QuarkusTest*Callbacks](https://quarkus.io/guides/getting-started-testing#enrichment-via-quarkustestcallback):</p>
+      <blockquote>
+      <p>While it is possible to use JUnit Jupiter callback interfaces like BeforeEachCallback, you might run into classloading issues because Quarkus has to run tests in a custom classloader which JUnit is not aware of.</p>
+      </blockquote>
+      <p>A final benefit is a reduction in the internal complexity of our code. Hopping between classloaders during test execution takes a lot of work, and adds a lot of code! It also is brittle in places. For example, because the hop between classloaders relies on serialization in some cases, it's becoming harder to do as the JVM tightens up security restrictions. We used to rely on xstream, but that stopped working in Java 17. In https://github.com/quarkusio/quarkus/pull/40601, @dmlloyd moved us to use the JBoss Serializer, which works better, but might still be affected by future restrictions on class access.</p>
+      <p>The goal of this working group is to allow test classes to fully participate in the 'quarkification' of classes. The mechanism for this is probably just to load the test classes with the classloader we intend to run them with, so that JUnit sees the 'correct' version of the class.</p>
+      <ul>
+      <li>Point of contact: @holly-cummins (@<strong>Holly Cummins</strong>  on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/41867</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20.2330.20Test.20Classloading.20chatter/">Zulip topic</a></li>
+      </ul>
+    status: staled
+    lts: false
+    completed: false
+    last-activity: 2026-07-09
+    last-update-date: 2026-05-26
+    last-update: |
+      The Test classloading group wrapped up an issue this week. We ensured Mongodb dev services no longer start during the augmentation phase.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@holly-cummins (@<strong>Holly Cummins</strong>  on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/41867
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20.2330.20Test.20Classloading.20chatter/
+  - title: "Gizmo 2"
+    board-url: "https://github.com/orgs/quarkusio/projects/43"
+    short-description: |
+      Gizmo 2 related tasks
+    readme: |
+      <p>This _working group aims to make the <a href="https://github.com/dmlloyd/gizmo/tree/gizmo2">Gizmo 2 POC</a> production-ready and integrate it into Quarkus core.</p>
+      <ul>
+      <li>Point of contact: @mkouba (@<strong>Martin Kouba</strong>  on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/46627</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Gizmo.202.2Ex.20WG.20chat">Zulip topic</a></li>
+      <li>Deliverable: <a href="https://quarkus.io/blog/arc-migrates-to-gizmo2/">Blog</a></li>
+      </ul>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2026-07-02
+    last-update-date: 2025-11-03
+    last-update: |
+      While there are still tons of work to do on Gizmo 2, it meets the definition of done from the proposal. 
+      Arc got migrated to Gizmo 2 - see https://quarkus.io/blog/arc-migrates-to-gizmo2/.
+    deliverable: <a rel="nofollow" href="https://quarkus.io/blog/arc-migrates-to-gizmo2/">Blog</a>
+    point-of-contact: "@mkouba (@<strong>Martin Kouba</strong>  on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/46627
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Gizmo.202.2Ex.20WG.20chat
+  - title: "Offering Metadata and Tooling Integration"
+    board-url: "https://github.com/orgs/quarkusio/projects/52"
+    short-description: |
+      Track and coordinate the introduction of offering-level support metadata in Quarkus platform descriptors and its integration into developer tools (e.g., code.quarkus.io, CLI).
+    readme: |
+      <h2>Motivation:</h2>
+      <p>Quarkus is now part of multiple product offerings (e.g., Red Hat Build of Quarkus, Camel integrations, ...). To enable tooling and automation to reflect product-specific support levels, we need to:</p>
+      <ul>
+      <li>Extend the platform metadata with structured offering-level support indicators.</li>
+      <li>Adapt code.quarkus.io and code.quarkus.redhat.com to display and filter based on offering.</li>
+      <li>Plan for downstream use by the CLI, build tooling, and possibly SKU-based features.</li>
+      </ul>
+      <p>This working group ensures a coordinated effort across platform, metadata, and UI/UX teams to avoid fragmentation and deliver a coherent user experience.</p>
+      <h2>Goals:</h2>
+      <ul>
+      <li>Define and adopt a standard metadata format for offering-level support annotations.</li>
+      <li>Apply metadata consistently across all productized platform descriptors.</li>
+      <li>Integrate offering awareness into code.quarkus.redhat.com:</li>
+      <li>Display per-offering support levels.</li>
+      <li>Allow filtering and navigation based on offering.</li>
+      <li>Ensure the upstream site (code.quarkus.io) remains offering-agnostic.</li>
+      <li>Evaluate CLI support for offering information</li>
+      </ul>
+      <h2>Scope:</h2>
+      <p>In scope:</p>
+      <ul>
+      <li>JSON platform descriptor enhancements</li>
+      <li>Tooling (code.quarkus.io/redhat.com) UI/UX changes</li>
+      <li>CLI enhancements (optional, pending feasibility)</li>
+      </ul>
+      <p>Out of scope:</p>
+      <ul>
+      <li>
+      <p>Modifying Quarkus runtime behavior based on offering</p>
+      </li>
+      <li>
+      <p>License/SKU enforcement mechanisms</p>
+      </li>
+      <li>
+      <p>Point of contact: @ia3andy (@<strong>Andy Damevin</strong>  on Zulip) and @aloubyansky (@<strong>Alexey Loubyansky</strong>  on Zulip)</p>
+      </li>
+      </ul>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2026-06-30
+    last-update-date: 2025-11-03
+    last-update: |
+      Feature shipped - completing this working group!
+    point-of-contact: "@ia3andy (@<strong>Andy Damevin</strong>  on Zulip) and @aloubyansky (@<strong>Alexey Loubyansky</strong>  on Zulip)"
+  - title: "Unified Saga implementation"
+    board-url: "https://github.com/orgs/quarkusio/projects/48"
+    short-description: |
+      The main objective of this working group is to unify Quarkus's story about Saga-based transactions.
+    readme: |
+      <h3>Objective:</h3>
+      <p>The main objective of this working group is to unify Quarkus's story about Saga-based transactions.</p>
+      <h3>The Problem</h3>
+      <p>The primary saga solution for distributed transactions is <a href="https://github.com/quarkusio/quarkus/tree/main/extensions/narayana-lra">narayana-lra</a> extension. However, it wasn't maintained and marketed as the number one solution for distributed sagas. So we either need to update LRA to make a unified solution for Quarkus or pick a different solution that was introduced in the meantime. This WG will unify Quarkus's story in a distributed transaction solution.</p>
+      <h3>The proposed Solution</h3>
+      <p>We will investigate and compare available solutions for the saga-based implementation of the distributed tx processing. This will be documented, and the choice should be proven to be able to drive development and innovation in this area. We will ensure the solution meets the Quarkus standards (build/runtime split, dev service, dev ui).</p>
+      <h3>Definition of Done</h3>
+      <ul>
+      <li>A new guide for the distributed tx (or the chosen solution if there is only one)</li>
+      <li>Blog post comparing available solutions or just marketing the chosen solution</li>
+      <li>Quarkus insights about this topic</li>
+      </ul>
+      <h3>Scope of Work</h3>
+      <p>The scope of this WG is to pick a chosen saga-based implementation and make it Quarkus native (dev mode, any possible enhancements). We will choose implementation with an already available Quarkus integration. Research of new saga-based alternatives is out of scope.</p>
+      <h3>Organizing the Work</h3>
+      <p>Communication and Transparency:</p>
+      <p>Coordination will be done in this GitHub discussion and the individual GitHub issues. GitHub issues can be closed if the saga-solution is not to be updated anymore. The decision of the chosen solution will be stated also as the resolution of https://github.com/quarkusio/quarkus/issues/34181.</p>
+      <p>This work can take place in either Quarkus core (narayana-lra) or some new extension that will be provided in Quarkiverse.</p>
+      <h3>Expected Timeline:</h3>
+      <p>Milestone 1 - Document in this discussion saga-based implementations alternatives
+      Milestone 2 - Pick one solution that will be Quarkus Saga solution
+      Milestone 3 - Update the chosen alternative for Quarkus standards (simplification of use, dev * features)
+      Milestone 4 - Create a guide to document it
+      Milestone 5 - Blog + Quarkus insights</p>
+      <hr />
+      <ul>
+      <li>Point of contact: @xstefank (@<strong>Martin Stefanko|448453</strong>  on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/46672</li>
+      <li>Deliverable: TBD</li>
+      </ul>
+    status: staled
+    lts: false
+    completed: false
+    last-activity: 2026-06-27
+    last-update-date: 2026-05-26
+    last-update: |
+      The Unified Saga group focused on "Default extension capability providers" this period. We closed out the previous issue, and a new one is now open to track further efforts on this topic.
+      
+      (This status update was automatically generated using AI.)
+    deliverable: TBD
+    point-of-contact: "@xstefank (@<strong>Martin Stefanko|448453</strong>  on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/46672
+  - title: "Unified Event Bus"
+    board-url: "https://github.com/orgs/quarkusio/projects/73"
+    short-description: |
+      Design and implement a new Quarkus-native event API that is type-safe, supports multiple messaging patterns (pub/sub, point-to-point, request-response), automatically propagates context, and works without a Vert.x (HTTP) dependency, providing a unified programming model for decoupled component inter
+    readme: |
+      <h2>Objective</h2>
+      <p>Design and implement a new Quarkus-native event API that is type-safe, supports multiple messaging patterns (pub/sub, point-to-point, request-response), automatically propagates context, and works without a Vert.x (HTTP) dependency, providing a unified programming model for decoupled component interaction.</p>
+      <h2>The Problem</h2>
+      <p>Quarkus developers who want application components to interact in a decoupled fashion, with no compile-time dependency between interacting components, face a fragmented landscape of three overlapping mechanisms, each with significant limitations.</p>
+      <p>This problem becomes even more pressing with the rise of modular monolith (<em>modulith</em>) architectures, in which a reliable in-process event bus serves as the primary integration backbone between modules.</p>
+      <h3>1. CDI Events: Type-Safe but Limited</h3>
+      <p><strong>Pros:</strong></p>
+      <ul>
+      <li>Clear, understandable API with type-safety (&quot;type is the address&quot;, observed event types and qualifiers form the routing address)</li>
+      <li>Context propagation works for regular (synchronous) observers</li>
+      </ul>
+      <p><strong>Cons:</strong></p>
+      <ul>
+      <li>Only supports publish/subscribe, no point-to-point or request-response patterns</li>
+      <li>Only declarative consumers (observer methods), no programmatic registration at runtime</li>
+      <li>Confusing execution model</li>
+      <li>Compatibility burden from the CDI specification (e.g., cannot simply say that <code>Uni</code>-returning observers run on the event loop; qualifier matching complexity with <code>BeanManager#fireEvent()</code> deriving types from runtime class)</li>
+      </ul>
+      <p><strong>Async observers (CDI 2.0) make things worse:</strong></p>
+      <ul>
+      <li>Largely unknown and unused by developers</li>
+      <li>Offload execution to a different thread, cannot participate in a reactive pipeline</li>
+      <li>Require a completely separate API (<code>@ObservesAsync</code> + <code>Event#fireAsync()</code>)</li>
+      <li>An observer cannot be both sync and async (forbidden by the spec)</li>
+      <li>Async observers always receive a <strong>new</strong> CDI request context with no context propagation</li>
+      </ul>
+      <h3>2. Vert.x Event Bus: Flexible but Unsafe</h3>
+      <p><strong>Pros:</strong></p>
+      <ul>
+      <li>Supports publish/subscribe, point-to-point, and request-response messaging patterns</li>
+      <li>Consumers can be added programmatically at any time</li>
+      </ul>
+      <p><strong>Cons:</strong></p>
+      <ul>
+      <li>No type-safety: string-based addresses, messages accept any payload type</li>
+      <li>Cluster/polyglot constraints from the Vert.x EventBus design</li>
+      <li>Context propagation does not work:</li>
+      <li><code>@ConsumeEvent</code> handlers get a new CDI request context (not propagated from sender)</li>
+      <li>Normal programmatic consumers have no CDI context at all</li>
+      </ul>
+      <h3>3. In-Memory Quarkus Messaging: The wrong tool</h3>
+      <p>SmallRye Reactive Messaging's in-memory transport serves a similar purpose for channel-based communication, adding yet another option to the mix. Developers must understand where in-memory channels, CDI events, and Vert.x event bus each apply.</p>
+      <h3>The Result</h3>
+      <ul>
+      <li><strong>No unified programming model</strong> — developers must learn three separate APIs with different trade-offs</li>
+      <li><strong>Context propagation is broken or absent</strong> in most event-driven scenarios (async CDI observers, Vert.x consumers)</li>
+      <li><strong>Type-safety and flexibility are mutually exclusive</strong> — CDI events are type-safe but inflexible; Vert.x event bus is flexible but type-unsafe</li>
+      <li><strong>Vert.x is a hard dependency</strong> for event bus functionality, but not all Quarkus applications use Vert.x (e.g., CLI applications)</li>
+      </ul>
+      <h2>The Proposed Solution</h2>
+      <h3>A New Quarkus-Native Event API</h3>
+      <p>Design a new event API built specifically for Quarkus with the following properties:</p>
+      <p><strong>Type-safe routing:</strong> The event type <em>is</em> the address. No string-based addressing. The API leverages Java's type system for event routing, similar to CDI events but without the CDI specification's compatibility constraints.</p>
+      <p><strong>Multi-pattern support:</strong> A single API supports:</p>
+      <ul>
+      <li><strong>Publish/subscribe</strong>: one-to-many event distribution</li>
+      <li><strong>Point-to-point</strong>: one-to-one event delivery</li>
+      <li><strong>Request-response</strong>: send an event and receive a typed reply</li>
+      </ul>
+      <p><strong>Automatic context propagation:</strong> Security, tracing, MDC, and CDI contexts (except the request scope) propagate automatically across event-delivery boundaries, for both synchronous and asynchronous handlers.</p>
+      <p><strong>No Vert.x HTTP dependency:</strong> The API works without <code>vertx-http</code> (Vert.x core may be required - still need to be discussed), making it usable in CLI applications and other non-HTTP scenarios.</p>
+      <p><strong>Usable by both users and extension developers:</strong> The API is designed for application developers writing business logic and for extension developers building framework-level integrations.</p>
+      <h3>Relationship with Existing Mechanisms</h3>
+      <ul>
+      <li>
+      <p><strong>CDI Events:</strong> Continue to exist for CDI-specification-level interoperability. The new API does not replace <code>@Observes</code> for standard CDI use cases but provides a superior Quarkus-native alternative for application-level eventing.</p>
+      </li>
+      <li>
+      <p><strong>Vert.x Event Bus:</strong> The <code>@ConsumeEvent</code> annotation and direct Vert.x event bus usage will be deprecated in favor of the new API. A migration path will be provided.</p>
+      </li>
+      <li>
+      <p><strong>In-Memory Quarkus Messaging:</strong> The relationship is clearly defined: Quarkus/Reactive Messaging is for stream processing and external messaging integration; the new event API is for in-process decoupled component interaction.</p>
+      </li>
+      </ul>
+      <h3>Leverage the Vert.x 5 Migration Window</h3>
+      <p>The Quarkus 4/Vert.x 5 migration provides a natural opportunity for redesign. Since <code>@ConsumeEvent</code> and Vert.x event bus usage patterns will need updates regardless, this is the right time to introduce a unified replacement.</p>
+      <h2>Definition of Done</h2>
+      <ul>
+      <li>[ ] A new event API exists with type-based routing (no string addresses)</li>
+      <li>[ ] The API supports publish/subscribe, point-to-point, and request-response patterns</li>
+      <li>[ ] Context (security, tracing, MDC) automatically propagates across event delivery (not the request context)</li>
+      <li>[ ] The API works without Vert.x HTTP dependency (verified in a CLI application)</li>
+      <li>[ ] Relationship between the new API, CDI events, and in-memory Reactive Messaging is clearly defined and documented</li>
+      <li>[ ] The API is usable by both application developers and extension developers</li>
+      <li>[ ] Migration guide from <code>@ConsumeEvent</code> and Vert.x event bus to the new API</li>
+      <li>[ ] Quarkus guide documenting the unified event programming model</li>
+      <li>[ ] Both declarative (annotation-based) and programmatic consumer registration are supported</li>
+      <li>[ ] Integration tests covering all three messaging patterns with context propagation</li>
+      </ul>
+      <h2>Scope of Work</h2>
+      <h3>In Scope</h3>
+      <ul>
+      <li>API design: type-safe, multi-pattern (pub/sub, P2P, request-response) event API</li>
+      <li>Context propagation across event delivery (security, tracing, MDC, CDI contexts)</li>
+      <li>Clarify relationship with CDI events and in-memory Quarkus Messaging</li>
+      <li>Both declarative and programmatic consumer registration</li>
+      <li>Migration guide from <code>@ConsumeEvent</code> / Vert.x event bus</li>
+      <li>Comprehensive documentation (Quarkus guide)</li>
+      </ul>
+      <h3>Out of Scope</h3>
+      <ul>
+      <li>External messaging systems (Kafka, AMQP, MQTT), this is Quarkus Messaging's domain</li>
+      <li>Clustered / distributed event bus</li>
+      <li>Event sourcing or CQRS patterns</li>
+      </ul>
+      <h2>Organizing the Work</h2>
+      <h3>Communication</h3>
+      <ul>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/53202</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-unified-events/with/581622437"><code>#wg-unified-events</code></a></li>
+      <li>Point of contact: @mkouba, @ozangunalp</li>
+      </ul>
+      <h3>Timeline</h3>
+      <ul>
+      <li>Target: Quarkus 4 release cycle</li>
+      </ul>
+      <h3>Existing Issues</h3>
+      <ul>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/50583">#50583</a> : Unified event bus discussion</li>
+      <li><a href="https://github.com/quarkusio/quarkus/issues/51959">#51959</a> : Vert.x 5 epic</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-06-25
+    last-update-date: 2026-06-29
+    last-update: |
+      The team improved the Event bus and addressed OTel context loss for `@ConsumeEvent` messages. We resolved issues with `@RunOnVirtualThread` for Signal receivers and added configurable concurrency limits. Efforts now focus on propagating security identity and OTel trace context to Signal receivers.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@mkouba, @ozangunalp"
+    proposal: https://github.com/quarkusio/quarkus/discussions/53202
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/wg-unified-events/with/581622437
+  - title: "AOT Support"
+    board-url: "https://github.com/orgs/quarkusio/projects/68"
+    short-description: |
+      The main objective of this working group is to consolidate, enhance, and modernize Quarkus's Ahead-of-Time (AOT) and runtime efficiency (in JVM mode) capabilities. We aim to leverage OpenJDK's Project Leyden, IBM Semeru's advanced features, and JLink to provide a unified, "native-like" startup exper
+    readme: |
+      <h3>Objective</h3>
+      <p>The main objective of this working group is to consolidate, enhance, and modernize Quarkus's Ahead-of-Time (AOT) and runtime efficiency (in JVM mode) capabilities. We aim to leverage OpenJDK's Project Leyden, IBM Semeru's advanced features, and JLink to provide a unified, &quot;native-like&quot; startup experience on the JVM.</p>
+      <h3>The Problem</h3>
+      <p>Currently, AOT file handling and runtime optimization in Quarkus are fragmented. While we support features like AppCDS and AWS Snapstart, the strategy lacks cohesion:</p>
+      <ul>
+      <li><strong>Usability:</strong> Configuration is obscure (legacy AppCDS naming) and hard to discover.</li>
+      <li><strong>Integration:</strong> There is no seamless way to generate and embed AOT caches or custom runtimes (JLink) within our container image generation pipeline.</li>
+      <li><strong>Missed Opportunities:</strong>
+      <ul>
+      <li><strong>Project Leyden:</strong> We are not fully-prepared to exploit the standardized AOT capabilities arriving in Java 25.</li>
+      <li><strong>IBM Semeru:</strong> We are underutilizing Semeru's &quot;Shared Classes Cache&quot; (a Leyden-like mechanism available today) and &quot;InstantOn&quot; (CRIU/snapshotting), which offer immediate gains.</li>
+      <li><strong>JLink:</strong> We heavily rely on full JDK/JRE images (UBI Java runtime), missing the chance to build minimal, modular runtimes that complement AOT optimizations for faster startup and lower storage costs.</li>
+      </ul>
+      </li>
+      </ul>
+      <h3>The Proposed Solution</h3>
+      <p>This working group is structuring a dedicated effort to focus on JVM AOT support in Quarkus. The working group will focus on:</p>
+      <ol>
+      <li><strong>Unified AOT Configuration:</strong> Redesigning configuration to be intuitive and forward-looking (aligned with Project Leyden), abstracting the underlying mechanism (CDS, Leyden AOT Cache, Semeru SCC).</li>
+      <li><strong>Dedicated Packaging (<strong>aot-jar (proposal)</strong>):</strong> Defining and implementing a specific packaging type (e.g., quarkus.package.type=aot-jar) that automatically orchestrates the transparent training phase to generate AOT artifacts (CDS, SCC), bundles them with the application, and configures the startup scripts, removing the need for manual cache management.</li>
+      <li><strong>Container &amp; Runtime Integration:</strong>
+      <ul>
+      <li><strong>AOT Embedding:</strong> Build-time support to generate and embed AOT caches (CDS/SCC) directly into container images.</li>
+      <li><strong>JLink Support:</strong> Introduce a mechanism to generate custom, stripped-down JREs using jlink. Combining AOT caches with a minimal JLink runtime will yield the smallest, fastest non-native container possible.</li>
+      </ul>
+      </li>
+      <li><strong>Vendor-Specific Optimizations:</strong>
+      <ul>
+      <li><strong>IBM Semeru:</strong> Explicit support for <strong>Semeru InstantOn</strong> (CRaC-like snapshotting) and their <strong>Shared Classes Cache</strong> (SCC), which effectively provides &quot;Leyden-like&quot; benefits (cached classes + AOT code) today.</li>
+      </ul>
+      </li>
+      <li><strong>Measurement &amp; Validation:</strong> Establishing benchmarks to measure RSS usage, startup time, and image size specifically attributed to these enhancements.</li>
+      </ol>
+      <h3>Definition of Done</h3>
+      <p>The working group will be considered successfully closed when:</p>
+      <ul>
+      <li>The AOT configuration namespace has been refactored.</li>
+      <li>aot-jar <strong>Packaging:</strong> The new packaging type is implemented and fully supported in Maven/Gradle plugins.</li>
+      <li>Container builders (Docker/Podman) support automatic generation/embedding of AOT caches.</li>
+      <li><strong>JLink integration</strong> is available to build minimal runtime images with Quarkus applications.</li>
+      <li><strong>Semeru InstantOn</strong> and <strong>SCC</strong> are first-class, configurable options in the Quarkus build.</li>
+      <li>A comprehensive guide on &quot;JVM Efficiency: AOT, JLink, and Caching&quot; is published.</li>
+      <li><strong>Blog Post:</strong> A comparative blog post is published analyzing Plain JVM, AOT (using the new aot-jar), and Native Image. The analysis should use the Quarkus Super-Heroes microservices suite to cover diverse use cases and provide concrete, reproducible data on Startup Time and RSS usage gains.</li>
+      <li>All sub-tasks in <a href="https://github.com/quarkusio/quarkus/issues/51976">Issue #51976</a> are resolved.</li>
+      </ul>
+      <h3>Scope of Work</h3>
+      <p><strong>In Scope:</strong></p>
+      <ul>
+      <li>Refactoring quarkus.package.jar.appcds.* and related configurations.</li>
+      <li><strong>Implementation of the</strong> aot-jar <strong>packaging type.</strong></li>
+      <li>Integration with OpenJDK Project Leyden (Java 25 AOT cache).</li>
+      <li><strong>JLink Integration:</strong> Tooling to create custom runtime images during the build.</li>
+      <li><strong>IBM Semeru Integration:</strong>
+      <ul>
+      <li>Configuration for Shared Classes Cache (SCC).</li>
+      <li>Support/Guide for &quot;InstantOn&quot; (CRIU snapshotting).</li>
+      </ul>
+      </li>
+      <li>Modifying container image generation (Jib, Docker) to support these artifacts.</li>
+      <li><strong>Benchmarking:</strong> executing performance tests using the Quarkus Super-Heroes suite to validate the aot-jar benefits.</li>
+      <li>Documentation and Blog Post creation.</li>
+      </ul>
+      <p>⠀<strong>Out of Scope:</strong></p>
+      <ul>
+      <li>General runtime performance optimizations unrelated to Startup/Warmup/Footprint.</li>
+      </ul>
+      <h3>Organizing the Work</h3>
+      <ul>
+      <li>Point of contact: Guillaume Smet (@gmset) / Georgios Andrianakis (@geoand)</li>
+      <li>Timeline: Features will be delivered step by step between now and Quarkus 4.</li>
+      <li>Repositories: quarkusio/quarkus</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/AOT.20cache.20-.20Global.20thread/with/568847190">Zulip</a></li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/52017</li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-06-19
+    last-update-date: 2026-06-29
+    last-update: |
+      The team introduced the first version of `aot-jar` packaging, making it the default when AOT is enabled. We also completed several small adjustments for JLink integration. No new issues were reported.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "Guillaume Smet (@gmset) / Georgios Andrianakis (@geoand)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/52017
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/AOT.20cache.20-.20Global.20thread/with/568847190
+  - title: "Quarkus Terminal"
+    board-url: "https://github.com/orgs/quarkusio/projects/77"
+    short-description: |
+      The main objective of this working group is to establish a cohesive foundation for terminal-based experiences in Quarkus. Spanning console I/O, TUIs, CLI parsing, and startup/lifecycle integration. Enable Quarkus itself and applications built on it to have a consistent, lightweight stack to build.
+    readme: |
+      <h2>The Problem</h2>
+      <p>Quarkus early start was focus most on web applications and microservices. Over the years we enabled things like command mode and CLI parsing (mainly using Picocli) but its been more a organic adaption than a clean and extendable setup.</p>
+      <p>Quarkus dev mode itself is quite a fancy TUI but its not easy to do similar in Quarkus applications in a consistent way.</p>
+      <p>We currently have terminal-related functionality scattered across multiple libraries with overlapping concerns and inconsistent trade-offs:</p>
+      <ul>
+      <li>Æsh and JLine both ship &quot;complete&quot; stacks (readline, parsing, rendering, history, completion) and pull in more than many consumers need. There is no shared minimal console/ANSI primitive that higher-level libraries can depend on without inheriting a full stack.</li>
+      <li>Dev mode and dev shell UX could be significantly richer with a proper TUI layer, but we have no sanctioned approach for devmode  nor extension for building TUIs in Quarkus applications.</li>
+      <li>The CLI story is split between Æsh (strong on readline/interactive shells) and picocli (strong on argument parsing), with no clear guidance on when to use which, and no shared story around native-image friendliness, startup time, and reflection config.</li>
+      <li>The startup phase itself is murky for terminal-heavy apps: there is no clean pattern for CLI argument parsing to interact with Quarkus' config system (exposing picocli options as config sources, reaching <code>quarkus.application.version</code> from <code>@Command</code> annotations, etc.), and TUI-style full-screen applications conflict with dev mode and main-thread assumptions in ways that are not well defined, dev mode partially captures keystrokes destined for the application being a concrete example.</li>
+      </ul>
+      <p>The net effect is duplicated effort, inconsistent behavior across Quarkus-adjacent tooling, missed opportunities in dev mode, and friction for anyone trying to build a terminal-first Quarkus application.</p>
+      <h2>The Proposed Solution</h2>
+      <p>Organize the work into four coordinated tracks under a single working group. The tracks are related but the shape of the shared substrate/results (if any) is an open design question which this working group will try solve.</p>
+      <ol>
+      <li>
+      <p><strong>ansi/terminal</strong> — explore how to best provide minimal console primitives (terminal detection, ANSI handling, raw/cooked mode, resize, input events, color/style). Whether this is a new library, a refactor of what exists, or a thin facade over JLine/Æsh is itself part of the work.</p>
+      </li>
+      <li>
+      <p><strong>TUI</strong> Use TamboUI as a vehicle to explore TUI integration in dev mode and dev shell, and enable application developers to build TUIs in Quarkus. TamboUI is the starting point for exploration, not a predetermined final choice; the track should surface what a good Quarkus TUI story looks like regardless of which library ultimately backs it.</p>
+      </li>
+      <li>
+      <p><strong>CLI</strong> clarify and improve the two main CLI paths: an Æsh extension focused on interactive/readline use cases, and picocli optimizations focused on argument parsing, startup, and native image. Evaluate what can be done for startup impact.</p>
+      </li>
+      <li>
+      <p><strong>Startup &amp; lifecycle</strong> define clean patterns for terminal-first Quarkus applications: how CLI argument parsing interacts with the Quarkus config system (so flags, env, and <code>application.properties</code> compose predictably), and how TUI/full-screen modes coexist with dev mode, the main thread, and Quarkus' startup/shutdown lifecycle without fighting each other.</p>
+      </li>
+      </ol>
+      <h2>Definition of Done</h2>
+      <ul>
+      <li>A documented direction for the ansi/terminal layer — whether that means a new library, a consolidation, or a decision that the status quo plus minor changes is sufficient.</li>
+      <li>DevShell - Integrated use of TamboUI (or similar) into Quarkus dev mode and/or dev shell in a visible, demoable way.</li>
+      <li>A path for building TamboUI based Quarkus applications with hotreload and native image, delivered as an extension.</li>
+      <li>Updated CLI story: Æsh extension direction clarified, optional picocli improvements landed (startup, native, reflection), and a documented decision on a third alternative.</li>
+      <li>Documented patterns and supporting code for CLI-args-vs-config integration and TUI-vs-dev-mode lifecycle coexistence.</li>
+      <li>ADRs covering the key design decisions across all four tracks.</li>
+      <li>Documentation on quarkus.io, plus at least one blog post and one demo/video.</li>
+      </ul>
+      <h2>Scope of Work</h2>
+      <p><strong>In scope:</strong></p>
+      <ul>
+      <li>Exploration and design of the ansi/terminal layer.</li>
+      <li>TamboUI-based exploration of TUI in dev mode / dev shell, and a Quarkus extension enabling application TUIs.</li>
+      <li>Æsh extension direction and alignment.</li>
+      <li>Picocli optimizations (native image, startup, reflection config).</li>
+      <li>Evaluation of a potential lighter CLI alternative.</li>
+      <li>Integration of CLI argument parsing with the Quarkus config system.</li>
+      <li>Lifecycle patterns for full-screen TUI applications, including dev mode coexistence and main-thread handling.</li>
+      <li>Native image support across the tracks.</li>
+      <li>Documentation, ADRs, samples.</li>
+      </ul>
+      <p><strong>Out of scope:</strong></p>
+      <ul>
+      <li>Rewriting Æsh or JLine internals beyond what the tracks require.</li>
+      <li>GUI or web-based dev UI work (covered by other efforts).</li>
+      <li>Shell scripting languages or REPL language design.</li>
+      <li>Replacing picocli or Æsh as user-facing choices — both remain supported.</li>
+      </ul>
+      <h2>Organizing the Work</h2>
+      <h3>Communication and Transparency</h3>
+      <ul>
+      <li>Coordination via a dedicated GitHub Project spanning the relevant repositories.</li>
+      <li>Discussion in GitHub Discussions on <code>quarkusio/quarkus</code> for cross-cutting topics; implementation issues on the individual repos.</li>
+      <li>Work will land across Quarkus core (dev mode, dev shell, lifecycle), Quarkiverse (TUI extension, Æsh extension, picocli extension), and potentially standalone repositories depending on where the ansi/terminal exploration lands.</li>
+      </ul>
+      <h3>Potential Outcomes &amp; Deliverables</h3>
+      <ul>
+      <li>A direction (and, where warranted, code) for the ansi/terminal layer.</li>
+      <li>TamboUI-powered Quarkus dev mode / dev shell enhancements.</li>
+      <li>A Quarkiverse extension for building TUIs.</li>
+      <li>Updated Æsh extension.</li>
+      <li>Picocli extension improvements (startup, native, reflection).</li>
+      <li>Documented and supported patterns for CLI args ↔ Quarkus config, and for TUI lifecycle coexistence with dev mode.</li>
+      <li>ADRs across the tracks.</li>
+      <li>Blog post + demo/video.</li>
+      </ul>
+      <ul>
+      <li>Point of contact: @maxandersen</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/53667</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Quarkus.20Terminal/with/587817394">Zulip</a></li>
+      </ul>
+    status: on track
+    lts: false
+    completed: false
+    last-activity: 2026-06-15
+    last-update-date: 2026-06-29
+    last-update: |
+      The team added initial aesh extension support, including SSH and websockets. They also replaced picocli with aesh for CLI parsing. No new issues were opened this period.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@maxandersen"
+    proposal: https://github.com/quarkusio/quarkus/discussions/53667
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Quarkus.20Terminal/with/587817394
+  - title: "Quarkus 3.33 LTS"
+    board-url: "https://github.com/orgs/quarkusio/projects/70"
+    short-description: |
+      This working group aims to track the effort around the Quarkus 3.33 LTS version.
+    readme: |
+      <p>All tasks related to the 3.33 LTS, including issues with backports, the release process, and so on.</p>
+    status: paused
+    lts: true
+    completed: false
+    last-activity: 2026-06-11
+  - title: "Quarkus 3.15 LTS"
+    board-url: "https://github.com/orgs/quarkusio/projects/28"
+    short-description: |
+      This WG focuses on defining the issues we would like to have in the next-to-be LTS (Quarkus 3.14/3.15)
+    readme: |
+      <p>This working group uses a different board:</p>
+      <ul>
+      <li>The <code>under discussion</code> column contains the issues we would like to have in the next LTS but are still under consideration.</li>
+      <li>The <code>out of scope</code> column contains the issues under discussion' that won't be included. The reason can be time or technical...</li>
+      <li>The <code>in progress</code> means that the work has started and should be completed before the TLS cut date</li>
+      <li>The <code>done</code> column means that the issues have been completed</li>
+      </ul>
+    status: complete
+    lts: true
+    completed: true
+    last-activity: 2026-06-02
+    last-update-date: 2025-11-03
+    last-update: |
+      3.15 is now EOL.
+  - title: "Java 25 support"
+    board-url: "https://github.com/orgs/quarkusio/projects/59"
+    short-description: |
+      The objective of this working group is to enable Quarkus applications to run cleanly across dev/test/production modes on Java 25, with no requirement to adopt Java 25 as a baseline.
+    readme: |
+      <h3>Objective</h3>
+      <p>To enable Quarkus applications to run cleanly across dev/test/production modes on Java 25, with no requirement to adopt Java 25 as a baseline.</p>
+      <h3>The Problem</h3>
+      <p>Java 25 brings new features and platform-level changes (e.g., new JEPs, VM flags, performance tweaks) that may trigger warnings, break behavior, or degrade Quarkus experiences. Dependencies or extensions may also face compatibility challenges. A coordinated effort is needed to identify, fix, document, and optionally leverage these changes.</p>
+      <h3>The Solution</h3>
+      <p>The working group will:</p>
+      <ul>
+      <li>Attempt to run representative Quarkus applications under Java 25 in dev, test, and production modes.</li>
+      <li>Catalog issues, warnings, or incompatibilities in a Wiki or issue tracker.</li>
+      <li>Propose and implement fixes or mitigations (or document workarounds).</li>
+      <li>Optionally explore beneficial Java 25 features (e.g., Scoped Values, Flexible Constructor Bodies), without requiring their use.</li>
+      <li>Identify and remediate or flag problematic Quarkus extensions.
+      ⠀</li>
+      </ul>
+      <h3>Definition of Done</h3>
+      <ul>
+      <li>Publish a wiki page detailing issues and resolutions.</li>
+      <li>Ensure Quarkus core and its ecosystem can operate cleanly under Java 25 in all modes.</li>
+      <li>Integrate any selected Java 25 features in an optional, non-breaking manner.</li>
+      <li>Document or fix problematic extensions, offering guidance where needed.</li>
+      <li>Communicate results via a blog post or quarkus-dev announcement.
+      ⠀</li>
+      </ul>
+      <h3>Scope of Work</h3>
+      <p><strong>In scope:</strong></p>
+      <ul>
+      <li>Running and diagnosing Quarkus on Java 25.</li>
+      <li>Fixing issues in Quarkus core repository and extensions.</li>
+      <li>Exploring select Java 25 enhancements.</li>
+      </ul>
+      <p>⠀
+      <strong>Out of scope:</strong></p>
+      <ul>
+      <li>Mandating Java 25 as the minimum supported runtime.</li>
+      </ul>
+      <p>⠀</p>
+      <h3>Organizing the Work</h3>
+      <ol>
+      <li><strong>Communication &amp; Transparency:</strong>
+      <ul>
+      <li>Use GitHub discussion, project board, and issues.</li>
+      <li>Coordinate via Quarkus Zulip and GitHub.</li>
+      </ul>
+      </li>
+      <li><strong>Timeline &amp; Milestones:</strong>
+      <ul>
+      <li><strong>Exploration Phase:</strong> Run tests on Java 25 Candidate Release, document findings before GA (target: <em>before September 16, 2025</em>), so we can guide our users as soon as Java 25 reaches GA.</li>
+      </ul>
+      </li>
+      </ol>
+      <hr />
+      <ul>
+      <li>Point of contact: @Sanne (@<strong>Sanne</strong> on Zulip) and @gsmet (@_<strong>Guillaume Smet</strong> on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/49696</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Java.2025.20chat">Zulip</a></li>
+      </ul>
+    status: staled
+    lts: false
+    completed: false
+    last-activity: 2026-05-27
+    last-update-date: 2026-05-26
+    last-update: |
+      The Java 25 support group addressed the Mockito/Bytebuddy warnings this week. We closed out the issue related to self-attaching to the JVM.
+      
+      (This status update was automatically generated using AI.)
+    point-of-contact: "@Sanne (@<strong>Sanne</strong> on Zulip) and @gsmet (@_<strong>Guillaume Smet</strong> on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/49696
+    discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Java.2025.20chat
+  - title: "OIDC improvements"
+    board-url: "https://github.com/orgs/quarkusio/projects/46"
+    short-description: |
+      The goal of this working group is to improve quarkus-oidc by: implementing crucial new security features, continuing with improving the way OIDC requests can be intercepted, prioritizing some other open issues, such as using JWT bearer client authentication to complete the authorization code flow
+    readme: |
+      <p>The goal of this working group is to improve quarkus-oidc by: implementing crucial new security features, continuing with improving the way OIDC requests can be intercepted, prioritizing some other open issues, such as using JWT bearer client authentication to complete the authorization code flow</p>
+      <ul>
+      <li>Point of contact: @sberyozkin (@_<strong>Sergey Beryozkin</strong>  on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/42116</li>
+      </ul>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2026-04-30
+    last-update-date: 2026-03-23
+    last-update: |
+      Done! Lots of ODIC features have been shipped by this working group.
+    point-of-contact: "@sberyozkin (@_<strong>Sergey Beryozkin</strong>  on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/42116
+  - title: "Chappie"
+    board-url: "https://github.com/orgs/quarkiverse/projects/8"
+    short-description: |
+      The main objective of this working group is to allow AI features in Quarkus Dev Mode (Dev UI and CLI)
+    readme: |
+      <p>The main objective of this working group is to allow AI features in Quarkus Dev Mode (Dev UI and CLI)</p>
+      <h3>The Problem</h3>
+      <p>The way developers write code is changing with the rise of AI tools like chatGPT, etc. Developers now ask an AI agent to help with tasks.</p>
+      <h3>The proposed Solution</h3>
+      <p>Provide a way to allow AI integration into Quarkus Dev Mode (Dev UI and CLI) . They should enable extensions to to contribute to the AI hooks.</p>
+      <p>Quarkus core should allow hooks (BuildItems) that extensions can use to define AI functions.</p>
+      <p>The chappie extensions will use this and set it up in Dev UI. The Chappie extension will also be responsible for an indexed vector DB that contains the Quarkus documentation. Extensions should be able to use this with groupId and artifactId.</p>
+      <p>The Chappie extension will manage the backend configuration, connection (to the LLM), and the elements in the Dev UI.</p>
+      <p>Extensions will provide relevant AI functions.</p>
+      <p>Adding a chatbot can also be added.</p>
+      <ul>
+      <li>Point of contact: @phillip-kruger (@<strong>Phillip Krüger</strong>  on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/45377</li>
+      <li>Discussion: <a href="https://quarkusio.zulipchat.com/#narrow/stream/187038-dev">Zulip topic</a></li>
+      <li>Deliverable: <a href="https://quarkus.io/guides/assistant">Quarkus Dev Assistant</a></li>
+      </ul>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2026-04-15
+    last-update-date: 2026-03-23
+    last-update: |
+      This working group is now complete. For those interested in the next phase, we've kicked off the Quarkus Dev Start follow-up group here: [#53093](https://github.com/quarkusio/quarkus/discussions/53093). See you there!
+    deliverable: <a rel="nofollow" href="https://quarkus.io/guides/assistant">Quarkus Dev Assistant</a>
+    point-of-contact: "@phillip-kruger (@<strong>Phillip Krüger</strong>  on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/45377
+    discussion: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev
+  - title: "Quarkus to the CommonHaus Foundation"
+    board-url: "https://github.com/orgs/quarkusio/projects/38"
+    short-description: |
+      Work needed around moving Quarkus to foundation and streamline open governance.
+    readme: |
+      <p>from Discussion at https://github.com/quarkusio/quarkus/discussions/43013</p>
+      <p>We started the move of Quarkus to a foundation <a href="https://quarkus.io/blog/quarkus-in-a-foundation/">earlier this year</a> and recently <a href="https://quarkus.io/blog/quarkus-moving-to-commonhaus/">set the direction</a> towards <a href="https://www.commonhaus.org/">CommonHaus</a> and during the summer break the CommonHaus council <a href="https://github.com/commonhaus/foundation/pull/183">approved our request</a> to join.</p>
+      <p>Thus, now the real work starts, and it's just fitting we set up a working group for the effort getting Quarkus to CommonHaus foundation.</p>
+      <h1>Goal</h1>
+      <p>Two parts</p>
+      <ul>
+      <li>setup Quarkus to have transparent and open governance</li>
+      <li>Go through the few but important requirements for a CommonHaus project.</li>
+      </ul>
+      <h1>Initial work items/questions:</h1>
+      <p>Current known list, but not limited to:</p>
+      <ul>
+      <li>identify design communication channels (i.e. #41973)</li>
+      <li>which repositories / code will move</li>
+      <li>impact (if any) on quarkiverse projects</li>
+      <li>how will trademarks work/change</li>
+      <li>identify running services and setup/maintain them (registry.quarkus.io, code.quarkus.io etc.)</li>
+      <li>add required metadata/files to the various repositories</li>
+      </ul>
+      <h1>Tracking</h1>
+      <p>We will use the working group board to track publicly all the known relevant work and questions.For the few exception cases where, for legal or personal constraints, the work must happen in private, we will post the outcome and results in public places (like a GitHub discussion of a GitHub issue tracked on the working group board).</p>
+      <h1>When will this working group be done?</h1>
+      <p>When Quarkus has an active working governance model in place and all major work items around setting up Quarkus at CommonHaus are completed - after that, its expected things will just be iteratively improved, and the dedicated working group will not be needed (others might start to continue more specific efforts).</p>
+      <p>The majority of the work must be done before the end of December 2024. The latest deadline for CommonHaus is April 2025, when the bootstrap period of CommonHaus ends.</p>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2026-03-23
+    last-update-date: 2026-03-23
+    last-update: |
+      Quarkus is now on Commonhaus! Since only a few "mini" admin tasks remain, we’re closing out this working group.
+  - title: "Roq :: Quarkus SSG"
+    board-url: "https://github.com/orgs/quarkiverse/projects/6"
+    short-description: |
+      Allow Static Site Generation with Quarkus.
+    readme: |
+      <p>New initiative to allow Static Site Generation with Quarkus.</p>
+      <p>Quarkus already provides most of the pieces to create great web applications (https://quarkus.io/guides/web).</p>
+      <p>I recently added https://github.com/quarkiverse/quarkus-roq. It will allow generating a static website out of any Quarkus application (it starts the app, fetch all the configured pages and assets, generate a static website and stop), it already works but it is still very alpha.</p>
+      <p>What's missing? we now need to incrementally add the toolkit to ease the process of creating static content through Quarkus:</p>
+      <ul>
+      <li>Static Data</li>
+      <li>Markdown/Asciidoc and frontmatter</li>
+      <li>SEO</li>
+      <li>Image processing</li>
+      <li>Easy to configure routing</li>
+      </ul>
+      <p>This will allow to develop the content using Quarkus dev-mode, and then generate for Github Pages or similar when it's ready.</p>
+      <p>Bonus, everything added will benefit any &quot;non-static&quot; Quarkus app and any Static Quarkus app could also become non static.</p>
+      <p>This effort is now tracked using a &quot;Working Group&quot; project: https://github.com/orgs/quarkiverse/projects/6</p>
+      <p>This is a great opportunity to participate in fun effort and be involved with the Quarkus community, if anyone is interested in being a part of this, please reach out to me 🚀</p>
+      <ul>
+      <li>Point of contact: @ia3andy</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/41309</li>
+      <li>Deliverable: <a href="https://www.youtube.com/live/hrF1a5sKqBI">Quarkus Insight</a></li>
+      </ul>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2025-11-25
+    last-update-date: 2024-11-18
+    last-update: |
+      ROQ has been released! See https://www.youtube.com/live/hrF1a5sKqBI to see ROQ in action.
+    deliverable: <a rel="nofollow" href="https://www.youtube.com/live/hrF1a5sKqBI">Quarkus Insight</a>
+    point-of-contact: "@ia3andy"
+    proposal: https://github.com/quarkusio/quarkus/discussions/41309
+  - title: "Quarkus 3.27 LTS"
+    board-url: "https://github.com/orgs/quarkusio/projects/65"
+    short-description: |
+      This working group aims to track the effort around the Quarkus 3.27 LTS version.
+    readme: |
+      <p>All the tasks related to the 3.27 LTS, including issues with backport, release process, and so on.</p>
+      <hr />
+      <ul>
+      <li>Backports: https://github.com/orgs/quarkusio/projects/62</li>
+      </ul>
+    status: on track
+    lts: true
+    completed: false
+    last-activity: 2025-11-03
+    backports: https://github.com/orgs/quarkusio/projects/62
+  - title: "Quarkus Config and IDEs"
+    board-url: "https://github.com/orgs/quarkusio/projects/32"
+    short-description: |
+      Let's define a format for the files containing the config model we will include in the jars for IDE consumption.
+    readme: |
+      <p>Let's define a format for the files containing the config model we will include in the jars for IDE consumption.</p>
+      <p>See https://github.com/quarkusio/quarkus/discussions/42671 for more details.</p>
+      <p><em>Point of contact</em>: @gsmet (Zulip: @_<strong>Guillaume Smet</strong> )</p>
+    status: paused
+    lts: false
+    completed: false
+    last-activity: 2025-09-08
+    last-update-date: 2025-07-22
+    last-update: |
+      The working group has been paused due to a lack of progress for some time now. Let's revisit it in a few months.
+  - title: "Quarkus 3.20 LTS"
+    board-url: "https://github.com/orgs/quarkusio/projects/41"
+    short-description: |
+      This working group aims to track the effort around the Quarkus 3.20 LTS version.
+    readme: |
+      <p>All the tasks related to the 3.20 LTS, including issues with backport, release process, and so on.</p>
+    status: on track
+    lts: true
+    completed: false
+    last-activity: 2025-06-25
+    last-update-date: 2025-04-01
+    last-update: |
+      In the past month, the WG - Quarkus 3.20 LTS successfully closed three issues, addressing an exception related to missing Maven classes in the dev-ui for Gradle projects, enhancing the Grafana LGTM dashboards, and determining the appropriate Kafka client version for the 3.20 LTS release. No new issues were opened during this period, indicating focused progress on existing challenges.
+  - title: "WebSocket Next"
+    board-url: "https://github.com/orgs/quarkusio/projects/26"
+    short-description: |
+      WebSocket-Next related tasks
+    readme: |
+      <p>The WebSocket Next <em>focus group</em> aims to improve our WebSocket experience.</p>
+      <p>Recently, we delivered a new approach to dealing with WebSocket (both for the server and client). This was the first step. There are still a few areas to improve, such as documentation, security, observability, and testability. The goal of this focus group is to track these efforts.</p>
+      <ul>
+      <li>Point of contact: @mkouba (@<strong>Martin Kouba</strong>  on Zulip)</li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/38473</li>
+      <li>Deliverable: <a href="https://www.youtube.com/watch?v=9ALOZrlP7TE">Quarkus Insight</a></li>
+      </ul>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2024-12-17
+    last-update-date: 2024-12-16
+    last-update: |
+      Completed! 
+      See https://quarkus.io/guides/websockets-next-tutorial and https://quarkus.io/guides/websockets-next-reference
+    deliverable: <a rel="nofollow" href="https://www.youtube.com/watch?v=9ALOZrlP7TE">Quarkus Insight</a>
+    point-of-contact: "@mkouba (@<strong>Martin Kouba</strong>  on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/38473
+  - title: "Enhanced TLS support"
+    board-url: "https://github.com/orgs/quarkusio/projects/24"
+    short-description: |
+      Track the progress around the new TLS configuration centralization and new features (like Let's Encrypt, Cert-Manager, and local experience...)
+    readme: |
+      <p>TLS is becoming increasingly common and recommended. However, for years, each Quarkus extension has been doing its own TLS configuration and management. As a result, the configuration looks different everywhere, and many extensions have incomplete configurations.</p>
+      <p>Based on the newly integrated TLS registry, we now have a single place to configure TLS. At runtime, it provides methods to configure Vert.x and &quot;pure&quot; Java clients (using an <code>SSLContext</code>).</p>
+      <p>The goal of this focus group is to continue integrating the TLS registry and improve Quarkus integration with certificate providers (Let's Encrypt, Cert-Manager). In addition, we would like to provide a frictionless local experience around TLS (i.e., without the infamous untrusted certificate screen).</p>
+      <ul>
+      <li>Point of contact:  @cescoffier (@<strong>Clement Escoffier</strong> on Zulip)</li>
+      <li>Deliverable: <a href="https://www.youtube.com/watch?v=VP7c9ftFwrQ">Quarkus Insight</a></li>
+      <li>Proposal: https://github.com/quarkusio/quarkus/discussions/41024</li>
+      </ul>
+    status: complete
+    lts: false
+    completed: true
+    last-activity: 2024-11-19
+    last-update-date: 2024-09-29
+    last-update: |
+      This working group is complete! 
+      That does not mean that no work will be done around TLS, but what was defined in the initial scope of the working group has been completed. 
+      Enhancements and bug fixes will follow.
+    deliverable: <a rel="nofollow" href="https://www.youtube.com/watch?v=VP7c9ftFwrQ">Quarkus Insight</a>
+    point-of-contact: "@cescoffier (@<strong>Clement Escoffier</strong> on Zulip)"
+    proposal: https://github.com/quarkusio/quarkus/discussions/41024
+  - title: "Docker file generation"
+    board-url: "https://github.com/orgs/quarkusio/projects/27"
+    short-description: |
+      A working group focusing on the generation of Dockerfile / ContainerFile
+    readme: |
+      <p>At the moment, when you create a Quarkus project (from code.quarkus.io or the CLI), a set of <code>Dockerfiles</code> is generated. However,</p>
+      <ol>
+      <li>Not all these files are used by the user</li>
+      <li>These files are very quickly outdated</li>
+      <li>It does not allow <em>extensions</em> to customize the content</li>
+      </ol>
+      <p>This working group aims to replace these `Dockerfiles' with a CLI command that generates an up-to-date Dockerfile and includes extension customization.</p>
+      <p>The goal is not to allow updating these files once generated but to provide a one-off generation that the user can consult and use. It will use the recommended and up-to-date <code>FROM</code> image to improve security and, depending on the generated <em>variant</em> (JVM, native, native-micro...), follow good practices (such as using <code>run-java</code> for the JVM one).</p>
+      <p>You can find more details about this working group on <a href="https://github.com/quarkusio/quarkus/discussions/41352">this discussion</a>.
+      Once completed, this working group will be followed by other initiatives focusing on generating the Github Action and Tekton pipelines.</p>
+      <p><em>Point of contact</em>: @iocanel (<code>Ioannis Canellos</code>on Zulip)</p>
+    status: paused
+    lts: false
+    completed: false
+    last-activity: 2024-10-31
+    last-update-date: 2025-10-28
+    last-update: |
+      Putting this working group on pause for now.
+

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
@@ -48,12 +48,24 @@ public class UnrenderedMarkupDetector {
             // Template error messages
             new MarkupPattern(Pattern.compile("(?i)(liquid|template) (error|syntax error|warning)"), "Template error message"),
             // YAML front matter: --- at very start of visible text
-            new MarkupPattern(Pattern.compile("\\A---\\s*\\n"), "YAML front matter (---)"),
-
-            // Qute/template expressions: {identifier.property} or {identifier.method()}
-            new MarkupPattern(Pattern.compile("\\{[a-zA-Z][a-zA-Z0-9]*\\.[a-zA-Z][a-zA-Z0-9().'\" ,-]*\\}"),
-                    "Qute expression ({obj.property})")
+            new MarkupPattern(Pattern.compile("\\A---\\s*\\n"), "YAML front matter (---)")
     );
+
+    private static final Pattern UNRESOLVED_PLACEHOLDER = Pattern.compile(
+            "\\{[a-zA-Z][a-zA-Z0-9]*\\.[a-zA-Z][a-zA-Z0-9().'\" ,-]*\\}");
+
+    public static List<String> findUnresolvedPlaceholders(String text) {
+        List<String> findings = new ArrayList<>();
+        var matcher = UNRESOLVED_PLACEHOLDER.matcher(text);
+        while (matcher.find()) {
+            String match = matcher.group();
+            if (match.length() > 60) {
+                match = match.substring(0, 57) + "...";
+            }
+            findings.add("Unresolved placeholder ({obj.property}): \"" + match + "\"");
+        }
+        return findings;
+    }
 
     private static final Pattern HTML_TAG = Pattern.compile("</?[a-zA-Z][a-zA-Z0-9]*[\\s>/]");
 

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetector.java
@@ -48,7 +48,11 @@ public class UnrenderedMarkupDetector {
             // Template error messages
             new MarkupPattern(Pattern.compile("(?i)(liquid|template) (error|syntax error|warning)"), "Template error message"),
             // YAML front matter: --- at very start of visible text
-            new MarkupPattern(Pattern.compile("\\A---\\s*\\n"), "YAML front matter (---)")
+            new MarkupPattern(Pattern.compile("\\A---\\s*\\n"), "YAML front matter (---)"),
+
+            // Qute/template expressions: {identifier.property} or {identifier.method()}
+            new MarkupPattern(Pattern.compile("\\{[a-zA-Z][a-zA-Z0-9]*\\.[a-zA-Z][a-zA-Z0-9().'\" ,-]*\\}"),
+                    "Qute expression ({obj.property})")
     );
 
     private static final Pattern HTML_TAG = Pattern.compile("</?[a-zA-Z][a-zA-Z0-9]*[\\s>/]");

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
@@ -97,6 +97,25 @@ class UnrenderedMarkupDetectorTest {
     }
 
     @Test
+    void detectsQuteExpressions() {
+        assertDetects("{board.title}", "Qute expression");
+        assertDetects("{board.isCompleted()}", "Qute expression");
+        assertDetects("{item.short-description.raw}", "Qute expression");
+        assertDetects("some text {board.shortDescription.trim()} more text", "Qute expression");
+    }
+
+    @Test
+    void doesNotFlagCssOrSimpleBraces() {
+        List<String> findings = findUnrenderedMarkup("{color: red}");
+        assertTrue(findings.stream().noneMatch(f -> f.contains("Qute expression")),
+                "Should not flag CSS-like content but got: " + findings);
+
+        findings = findUnrenderedMarkup("function() { return 1; }");
+        assertTrue(findings.stream().noneMatch(f -> f.contains("Qute expression")),
+                "Should not flag JS-like content but got: " + findings);
+    }
+
+    @Test
     void doesNotFlagCleanHtml() {
         List<String> findings = findUnrenderedMarkup(
                 "This is a normal blog post with headings and paragraphs. "

--- a/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
+++ b/src/test/java/io/quarkusio/UnrenderedMarkupDetectorTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import static io.quarkusio.UnrenderedMarkupDetector.findUnresolvedPlaceholders;
 import static io.quarkusio.UnrenderedMarkupDetector.findUnrenderedMarkup;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -97,23 +98,21 @@ class UnrenderedMarkupDetectorTest {
     }
 
     @Test
-    void detectsQuteExpressions() {
-        assertDetects("{board.title}", "Qute expression");
-        assertDetects("{board.isCompleted()}", "Qute expression");
-        assertDetects("{item.short-description.raw}", "Qute expression");
-        assertDetects("some text {board.shortDescription.trim()} more text", "Qute expression");
+    void detectsUnresolvedPlaceholders() {
+        assertDetectsPlaceholder("{board.title}");
+        assertDetectsPlaceholder("{board.isCompleted()}");
+        assertDetectsPlaceholder("{item.short-description.raw}");
+        assertDetectsPlaceholder("some text {board.shortDescription.trim()} more text");
     }
 
     @Test
-    void doesNotFlagCssOrSimpleBraces() {
-        List<String> findings = findUnrenderedMarkup("{color: red}");
-        assertTrue(findings.stream().noneMatch(f -> f.contains("Qute expression")),
-                "Should not flag CSS-like content but got: " + findings);
-
-        findings = findUnrenderedMarkup("function() { return 1; }");
-        assertTrue(findings.stream().noneMatch(f -> f.contains("Qute expression")),
-                "Should not flag JS-like content but got: " + findings);
+    void doesNotFlagCssOrSimpleBracesAsPlaceholders() {
+        assertTrue(findUnresolvedPlaceholders("{color: red}").isEmpty(),
+                "Should not flag CSS-like content");
+        assertTrue(findUnresolvedPlaceholders("function() { return 1; }").isEmpty(),
+                "Should not flag JS-like content");
     }
+
 
     @Test
     void doesNotFlagCleanHtml() {
@@ -129,5 +128,10 @@ class UnrenderedMarkupDetectorTest {
         assertFalse(findings.isEmpty(), "Expected to detect markup in: " + input);
         assertTrue(findings.stream().anyMatch(f -> f.contains(expectedFragment)),
                 "Expected finding containing '" + expectedFragment + "' but got: " + findings);
+    }
+
+    private void assertDetectsPlaceholder(String input) {
+        List<String> findings = findUnresolvedPlaceholders(input);
+        assertFalse(findings.isEmpty(), "Expected to detect unresolved placeholder in: " + input);
     }
 }

--- a/src/test/java/io/quarkusio/WorkingGroupsPageTest.java
+++ b/src/test/java/io/quarkusio/WorkingGroupsPageTest.java
@@ -1,5 +1,6 @@
 package io.quarkusio;
 
+import com.microsoft.playwright.Locator;
 import org.junit.jupiter.api.Test;
 
 import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainRawHtml;
@@ -26,5 +27,34 @@ public class WorkingGroupsPageTest extends BrowserTest {
     void workingGroupsPageDoesNotContainRawHtmlTags() {
         page.navigate(baseUrl + "/working-groups/");
         assertDoesNotContainRawHtml(page, "Working groups page");
+    }
+
+    @Test
+    void workingGroupsCardTitlesAreNotTemplateExpressions() {
+        page.navigate(baseUrl + "/working-groups/");
+        Locator titles = page.locator(".card .card-title");
+        int count = titles.count();
+        assertTrue(count >= 1, "Expected at least 1 card title");
+        for (int i = 0; i < count; i++) {
+            String title = titles.nth(i).innerText().trim();
+            assertFalse(title.matches("\\{.*\\..*}"),
+                    "Card title looks like an unresolved template expression: " + title);
+            assertFalse(title.isEmpty(), "Card title should not be empty");
+        }
+    }
+
+    @Test
+    void workingGroupsCardsHaveDistinctTitles() {
+        page.navigate(baseUrl + "/working-groups/");
+        Locator titles = page.locator(".card .card-title");
+        int count = titles.count();
+        assertTrue(count >= 5, "Expected at least 5 card titles");
+        long distinctCount = java.util.stream.IntStream.range(0, count)
+                .mapToObj(i -> titles.nth(i).innerText().trim())
+                .distinct()
+                .count();
+        assertTrue(distinctCount >= 5,
+                "Expected at least 5 distinct card titles but found " + distinctCount
+                        + " (all cards having the same title suggests unresolved template data)");
     }
 }

--- a/src/test/java/io/quarkusio/WorkingGroupsPageTest.java
+++ b/src/test/java/io/quarkusio/WorkingGroupsPageTest.java
@@ -3,8 +3,11 @@ package io.quarkusio;
 import com.microsoft.playwright.Locator;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainRawHtml;
 import static io.quarkusio.UnrenderedMarkupDetector.assertDoesNotContainUnrenderedMarkup;
+import static io.quarkusio.UnrenderedMarkupDetector.findUnresolvedPlaceholders;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WorkingGroupsPageTest extends BrowserTest {
@@ -30,16 +33,16 @@ public class WorkingGroupsPageTest extends BrowserTest {
     }
 
     @Test
-    void workingGroupsCardTitlesAreNotTemplateExpressions() {
+    void workingGroupsCardsDoNotContainUnresolvedPlaceholders() {
         page.navigate(baseUrl + "/working-groups/");
-        Locator titles = page.locator(".card .card-title");
-        int count = titles.count();
-        assertTrue(count >= 1, "Expected at least 1 card title");
+        Locator cards = page.locator(".card");
+        int count = cards.count();
+        assertTrue(count >= 1, "Expected at least 1 card");
         for (int i = 0; i < count; i++) {
-            String title = titles.nth(i).innerText().trim();
-            assertFalse(title.matches("\\{.*\\..*}"),
-                    "Card title looks like an unresolved template expression: " + title);
-            assertFalse(title.isEmpty(), "Card title should not be empty");
+            String text = cards.nth(i).innerText().trim();
+            List<String> findings = findUnresolvedPlaceholders(text);
+            assertTrue(findings.isEmpty(),
+                    "Card " + i + " contains unresolved placeholders: " + findings);
         }
     }
 

--- a/working-groups/main.java
+++ b/working-groups/main.java
@@ -1,6 +1,6 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVAC_OPTIONS -parameters
-//RUNTIME_OPTIONS --add-opens java.base/java.lang=ALL-UNNAMED
+//RUNTIME_OPTIONS --add-opens java.base/java.lang=ALL-UNNAMED -Dquarkus.qute.alt-expr-syntax=false
 //DEPS io.quarkus.platform:quarkus-bom:3.36.3@pom
 //DEPS io.quarkus:quarkus-picocli
 //DEPS io.quarkus:quarkus-smallrye-graphql-client
@@ -30,6 +30,7 @@ import picocli.CommandLine;
 import java.io.File;
 import java.nio.file.Files;
 import java.time.Instant;
+import java.util.regex.Pattern;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -78,7 +79,15 @@ public class main implements Callable<Integer> {
         Log.infof("Found %d working group projects", boards.size());
         boards.sort(Comparator.comparing(Board::updateDate).reversed());
 
-        Files.writeString(out.toPath(), yaml.data("boards", boards).render());
+        String rendered = yaml.data("boards", boards).render();
+
+        Pattern unresolvedExpression = Pattern.compile("\\{[a-zA-Z][a-zA-Z0-9]*\\.[a-zA-Z][a-zA-Z0-9().'\" ,-]*}");
+        if (unresolvedExpression.matcher(rendered).find()) {
+            Log.errorf("Rendered YAML contains unresolved template expressions — aborting write to %s", out);
+            return 1;
+        }
+
+        Files.writeString(out.toPath(), rendered);
 
         return 0;
     }


### PR DESCRIPTION
This is a funny failure. :)

The working group sync runs every three hours. Immediately after the conversion the working group page was fine, but then it lost all its content. What had happened was that the next WG sync ran, and the WG sync job picked up the repo-level Qute settings. Roq uses the alt Qute syntax, which meant the sync job rewrote https://github.com/quarkusio/quarkusio.github.io/blob/main/_data/wg.yaml into this kind of nonsense:

```        
    ---
working-groups:
    - title: "{board.title}"
      board-url: "{board.url}"
      short-description: |
        {board.shortDescription.trim()}
      readme: |
        {board.getIndentedReadme().raw}
      status: {board.getBadgeText()}
      lts: {board.isLTS()}
      
 ```

I hadn't rebased when I was diagnosing, so my local version still had the correct contents, and I was totally confused about what was going wrong. 

Tests should have caught this, but the working group test wasn't strong enough, and the unrendered markup test was detecting Jekyll markup but not many Roq patterns. 

This fix updates the generator script, and adds tests. For the tests to pass I also had to update the data, so I restored the version of the data from 10am this morning. I'm assuming the next sync job will update to the correct current data.