### PR TITLE
Isolate JBang sync scripts from website Quarkus config

### DIFF
--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -44,6 +44,7 @@ jobs:
           jbang --java ${JVM_VERSION} -Dcontributors.output=_data/contributors.yaml contributors/main.java
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_WORKING_GROUP_TOKEN }}
+          SMALLRYE_CONFIG_LOCATIONS: contributors/application.yaml
 
       - name: Configure Git author
         run: |

--- a/.github/workflows/sync-working-groups.yml
+++ b/.github/workflows/sync-working-groups.yml
@@ -44,6 +44,7 @@ jobs:
           jbang --java ${JVM_VERSION} -Dworking-groups.output=_data/wg.yaml working-groups/main.java
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_WORKING_GROUP_TOKEN }}
+          SMALLRYE_CONFIG_LOCATIONS: working-groups/application.yaml
 
       - name: Configure Git author
         run: |

--- a/working-groups/main.java
+++ b/working-groups/main.java
@@ -1,6 +1,6 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVAC_OPTIONS -parameters
-//RUNTIME_OPTIONS --add-opens java.base/java.lang=ALL-UNNAMED -Dquarkus.qute.alt-expr-syntax=false
+//RUNTIME_OPTIONS --add-opens java.base/java.lang=ALL-UNNAMED
 //DEPS io.quarkus.platform:quarkus-bom:3.36.3@pom
 //DEPS io.quarkus:quarkus-picocli
 //DEPS io.quarkus:quarkus-smallrye-graphql-client


### PR DESCRIPTION
This is a generalisation of https://github.com/quarkusio/quarkusio.github.io/pull/2924. We don't want the jbang scripts picking up *any* Roq config. Two scripts are potentially affected, not just one, although the contributors sync has been red for months so I don't know how much this would affect it in the short term. 

This sets `SMALLRYE_CONFIG_LOCATIONS` in the sync workflows to point only at each script's own application.yaml. This prevents Quarkus from loading config/application.properties (the website's Roq config) from the working directory, which was the root cause of the Qute alt-expr-syntax leak. 

As well as being nicer, it fixes a problem with my previous fix (see https://github.com/quarkusio/quarkusio.github.io/actions/runs/32760352207/job/97537461976)

```
2026-08-24 18:05:59,680 WARN  [io.quarkus.runtime.configuration.ConfigRecorder] (main) Build time property cannot be changed at runtime:
 - quarkus.qute.alt-expr-syntax is set to 'false' but it is build time fixed to 'true'. Did you change the property quarkus.qute.alt-expr-syntax after building the application?
```
