### PR TITLE
Fix older guide versions navigation to not trigger downloads from index page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,9 +91,33 @@ jobs:
         if: steps.detect.outputs.roq == 'true'
         run: ./roq-plugin-toc/build.sh
 
+      - name: Detect infra changes
+        id: infra
+        run: |
+          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- \
+              .github/workflows/build.yml \
+              pom.xml \
+              config/ \
+              src/ \
+              templates/ 2>/dev/null || true)
+          else
+            CHANGED="not-a-pr"
+          fi
+          if [ -n "$CHANGED" ]; then
+            echo "include_versions=true" >> $GITHUB_OUTPUT
+          else
+            echo "include_versions=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'
-        run: QUARKUS_ROQ_GENERATOR_BATCH=true QUARKUS_PROFILE=only-latest-guides mvn -B package quarkus:run -DskipTests
+        run: |
+          export QUARKUS_ROQ_GENERATOR_BATCH=true
+          if [ "${{ steps.infra.outputs.include_versions }}" != "true" ]; then
+            export QUARKUS_PROFILE=only-latest-guides
+          fi
+          mvn -B package quarkus:run -DskipTests
 
       - name: Compile tests
         run: mvn -B test-compile
@@ -127,17 +151,9 @@ jobs:
       - name: Determine link checker scope
         id: link_scope
         run: |
-          # If build infrastructure or the link checker itself changed, run a full check
-          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
-            INFRA_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- \
-              .github/workflows/build.yml \
-              pom.xml \
-              src/test/java/ 2>/dev/null || true)
-          else
-            INFRA_CHANGED="not-a-pr"
-          fi
-
-          if [ -n "$INFRA_CHANGED" ]; then
+          # Reuse the earlier infra-change detection (covers build.yml, pom.xml,
+          # config/, src/, templates/) instead of a separate git diff.
+          if [ "${{ steps.infra.outputs.include_versions }}" = "true" ]; then
             echo "mode=full" >> $GITHUB_OUTPUT
             echo "Infrastructure files changed, running full link check"
             exit 0
@@ -213,8 +229,9 @@ jobs:
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 
-      # Versioned guides (2.x-5.x) are excluded from this build by
-      # _only_latest_guides_config.yml, so skip crawling those paths.
+      # Versioned guides (2.x-5.x) are excluded from non-infra builds by
+      # the only-latest-guides profile, so skip crawling those paths unless
+      # infra changes triggered a full build.
       - name: Run link crawler
         if: steps.link_scope.outputs.mode != 'skip'
         run: |
@@ -222,9 +239,13 @@ jobs:
           if [ "${{ steps.link_scope.outputs.mode }}" = "partial" ]; then
             CHANGED_PATHS_ARG="-Dtest.crawl.changed-paths=${{ steps.link_scope.outputs.paths }}"
           fi
+          EXCLUDE_ARG="-Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main"
+          if [ "${{ steps.infra.outputs.include_versions }}" = "true" ]; then
+            EXCLUDE_ARG=""
+          fi
           mvn -B test -Pe2e -Dtest.url=http://localhost:8090 \
             -Dtest.crawl.check-external=false \
-            -Dtest.crawl.exclude-paths=/version/2,/version/3,/version/4,/version/5,/version/main \
+            $EXCLUDE_ARG \
             $CHANGED_PATHS_ARG
         env:
           PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,6 +349,16 @@ jobs:
           rm -rf "$SITE_DIR"/assets/stickers
           rm -rf "$SITE_DIR"/assets/images/desktopwallpapers
           rm -rf "$SITE_DIR"/assets/images/stickers
