### PR TITLE
Image fix for wide monitors and spring page layout change

### DIFF
--- a/templates/partials/spring-roles-band.html
+++ b/templates/partials/spring-roles-band.html
@@ -2,90 +2,94 @@
   <div class="width-12-12">
     <h2>How moving to Quarkus helps you be successful, no matter your role.</h2>
     <div class="grid-wrapper">
-      <div class="width-6-12 width-12-12-m">
+      <div class="width-12-12">
         <h3>ARCHITECTS</h3>
         <h4>Designing cloud-optimized applications</h4>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-performance.svg" alt="Performance icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-performance-dark.svg" alt="Performance icon">
+        <div class="roles-imagetext-grid">
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-performance.svg" alt="Performance icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-performance-dark.svg" alt="Performance icon">
+            </div>
+            <div class="imagetext-text"><h5>Struggling with cold starts and memory bloat in Microservices?</h5>
+              <p>Quarkus is engineered for speed and efficiency. Its build-time optimizations and native compilation capabilities deliver ultra-fast startup times and low memory usage.</p>
+              <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/performance/">Learn how Quarkus is so fast</a></p>
+            </div>
           </div>
-          <div class="imagetext-text"><H5>Struggling with cold starts and memory bloat in Microservices?</h5>
-            <p>Quarkus is engineered for speed and efficiency.Its build-time optimizations and native compilation capabilities deliver ultra-fast startup times and low memory usage.</p>
-            <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/performance/">Learn how Quarkus is so fast</a></p>
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-developerjoy.svg" alt="Developer joy icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-developerjoy-dark.svg" alt="Developer joy icon">
+            </div>
+            <div class="imagetext-text"><h5>Developer productivity dragging down your team?</h5>
+              <p>Quarkus brings developer joy to enterprise Java. With live reload, continuous testing, a built-in Developer UI, and automatic service provisioning via Dev Services, your team spends less time wiring things up and more time building value.</p>
+              <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/developer-joy/">How Quarkus accelerates developers</a></p>
+            </div>
           </div>
-        </div>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-developerjoy.svg" alt="Developer joy icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-developerjoy-dark.svg" alt="Developer joy icon">
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-kube-native.svg" alt="Kube-native icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-kube-native-dark.svg" alt="Kube-native icon">
+            </div>
+            <div class="imagetext-text"><h5>Feeling the friction of getting Java apps cloud-ready?</h5>
+              <p>Quarkus is Kubernetes-native by design. From minimal image footprints to seamless Kubernetes integration and cloud-friendly configuration, Quarkus fits naturally into CI/CD pipelines and container orchestrators.</p>
+              <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/kubernetes-native/">What Kubernetes-native really means</a></p>
+            </div>
           </div>
-          <div class="imagetext-text"><H5>Developer productivity dragging down your team?</h5>
-            <p>Quarkus brings developer joy to enterprise Java. With live reload, continuous testing, a built-in Developer UI, and automatic service provisioning via Dev Services, your team spends less time wiring things up and more time building value.</p>
-            <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/developer-joy/">How Quarkus accelerates developers</a></p>
-          </div>
-        </div>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-kube-native.svg" alt="Kube-native icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-kube-native-dark.svg" alt="Kube-native icon">
-          </div>
-          <div class="imagetext-text"><H5>Feeling the friction of getting Java apps cloud-ready?</h5>
-            <p>Quarkus is Kubernetes-native by design. From minimal image footprints to seamless Kubernetes integration and cloud-friendly configuration, Quarkus fits naturally into CI/CD pipelines and container orchestrators. </p>
-            <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/kubernetes-native/">What Kubernetes-native really means</a></p>
-          </div>
-        </div>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-aiapps.svg" alt="AI apps icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-aiapps-dark.svg" alt="AI apps icon">
-          </div>
-          <div class="imagetext-text"><H5>Planning for AI but stuck on integration complexity?</h5>
-            <p>Quarkus makes building AI-infused apps feel native. Thanks to built-in support for <a href="https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html">LangChain4j</a> and <a href="https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html">Model Context Protocol (MCP)</a>, you can create type-safe AI services, agents, and tool-calling logic in plain Java: Ready for RAG, structured outputs, and local or cloud models.</p>
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-aiapps.svg" alt="AI apps icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-aiapps-dark.svg" alt="AI apps icon">
+            </div>
+            <div class="imagetext-text"><h5>Planning for AI but stuck on integration complexity?</h5>
+              <p>Quarkus makes building AI-infused apps feel native. Thanks to built-in support for <a href="https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html">LangChain4j</a> and <a href="https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html">Model Context Protocol (MCP)</a>, you can create type-safe AI services, agents, and tool-calling logic in plain Java: Ready for RAG, structured outputs, and local or cloud models.</p>
+            </div>
           </div>
         </div>
       </div>
-      <div class="width-6-12 width-12-12-m">
+      <div class="width-12-12">
         <h3>DEVELOPERS</h3>
         <h4>Boost your Java productivity</h4>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-waiting.svg" alt="Waiting icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-waiting-dark.svg" alt="Waiting icon">
