### PR TITLE
Fix missing version options on single guide views after Roq migration

### DIFF
--- a/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -412,6 +412,45 @@ public class JekyllFiltersExtension {
         return new JsonArray(sorted);
     }
 
+    /**
+     * True if the given data index contains a guide with the given URL, in any source or type.
+     * Usage in Qute: {index.containsGuide('/guides/getting-started')}
+     */
+    static boolean containsGuide(JsonObject index, String url) {
+        if (index == null || url == null || url.isEmpty()) {
+            return false;
+        }
+        for (String key : index.fieldNames()) {
+            Map<String, Object> sourceMap = toMap(index.getValue(key));
+            if (sourceMap == null) {
+                continue;
+            }
+            Map<String, Object> typesMap = toMap(sourceMap.get("types"));
+            if (typesMap == null) {
+                continue;
+            }
+            for (Object items : typesMap.values()) {
+                for (Object item : listAsIterableOrEmpty(items)) {
+                    JsonObject guide = toJsonObject(item);
+                    if (guide != null && url.equals(guide.getString("url"))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+	private static Iterable<?> listAsIterableOrEmpty(Object items) {
+		if ( items instanceof JsonArray array ) {
+			return array;
+		}
+		if ( items instanceof List<?> list ) {
+			return list;
+		}
+		return List.of();
+	}
+
     @SuppressWarnings("unchecked")
     private static Map<String, Object> toMap(Object obj) {
         if (obj instanceof JsonObject jo)

--- a/src/test/java/io/quarkusio/GuidesPageTest.java
+++ b/src/test/java/io/quarkusio/GuidesPageTest.java
@@ -490,6 +490,31 @@ public class GuidesPageTest extends BrowserTest {
     }
 
     @Test
+    void guideVersionDropdownListsOtherVersions() {
+        page.navigate(baseUrl + "/guides/getting-started");
+
+        Locator options = page.locator("#guide-version-dropdown option");
+        assertTrue(options.count() >= 2,
+                "The version dropdown for a guide present in multiple versions should list "
+                        + "more than the current version, but found " + options.count()
+                        + " option(s). Guide-presence detection may be broken.");
+        assertTrue(page.locator("#guide-version-dropdown option[value='main']").count() > 0,
+                "The version dropdown for getting-started should include the 'main' version.");
+    }
+
+    @Test
+    void configReferenceGuideVersionDropdownListsOtherVersions() {
+        page.navigate(baseUrl + "/guides/all-config");
+
+        Locator options = page.locator("#guide-version-dropdown option");
+        assertTrue(options.count() >= 2,
+                "The config-reference version dropdown should list more than the current "
+                        + "version, but found " + options.count() + " option(s).");
+        assertTrue(page.locator("#guide-version-dropdown option[value='main']").count() > 0,
+                "The config-reference version dropdown should include the 'main' version.");
+    }
+
+    @Test
     void versionedGuideDropdownHasCorrectVersionSelected() {
         page.navigate(baseUrl + "/version/main/guides/getting-started");
 

--- a/templates/layouts/guides-configuration-reference.html
+++ b/templates/layouts/guides-configuration-reference.html
@@ -5,7 +5,7 @@ layout: base
 {#if versioned_page}
   {#let docversion=page.url.path.replaceAll('^/version/([^/]+)/.*', '$1')}
 
-{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1')}
+{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1').replaceAll('/$', '')}
 
 {#include partials/title-band.html _unisolated /}
 
@@ -20,7 +20,11 @@ layout: base
     <div class="guidepulldown version">
     <select id="guide-version-dropdown">
     {#for version in cdi:versions.documentation.orEmpty}
-      <option value="{=version.raw}" {#if docversion == version}selected{/if}>{#if version == 'latest'}{=cdi:versions.quarkus.version.replaceAll("\.[0-9+]\.Final", "").raw} - {/if}{=version.capitalize.raw}{#if version == 'main'} - SNAPSHOT{/if}</option>
+      {#let data_source=version.replace('.', '-')}
+        {#if docversion == version || cdi:versioned.get(data_source).index.containsGuide(guide_url)}
+        <option value="{=version.raw}" {#if docversion == version}selected{/if}>{#if version == 'latest'}{=cdi:versions.quarkus.version.replaceAll("\.[0-9+]\.Final", "").raw} - {/if}{=version.capitalize.raw}{#if version == 'main'} - SNAPSHOT{/if}</option>
+        {/if}
+      {/let}
     {/for}
     </select>
     </div>
@@ -37,7 +41,7 @@ layout: base
 {/let}{/let}{#else}
   {#let docversion='latest'}
 
-{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1')}
+{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1').replaceAll('/$', '')}
 
 {#include partials/title-band.html _unisolated /}
 
@@ -52,7 +56,11 @@ layout: base
     <div class="guidepulldown version">
     <select id="guide-version-dropdown">
     {#for version in cdi:versions.documentation.orEmpty}
-      <option value="{=version.raw}" {#if docversion == version}selected{/if}>{#if version == 'latest'}{=cdi:versions.quarkus.version.replaceAll("\.[0-9+]\.Final", "").raw} - {/if}{=version.capitalize.raw}{#if version == 'main'} - SNAPSHOT{/if}</option>
+      {#let data_source=version.replace('.', '-')}
+        {#if docversion == version || cdi:versioned.get(data_source).index.containsGuide(guide_url)}
+        <option value="{=version.raw}" {#if docversion == version}selected{/if}>{#if version == 'latest'}{=cdi:versions.quarkus.version.replaceAll("\.[0-9+]\.Final", "").raw} - {/if}{=version.capitalize.raw}{#if version == 'main'} - SNAPSHOT{/if}</option>
+        {/if}
+      {/let}
     {/for}
     </select>
     </div>

--- a/templates/layouts/guides.html
+++ b/templates/layouts/guides.html
@@ -14,7 +14,7 @@ layout: base
  !}
 {#let page_filename=page.sourcePath.replace('_guides/', '').replace('_versions/main/guides/', '')}
 {#let relations=cdi:versioned.get(docversion_index).index.relations}
-{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1')}
+{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1').replaceAll('/$', '')}
 
 <section class="full-width-version-bg flexfilterbar guides">
   <div class="guideflexcontainer">
@@ -37,13 +37,9 @@ layout: base
           {/for}
         {/for}
         {#let data_source=version.replace('.', '-')}
-        {#for type in cdi:versioned.get(data_source).index.quarkus.types.orEmpty}
-          {#for guide in type.get(1).orEmpty}
-            {#if guide.url == guide_url}
-              {=_m.assign('guide_present_in_version', true).raw}
-            {/if}
-          {/for}
-        {/for}
+        {#if cdi:versioned.get(data_source).index.containsGuide(guide_url)}
+          {=_m.assign('guide_present_in_version', true).raw}
+        {/if}
         {#if _m.read('guide_present_in_version') || docversion == version}
         <option value="{=version.raw}" {#if docversion == version}selected{/if}>{#if version == 'latest'}{=cdi:versions.quarkus.version.replaceAll("\.[0-9+]\.Final", "").raw} - {/if}{=version.capitalize.raw}{#if version == 'main'} - SNAPSHOT{/if}</option>
         {/if}
@@ -124,7 +120,7 @@ layout: base
  !}
 {#let page_filename=page.sourcePath.replace('_guides/', '').replace('_versions/main/guides/', '')}
 {#let relations=cdi:versioned.get(docversion_index).index.relations}
-{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1')}
+{#let guide_url=page.url.path.replaceAll('^/version/[^/]+(/.*)', '$1').replaceAll('/$', '')}
 
 <section class="full-width-version-bg flexfilterbar guides">
   <div class="guideflexcontainer">
@@ -147,13 +143,9 @@ layout: base
           {/for}
         {/for}
         {#let data_source=version.replace('.', '-')}
-        {#for type in cdi:versioned.get(data_source).index.quarkus.types.orEmpty}
-          {#for guide in type.get(1).orEmpty}
-            {#if guide.url == guide_url}
-              {=_m.assign('guide_present_in_version', true).raw}
-            {/if}
-          {/for}
-        {/for}
+        {#if cdi:versioned.get(data_source).index.containsGuide(guide_url)}
+          {=_m.assign('guide_present_in_version', true).raw}
+        {/if}
         {#if _m.read('guide_present_in_version') || docversion == version}
         <option value="{=version.raw}" {#if docversion == version}selected{/if}>{#if version == 'latest'}{=cdi:versions.quarkus.version.replaceAll("\.[0-9+]\.Final", "").raw} - {/if}{=version.capitalize.raw}{#if version == 'main'} - SNAPSHOT{/if}</option>
         {/if}


### PR DESCRIPTION
Apparently, the guides never "matched" in other versions, so everything but "current" was filtered out. And that trailing `/` didn't help either, sicne it's not in the data files 🙈 😖 