+          # Keep main and the newest numbered version, drop the rest
+          if [ -d "$SITE_DIR/version" ]; then
+            NEWEST=$(ls -1 "$SITE_DIR/version" | grep -v main | sort -t. -k1,1n -k2,2n | tail -1)
+            for v in "$SITE_DIR/version"/*/; do
+              NAME=$(basename "$v")
+              if [ "$NAME" != "main" ] && [ "$NAME" != "$NEWEST" ]; then
+                rm -rf "$v"
+              fi
+            done
+          fi
 
       - name: Publishing directory for PR preview
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/config/application.properties
+++ b/config/application.properties
@@ -19,7 +19,8 @@ site.collections.redirects=true
 site.collections.redirects.layout=redirect
 site.collections.versions=true
 site.collections.versions.layout=guides
-site.collections.versions.link=/version/:dir[1]/:name
+# Trailing slash works around https://github.com/quarkiverse/quarkus-web-bundler/issues/473
+site.collections.versions.link=/version/:dir[1]/:name/
 site.date-format=yyyy-MM-dd['T'HH:mm:ss][X]
 site.escaped-pages=guides/**,versions/**
 site.url=https://quarkus.io

--- a/src/test/java/io/quarkusio/GuidesPageTest.java
+++ b/src/test/java/io/quarkusio/GuidesPageTest.java
@@ -2,6 +2,8 @@ package io.quarkusio;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Response;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -520,5 +522,63 @@ public class GuidesPageTest extends BrowserTest {
                 "Non-versioned guide title should not include '- main', got: " + title);
         assertFalse(title.contains("- latest"),
                 "Non-versioned guide title should not include '- latest', got: " + title);
+    }
+
+    @Nested
+    class NumberedVersionTests {
+
+        private String version;
+
+        @BeforeEach
+        void findVersion() {
+            for (String v : new String[] { "3.34", "3.33", "3.27", "3.20", "3.15" }) {
+                Response response = page.navigate(baseUrl + "/version/" + v + "/guides/");
+                if (response != null && response.status() == 200) {
+                    version = v;
+                    return;
+                }
+            }
+            Assumptions.assumeTrue(false,
+                    "No numbered version guides available (build is using only-latest-guides profile)");
+        }
+
+        @Test
+        void numberedVersionGuideIndexRendersWithContent() {
+            int guideCount = page.locator(".docslist h4 a[href*='/guides/']").count();
+            assertTrue(guideCount >= 50,
+                    "/version/" + version + "/guides/: Expected at least 50 guides but found " + guideCount);
+        }
+
+        @Test
+        void numberedVersionGuideReturns200() {
+            Response response = page.navigate(baseUrl + "/version/" + version + "/guides/getting-started/");
+            assertNotNull(response, "No response for /version/" + version + "/guides/getting-started/");
+            assertEquals(200, response.status(),
+                    "Expected 200 for /version/" + version + "/guides/getting-started/ but got " + response.status());
+        }
+
+        @Test
+        void numberedVersionGuideHasContent() {
+            page.navigate(baseUrl + "/version/" + version + "/guides/getting-started/");
+            String title = page.title();
+            assertFalse(title == null || title.isBlank(),
+                    "/version/" + version + "/guides/getting-started/: Guide page title should not be blank");
+            assertTrue(title.toLowerCase().contains("quarkus"),
+                    "/version/" + version + "/guides/getting-started/: Guide page title should contain 'Quarkus', got: " + title);
+        }
+
+        @Test
+        void numberedVersionGuideIndexLinksResolve() {
+            page.navigate(baseUrl + "/version/" + version + "/guides/");
+            Locator guideLinks = page.locator("qs-guide a[href*='/version/" + version + "/guides/']");
+            assertTrue(guideLinks.count() > 0,
+                    "Expected guide links on the versioned index page");
+
+            String firstHref = guideLinks.first().getAttribute("href");
+            Response response = page.navigate(baseUrl + firstHref);
+            assertNotNull(response, "No response for " + firstHref);
+            assertEquals(200, response.status(),
+                    "Expected 200 for " + firstHref + " but got " + response.status());
+        }
     }
 }

--- a/templates/partials/index-doc-item.html
+++ b/templates/partials/index-doc-item.html
@@ -2,7 +2,8 @@
 {#if is_external_guide}
 {#let guide_url=url}
 {/let}{#else if docversion == 'latest'}
-{#let guide_url=''.append(url)}
+{! Trailing slashes work around https://github.com/quarkiverse/quarkus-web-bundler/issues/473 !}
+{#let guide_url=url.replaceAll('/+$', '').concat('/')}
 
 <qs-guide type="{=type.escapeHtml.raw}"
           title="{=title.escapeHtml.raw}"
@@ -19,7 +20,7 @@
 </qs-guide>
 
 {/let}{#else}
-{#let guide_url=''.append('/version/').append(docversion).append(url)}
+{#let guide_url=''.append('/version/').append(docversion).append(url.replaceAll('/+$', '')).append('/')}
 
 <qs-guide type="{=type.escapeHtml.raw}"
           title="{=title.escapeHtml.raw}"


### PR DESCRIPTION
For older guides versions (anything with a dot), on the live site, but not in previews, and not in dev mode, trying to view a page by clicking on it on the index page does a download instead of a navigation. The root cause seems to be https://github.com/quarkiverse/quarkus-web-bundler/issues/473, which is muddling dots-in-folders with dots-extensions. Happily, it can be worked around with some template updates. 

I got annoyed at preview and CI tests being 'blind' for versions, so I've updated CI to detect infra changes and build all versions. That allows guides tests to run against older versions. I also, in these cases, updated the preview to include a handful of older versions, but not all of them. (The index always includes them all, which is a but confusing, but we can live with that for now.)