### PR TITLE
Give guides the TOC depth their toclevels asks for

### DIFF
--- a/roq-plugin-toc/build.sh
+++ b/roq-plugin-toc/build.sh
@@ -3,8 +3,15 @@
 # Builds the Roq TOC plugin from rolfedh/quarkus-roq PR #776 at a pinned commit,
 # using standalone POMs that decouple it from the Roq monorepo build.
 #
+# The pinned commit reads each guide's AsciiDoc :toclevels: attribute and registers only
+# its two template extensions, so the sources are built unmodified.
+#
 # Usage:
 #   ./roq-plugin-toc/build.sh          # fetch, build, and install to local Maven repo
+#
+# Set UPSTREAM_REPO and UPSTREAM_COMMIT to build from a local checkout instead, e.g.
+#   UPSTREAM_REPO=file:///path/to/quarkus-roq \
+#   UPSTREAM_COMMIT=$(git -C /path/to/quarkus-roq rev-parse fix-toc) ./roq-plugin-toc/build.sh
 #
 # The plugin is then available as:
 #   io.quarkiverse.roq:quarkus-roq-plugin-toc:1.0.0-SNAPSHOT
@@ -12,8 +19,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-UPSTREAM_REPO="https://github.com/rolfedh/quarkus-roq.git"
-UPSTREAM_COMMIT="c52d3ec79f3d6dcb4ff57c495666b60bcd98bf94"
+UPSTREAM_REPO="${UPSTREAM_REPO:-https://github.com/rolfedh/quarkus-roq.git}"
+UPSTREAM_COMMIT="${UPSTREAM_COMMIT:-94dc2ccb3825a8e9a716d46298a10811e9d17653}"
 
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
@@ -33,15 +40,6 @@ cp -r "$SRC/runtime/src/test/java/"* "$SCRIPT_DIR/runtime/src/test/java/"
 # Deployment sources
 mkdir -p "$SCRIPT_DIR/deployment/src/main/java"
 cp -r "$SRC/deployment/src/main/java/"* "$SCRIPT_DIR/deployment/src/main/java/"
-
-echo "Patching default TOC depth to match AsciiDoc :toclevels: default..."
-EXTENSION_FILE="$SCRIPT_DIR/runtime/src/main/java/io/quarkiverse/roq/plugin/toc/runtime/RoqPluginTocTemplateExtension.java"
-sed 's/getInteger("content-toc-levels", 6)/getInteger("content-toc-levels", page.data().getInteger("toclevels", 3))/' \
-  "$EXTENSION_FILE" > "$EXTENSION_FILE.tmp" && mv "$EXTENSION_FILE.tmp" "$EXTENSION_FILE"
-
-echo "Making escapeHtml/escapeAttr private to prevent Qute registering them as template extensions..."
-sed 's/static String escapeHtml/private static String escapeHtml/;s/static String escapeAttr/private static String escapeAttr/' \
-  "$EXTENSION_FILE" > "$EXTENSION_FILE.tmp" && mv "$EXTENSION_FILE.tmp" "$EXTENSION_FILE"
 
 echo "Building and installing TOC plugin..."
 mvn -B install -f "$SCRIPT_DIR/pom.xml"

