### PR TITLE
Use working directory instead of smallrye settings to isolate sync config

### DIFF
--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -40,11 +40,12 @@ jobs:
         uses: jbangdev/setup-jbang@2b1b465a7b75f4222b81426f23a01e013aa7b95c # v0.1.1
 
       - name: Run script
+        # Run from the script's directory to avoid picking up the website's config/application.properties
+        working-directory: contributors
         run: |
-          jbang --java ${JVM_VERSION} -Dcontributors.output=_data/contributors.yaml contributors/main.java
+          jbang --java ${JVM_VERSION} -Dcontributors.output=../_data/contributors.yaml main.java
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_WORKING_GROUP_TOKEN }}
-          SMALLRYE_CONFIG_LOCATIONS: contributors/application.yaml
 
       - name: Configure Git author
         run: |

--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -39,13 +39,15 @@ jobs:
       - uses: jbangdev/setup-jbang@main
 
       - name: Run release sync
-        run: jbang tools/releases-sync/main.java ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+        # Run from the script's directory to avoid picking up the website's config/application.properties
+        working-directory: tools/releases-sync
+        run: jbang main.java ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
           RELEASES_ORG: quarkusio
           RELEASES_REPO: quarkus
-          RELEASES_INPUT: _data/releases.yaml
-          RELEASES_OUTPUT: _data/releases.yaml
+          RELEASES_INPUT: ../../_data/releases.yaml
+          RELEASES_OUTPUT: ../../_data/releases.yaml
 
       - name: Commit and push
         if: github.event_name != 'pull_request'

--- a/.github/workflows/sync-working-groups.yml
+++ b/.github/workflows/sync-working-groups.yml
@@ -40,11 +40,12 @@ jobs:
         uses: jbangdev/setup-jbang@2b1b465a7b75f4222b81426f23a01e013aa7b95c # v0.1.1
 
       - name: Run script
+        # Run from the script's directory to avoid picking up the website's config/application.properties
+        working-directory: working-groups
         run: |
-          jbang --java ${JVM_VERSION} -Dworking-groups.output=_data/wg.yaml working-groups/main.java
+          jbang --java ${JVM_VERSION} -Dworking-groups.output=../_data/wg.yaml main.java
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_WORKING_GROUP_TOKEN }}
-          SMALLRYE_CONFIG_LOCATIONS: working-groups/application.yaml
 
       - name: Configure Git author
         run: |


### PR DESCRIPTION
The bad news is that wg sync is still failing. 

The good news is that it's failing in CI, rather than corrupting wg.yaml. The check I put in is working, yay! 

Now all we need to do is get the config isolated. The two previous approaches didn't work (the command-line config flag kicks in at the wrong phase, the SMALLRYE_CONFIG environment variable has too low a priority). It's a bit crude, but I think using working directory isolation is the best bet. 

As well as the two previous workflows, I've updated another jbang app that wants isolated config. 

(The next iteration of this PR will change 4 workflows, and so on ...) 