+        <div class="roles-imagetext-grid">
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-waiting.svg" alt="Waiting icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-waiting-dark.svg" alt="Waiting icon">
+            </div>
+            <div class="imagetext-text"><h5>Tired of waiting for builds and restarts?</h5>
+              <p>Experience true live coding with Quarkus Dev Mode. Make a change, save, and instantly see the result. Without restarting your app. Whether you're debugging, refining business logic, or tweaking your UI, Quarkus gives you continuous feedback at dev speed.</p>
+              <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/guides/maven-tooling#dev-mode">Give DevMode a try</a></p>
+            </div>
           </div>
-          <div class="imagetext-text"><H5>Tired of waiting for builds and restarts?</h5>
-            <p>Experience true live coding with Quarkus Dev Mode. Make a change, save, and instantly see the result. Without restarting your app. Whether you're debugging, refining business logic, or tweaking your UI, Quarkus gives you continuous feedback at dev speed.</p>
-            <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/guides/maven-tooling#dev-mode">Give DevMode a try</a></p>
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-norestart.svg" alt="No restart icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-norestart-dark.svg" alt="No restart icon">
+            </div>
+            <div class="imagetext-text"><h5>Using Spring now? You don't have to start over.</h5>
+              <p>Quarkus speaks fluent Spring. Reuse your @RestController, @Autowired, and JpaRepository code with Spring compatibility extensions. You get the same familiar APIs, now backed by a faster, more modern runtime.</p>
+              <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/spring/migrate">Ready to migrate? See our migration guide</a></p>
+            </div>
           </div>
-        </div>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-norestart.svg" alt="No restart icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-norestart-dark.svg" alt="No restart icon">
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-heavylifting.svg" alt="Heavy lifting icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-heavylifting-dark.svg" alt="Heavy lifting icon">
+            </div>
+            <div class="imagetext-text"><h5>Local setup slowing you down?</h5>
+              <p>Let Quarkus Dev Services do the heavy lifting. No more hunting for container images or writing docker-compose files. Just add an extension and Quarkus spins up databases, message brokers, and more for you. Clean, disposable, and zero config.</p>
+              <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/guides/dev-services">Use the Dev Services</a></p>
+            </div>
           </div>
-          <div class="imagetext-text"><h5>Using Spring now? you don’t have to start over.</h5>
-            <p>Quarkus speaks fluent Spring. Reuse your @RestController, @Autowired, and JpaRepository code with Spring compatibility extensions. You get the same familiar APIs, now backed by a faster, more modern runtime.</p>
-            <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/spring/migrate">Ready to migrate? See our migration guide</a></p>
-          </div>
-        </div>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-heavylifting.svg" alt="Heavy lifting icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-heavylifting-dark.svg" alt="Heavy lifting icon">
-          </div>
-          <div class="imagetext-text"><H5>Local setup slowing you down?</h5>
-            <p>Let Quarkus Dev Services do the heavy lifting. No more hunting for container images or writing docker-compose files. Just add an extension and Quarkus spins up databases, message brokers, and more for you. Clean, disposable, and zero config.</p>
-            <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="{=''}/guides/dev-services">Use the Dev Services</a></p>
-          </div>
-        </div>
-        <div class="imagetext-container">
-          <div class="imagetext-image">
-            <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-useai.svg" alt="Use AI icon">
-            <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-useai-dark.svg" alt="Use AI icon">
-          </div>
-          <div class="imagetext-text"><H5>Curious about AI but don’t know where to start?</h5>
-            <p>Quarkus puts AI right where you need it. Define type-safe AI interfaces, connect to local or remote models, and integrate tools, document stores, and agents. All using pure Java. Skip the glue code and start building real AI features today.</p>
-            <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html">Get started with AI right away</a></p>
+          <div class="imagetext-container">
+            <div class="imagetext-image">
+              <img loading="lazy" class="light-only" src="{=''}/assets/images/icons/icon-useai.svg" alt="Use AI icon">
+              <img loading="lazy" class="dark-only" src="{=''}/assets/images/icons/icon-useai-dark.svg" alt="Use AI icon">
+            </div>
+            <div class="imagetext-text"><h5>Curious about AI but don't know where to start?</h5>
+              <p>Quarkus puts AI right where you need it. Define type-safe AI interfaces, connect to local or remote models, and integrate tools, document stores, and agents. All using pure Java. Skip the glue code and start building real AI features today.</p>
+              <p class="textCTA"><i class="fa fa-chevron-right"></i><a href="https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html">Get started with AI right away</a></p>
+            </div>
           </div>
         </div>
       </div>

--- a/web/includes/_spring-page.scss
+++ b/web/includes/_spring-page.scss
@@ -16,6 +16,16 @@
     }
 }
 
+.roles-imagetext-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0 3rem;
+
+  @media (max-width: 800px) {
+    grid-template-columns: 1fr;
+  }
+}
+
 .imagetext-container {
     display: flex;
     flex-direction: row;
@@ -35,6 +45,10 @@
 
     h5 {
     margin-top: 0;
+    }
+
+    img {
+    max-width: 750px;
     }
 }
 


### PR DESCRIPTION
1) For large monitors, add a max width for images on the /about page so they don't get massive. Sizing based on common 2560x1440 monitor size.

2) refactor /spring page so the roles content is formatted to read as two horizontal bands instead of two verticals for user clarity.
