### PR TITLE
Do not deploy only the latest guides in the prod CI, obviously

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'
-        run: QUARKUS_ROQ_GENERATOR_BATCH=true QUARKUS_PROFILE=only-latest-guides mvn -B package quarkus:run -DskipTests
+        run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run -DskipTests
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v4.0.1


### PR DESCRIPTION
Why is the production build behaving like the preview build, and only showing the latest guides?

Because that's what the build tells it to do. ARGH. 

Turns out `QUARKUS_PROFILE=only-latest-guides` isn't what we want in prod. Copy-paste FTW. 