### PR TITLE
Fix fragment ids after Roq migration

### DIFF
--- a/content/faq.adoc
+++ b/content/faq.adoc
@@ -3,6 +3,8 @@ layout: base-fullwidthcontent
 title: FAQ
 subtitle: Get answers to some of your common Quarkus questions.
 ---
+:idprefix:
+:idseparator: -
 
 == What is your license?
 

--- a/content/guides/_attributes-local.adoc
+++ b/content/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :doc-guides: .


### PR DESCRIPTION
@ppalaga spotted that some of our fragment links regressed after migration. I checked, and about 50 had regressed. This should have been caught by https://github.com/quarkusio/quarkusio.github.io/pull/2713, but that PR is still failing because of _other_ dead fragment links. 

Asciidoctor defaults to idprefix='_' and idseparator='_', but jekyll-asciidoc overrode these to '' and '-', producing IDs like 'my-section' instead of '_my_section'. This can almost be controlled by application-properties, but SmallRye Config rejects empty map values so idprefix cannot be set to an empty value via application.properties. Instead, I set both attributes at the document level instead, using the global attributes. The faq.adoc doesn't inherit the attributes so in that document I edited the frontmatter directly.

I've tested this fix with #2713 and the links are back to passing.