--- a/src/test/java/io/quarkusio/GuideTocTest.java
+++ b/src/test/java/io/quarkusio/GuideTocTest.java
@@ -3,6 +3,7 @@ package io.quarkusio;
 import com.microsoft.playwright.Locator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -63,6 +64,48 @@ public class GuideTocTest extends BrowserTest {
         Locator toc = page.locator(".toc nav.roq-toc");
         assertTrue(toc.count() > 0,
                 "TOC nav should be inside the .toc wrapper div");
+    }
+
+    /**
+     * The TOC depth must follow each guide's AsciiDoc {@code :toclevels:} attribute, as the Jekyll
+     * site's {@code tocify_asciidoc} filter did. {@code data-level} counts heading tags from
+     * {@code h1} = 0, so a guide showing sections down to {@code h5} has a maximum of 4.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "/guides/logging, 4",                                // :toclevels: 4, has h5 sections
+            "/guides/qute-reference, 3",                         // :toclevels: 3
+            "/guides/getting-started, 2",                        // no :toclevels:, Asciidoctor defaults to 2
+            "/guides/cdi-integration, 2",                        // :toclevels: 2
+            "/guides/security-oidc-code-flow-authentication, 3", // :toclevels: 4, but no section is deeper than h4
+            "/version/main/guides/logging, 4"                    // the versioned copy resolves levels too
+    })
+    void tocDepthFollowsAsciidocTocLevels(String path, int expectedMaxLevel) {
+        assumeTocPluginInstalled();
+        page.navigate(baseUrl + path);
+        assertTrue(page.locator("nav.roq-toc li[data-level='" + expectedMaxLevel + "']").count() > 0,
+                path + ": expected TOC entries at data-level " + expectedMaxLevel);
+        assertEquals(0, page.locator("nav.roq-toc li[data-level='" + (expectedMaxLevel + 1) + "']").count(),
+                path + ": expected no TOC entries below data-level " + expectedMaxLevel);
+    }
+
+    /**
+     * Asciidoctor prefixes section titles with their number only when the document asks for it, so the
+     * TOC inherits the numbering rather than deciding it.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "/guides/qute-reference, true",                          // :sectnums:
+            "/guides/getting-started, true",                         // :sectnums:
+            "/guides/cdi-integration, true",                         // :numbered:, the legacy alias
+            "/guides/security-oidc-code-flow-authentication, false"  // neither
+    })
+    void tocEntriesAreNumberedOnlyWhenTheGuideAsksForIt(String path, boolean numbered) {
+        assumeTocPluginInstalled();
+        page.navigate(baseUrl + path);
+        String firstEntry = page.locator("nav.roq-toc > ul > li > a").first().textContent().trim();
+        assertEquals(numbered, firstEntry.matches("^\\d+\\. .*"),
+                path + ": first TOC entry was '" + firstEntry + "'");
     }
 
     @Test


### PR DESCRIPTION
## TLDR

Guides now get the table of contents depth their AsciiDoc `:toclevels:` asks for, as they did before the Roq migration. This repins the TOC plugin to a commit that reads that attribute and removes both `sed` patches from `roq-plugin-toc/build.sh`. Section numbering is unchanged.

Follow-up to #2929, which reinstated the TOC at a fixed depth of three heading levels as a temporary measure.

## What changed

- `roq-plugin-toc/build.sh` is pinned to `94dc2ccb` on the `fix-toc` branch of https://github.com/quarkiverse/quarkus-roq/pull/776. That commit reads each document's `toclevels`, so the patch that capped every guide at three heading levels is gone, and it registers only its two template extensions, so the patch that made the escaping helpers private is gone too.
- `UPSTREAM_REPO` and `UPSTREAM_COMMIT` can now be overridden from the environment, so you can build the plugin from a local checkout while iterating.
- `GuideTocTest` pins the depth of six pages and the numbering of four.

## Evidence

Depth is the maximum `data-level` in `nav.roq-toc`, counting heading tags from `h1` = 0. The last column is Asciidoctor's own `:toc:` outline for the same source, which is what the Jekyll site's `tocify_asciidoc` filter rendered.

| Guide | `:toclevels:` | Before | After | Asciidoctor |
|---|---|---|---|---|
| logging | 4 | 2 | 4 | 4 |
| qute-reference | 3 | 2 | 3 | 3 |
| getting-started | none | 2 | 2 | 2 |
| cdi-integration | 2 | 2 | 2 | 2 |
| security-oidc-code-flow-authentication | 4 | 2 | 3 | 3 |

The OIDC guide asks for four section levels but has no section deeper than `h4`, so three is the correct result for it.

Section numbering is unchanged and was never affected: Asciidoctor puts the number in the heading text, and only for guides that set `:sectnums:` or `:numbered:`. qute-reference, getting-started and cdi-integration are numbered before and after; logging and the OIDC guide set neither attribute and were unnumbered on the old site too.

## How this was verified

- Full batch build (`QUARKUS_ROQ_GENERATOR_BATCH=true mvn package quarkus:run`), 5341 pages, then the same check in dev mode. Both give the results above.
- `mvn test -Dtest.url=...` against the built site: `GuideTocTest` 18 tests and `RssFeedTest` 5 tests pass. `RssFeedTest` is the one that failed in #2929 before the plugin stopped registering its escaping helper as a Qute extension.
- 44 plugin unit tests pass in `build.sh`.

## Not fixed here

Guides that declare an anchor before their title, such as logging, still show `guides/logging.adoc` as the page heading. That is https://github.com/quarkiverse/quarkus-roq/issues/1136, fixed upstream in yupiik/tools-maven-plugin#92 but not yet in the parser version Roq pins. It is unrelated to the TOC.
