### PR TITLE
Patch Roq adoc tag processing to fix empty includes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,13 @@ jobs:
         if: steps.detect.outputs.roq == 'true'
         run: ./roq-plugin-toc/build.sh
 
+      # TODO: Remove once https://github.com/quarkiverse/quarkus-roq/issues/1178 is fixed and Roq is upgraded
+      - name: Patch Roq AsciiDoc tag handling
+        if: steps.detect.outputs.roq == 'true'
+        run: |
+          mvn -B dependency:resolve -q
+          bash patches/apply-roq-include-fix.sh
+
       - name: Detect infra changes
         id: infra
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,13 @@ jobs:
         if: steps.detect.outputs.roq == 'true'
         run: ./roq-plugin-toc/build.sh
 
+      # TODO: Remove once https://github.com/quarkiverse/quarkus-roq/issues/1178 is fixed and Roq is upgraded
+      - name: Patch Roq AsciiDoc tag handling
+        if: steps.detect.outputs.roq == 'true'
+        run: |
+          mvn -B dependency:resolve -q
+          bash patches/apply-roq-include-fix.sh
+
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'
         run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run -DskipTests

--- a/patches/AsciidocJInclude.java
+++ b/patches/AsciidocJInclude.java
@@ -1,0 +1,228 @@
+// Patched version of io.quarkiverse.roq.plugin.asciidoctorj.runtime.AsciidocJInclude
+// Fixes https://github.com/quarkiverse/quarkus-roq/issues/1178
+// TODO: Remove once Roq ships the fix and we upgrade
+package io.quarkiverse.roq.plugin.asciidoctorj.runtime;
+
+import static io.quarkiverse.roq.plugin.asciidoctorj.runtime.AsciidoctorJConverter.ROOTDIR;
+import static org.asciidoctor.Options.BASEDIR;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.asciidoctor.SafeMode;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.IncludeProcessor;
+import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
+
+import io.quarkiverse.tools.stringpaths.StringPaths;
+
+public class AsciidocJInclude extends IncludeProcessor {
+    private static final Pattern URL_PREFIX_PATTERN = Pattern.compile("^((https?|file|ftp|irc)://|mailto:)");
+    private static final Pattern HEADING_PATTERN = Pattern.compile("^(=+)(\\s+.*)$");
+    private static final Pattern TAG_START_PATTERN = Pattern.compile("^\\s*(?://|#|--|;;|<!--)\\s*tag::(\\S+?)\\[\\]");
+    private static final Pattern TAG_END_PATTERN = Pattern.compile("^\\s*(?://|#|--|;;|<!--)\\s*end::(\\S+?)\\[\\]");
+
+    public AsciidocJInclude() {
+    }
+
+    @Override
+    public boolean handles(String target) {
+        return !URL_PREFIX_PATTERN.matcher(target).find();
+    }
+
+    @Override
+    public void process(Document document, PreprocessorReader reader, String target, Map<String, Object> attributes) {
+        long safeLevel = (Long) document.getOptions().get("safe");
+        if (safeLevel >= SafeMode.SECURE.getLevel()) {
+            throw new SecurityException("File includes are not allowed in SECURE mode.");
+        }
+
+        final String dir = reader.getDir();
+        Charset charset = Charset.forName((String) document.getAttributes().getOrDefault("encoding", "UTF-8"));
+        final Path baseDir = Path.of(document.getOptions().getOrDefault(BASEDIR, "").toString());
+        final Path rootDir = Path.of(document.getOptions().getOrDefault(ROOTDIR, "").toString());
+        Path p = Path.of(target);
+        Path targetPath = (p.isAbsolute() ? p : baseDir.resolve(dir).resolve(target)).normalize();
+
+        if (safeLevel >= SafeMode.SAFE.getLevel()) {
+            if (!targetPath.startsWith(rootDir.normalize())) {
+                throw new SecurityException("Include path is outside the root dir ('%s'): '%s'".formatted(rootDir, targetPath));
+            }
+        }
+
+        String resourcePath = StringPaths.toUnixPath(targetPath.toString());
+        try (InputStream resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourcePath)) {
+            if (resource != null) {
+                pushInclude(reader, new String(resource.readAllBytes(), charset), target, attributes);
+                return;
+            }
+        } catch (IOException e) {
+            log(new LogRecord(Severity.ERROR, "Can't read '" + target + "'"));
+            return;
+        }
+
+        if (!Files.isRegularFile(targetPath)) {
+            log(new LogRecord(Severity.ERROR, "Include file not found '" + target + "'"));
+            return;
+        }
+        try {
+            pushInclude(reader, Files.readString(targetPath, charset), target, attributes);
+        } catch (IOException e) {
+            log(new LogRecord(Severity.ERROR, "Can't read '" + target + "'"));
+        }
+
+    }
+
+    private static void pushInclude(PreprocessorReader reader, String content, String target, Map<String, Object> attributes)
+            throws IOException {
+        final String processedContent = String.join("\n", processInclude(content, attributes));
+        reader.pushInclude(
+                processedContent,
+                target,
+                target,
+                1,
+                attributes);
+    }
+
+    static List<String> processInclude(String content, Map<String, Object> attrs) throws IOException {
+        List<String> lines = content.lines().toList();
+
+        if (attrs.containsKey("tag") && attrs.get("tag") instanceof String) {
+            lines = extractSingleTag(lines, (String) attrs.get("tag"));
+        } else if (attrs.containsKey("tags") && attrs.get("tags") instanceof String) {
+            String tagsVal = (String) attrs.get("tags");
+            lines = extractTags(lines, tagsVal);
+        }
+
+        if (attrs.containsKey("lines") && attrs.get("lines") instanceof String) {
+            lines = extractLines(lines, (String) attrs.get("lines"));
+        }
+
+        if (attrs.containsKey("indent") && attrs.get("indent") instanceof String) {
+            int indent = Integer.parseInt((String) attrs.get("indent"));
+            String pad = " ".repeat(indent);
+            lines = lines.stream().map(line -> pad + line).toList();
+        }
+
+        return lines;
+    }
+
+    // --- Fixed: split on ; or , and support ! negation ---
+
+    private static List<String> extractTags(List<String> lines, String tagsValue) {
+        List<String> includeTags = new ArrayList<>();
+        List<String> excludeTags = new ArrayList<>();
+
+        for (String raw : tagsValue.split("[;,]")) {
+            String tag = raw.trim();
+            if (tag.isEmpty()) {
+                continue;
+            }
+            if (tag.startsWith("!")) {
+                excludeTags.add(tag.substring(1));
+            } else {
+                includeTags.add(tag);
+            }
+        }
+
+        Set<String> activeTagStack = new LinkedHashSet<>();
+        List<String> result = new ArrayList<>();
+
+        for (String line : lines) {
+            Matcher startMatcher = TAG_START_PATTERN.matcher(line);
+            if (startMatcher.find()) {
+                activeTagStack.add(startMatcher.group(1));
+                continue;
+            }
+            Matcher endMatcher = TAG_END_PATTERN.matcher(line);
+            if (endMatcher.find()) {
+                activeTagStack.remove(endMatcher.group(1));
+                continue;
+            }
+
+            boolean included = includeTags.isEmpty()
+                    || activeTagStack.stream().anyMatch(includeTags::contains);
+            boolean excluded = activeTagStack.stream().anyMatch(excludeTags::contains);
+
+            if (included && !excluded) {
+                result.add(line);
+            }
+        }
+
+        return result;
+    }
+
+    private static List<String> extractSingleTag(List<String> lines, String tag) {
+        List<String> result = new ArrayList<>();
+        boolean inTag = false;
+        for (String line : lines) {
+            if (!inTag) {
+                Matcher m = TAG_START_PATTERN.matcher(line);
+                if (m.find() && m.group(1).equals(tag)) {
+                    inTag = true;
+                    continue;
+                }
+            } else {
+                Matcher m = TAG_END_PATTERN.matcher(line);
+                if (m.find() && m.group(1).equals(tag)) {
+                    break;
+                }
+            }
+            if (inTag) {
+                result.add(line);
+            }
+        }
+        return result;
+    }
+
+    private static List<String> extractLines(List<String> lines, String lineRanges) {
+        Set<Integer> indices = new LinkedHashSet<>();
+        for (String part : lineRanges.split("[;,]")) {
+            part = part.trim();
+            if (part.matches("\\d+")) {
+                indices.add(Integer.parseInt(part) - 1);
+            } else if (part.matches("\\d+\\.\\.\\d+")) {
+                String[] range = part.split("\\.\\.");
+                int start = Integer.parseInt(range[0]) - 1;
+                int end = Integer.parseInt(range[1]) - 1;
+                for (int i = start; i <= end; i++) {
+                    indices.add(i);
+                }
+            }
+        }
+        List<String> result = new ArrayList<>();
+        for (int idx : indices) {
+            if (idx >= 0 && idx < lines.size()) {
+                result.add(lines.get(idx));
+            }
+        }
+        return result;
+    }
+
+    private static List<String> applyLevelOffset(List<String> lines, String leveloffset) {
+        int offset = Integer.parseInt(leveloffset);
+        List<String> result = new ArrayList<>();
+        Pattern heading = HEADING_PATTERN;
+        for (String line : lines) {
+            Matcher m = heading.matcher(line);
+            if (m.matches()) {
+                int level = m.group(1).length() + offset;
+                level = Math.max(1, level);
+                String newLine = "=".repeat(level) + m.group(2);
+                result.add(newLine);
+            } else {
+                result.add(line);
+            }
+        }
+        return result;
+    }
+
+}

--- a/patches/apply-roq-include-fix.sh
+++ b/patches/apply-roq-include-fix.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Patches the Roq AsciidocJInclude class to fix AsciiDoc tag handling:
+#   - Split tags on ";" (not just ",")
+#   - Support "!" negation (e.g. tags=example;!ignore)
+#
+# Fixes: https://github.com/quarkusio/quarkusio.github.io/issues/2939
+# Upstream: https://github.com/quarkiverse/quarkus-roq/issues/1178
+# TODO: Remove once Roq ships the fix and we upgrade
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Extract the Roq version from pom.xml
+ROQ_VERSION=$(grep -m1 -oP '(?<=quarkus-roq-plugin-asciidoc-jruby</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
+  || grep -oP '(?<=quarkus-roq</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
+  || echo "2.1.7")
+
+ROQ_JAR="$HOME/.m2/repository/io/quarkiverse/roq/quarkus-roq-plugin-asciidoc-jruby/$ROQ_VERSION/quarkus-roq-plugin-asciidoc-jruby-$ROQ_VERSION.jar"
+MARKER="$ROQ_JAR.patched-issue-2939"
+
+if [ ! -f "$ROQ_JAR" ]; then
+  echo "Roq JAR not found at $ROQ_JAR — run 'mvn dependency:resolve' first"
+  exit 1
+fi
+
+if [ -f "$MARKER" ]; then
+  echo "Roq JAR already patched, skipping"
+  exit 0
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Build the compilation classpath from the existing JAR's dependencies
+ASCIIDOCTORJ_API=$(find "$HOME/.m2/repository/org/asciidoctor/asciidoctorj-api" -name '*.jar' -not -name '*sources*' | sort -V | tail -1)
+STRING_PATHS=$(find "$HOME/.m2/repository/io/quarkiverse/tools/string-paths" -name '*.jar' -not -name '*sources*' | sort -V | tail -1)
+
+if [ -z "$ASCIIDOCTORJ_API" ] || [ -z "$STRING_PATHS" ]; then
+  echo "Missing compilation dependencies — run 'mvn dependency:resolve' first"
+  exit 1
+fi
+
+CP="$ROQ_JAR:$ASCIIDOCTORJ_API:$STRING_PATHS"
+
+echo "Compiling patched AsciidocJInclude..."
+javac --release 21 -cp "$CP" -d "$WORK_DIR" "$SCRIPT_DIR/AsciidocJInclude.java"
+
+echo "Patching $ROQ_JAR..."
+jar uf "$ROQ_JAR" -C "$WORK_DIR" io/quarkiverse/roq/plugin/asciidoctorj/runtime/AsciidocJInclude.class
+
+touch "$MARKER"
+echo "Roq JAR patched successfully"

--- a/src/test/java/io/quarkusio/GuidesPageTest.java
+++ b/src/test/java/io/quarkusio/GuidesPageTest.java
@@ -1,5 +1,8 @@
 package io.quarkusio;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Response;
 import org.junit.jupiter.api.Assumptions;
@@ -236,6 +239,36 @@ public class GuidesPageTest extends BrowserTest {
                 path + ": Expected some guides to match 'hibernate'");
         assertTrue(filteredCount < initialCount,
                 path + ": Expected fewer guides after filtering, but got " + filteredCount + " (was " + initialCount + ")");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/version/main/guides/telemetry-micrometer-tutorial",
+            "/version/main/guides/rest-json",
+            "/guides/getting-started",
+            "/guides/rest"
+    })
+    void guideCodeBlocksAreNotEmpty(String path) {
+        page.navigate(baseUrl + path);
+
+        Locator codeBlocks = page.locator("pre code[class*='language-']");
+        int blockCount = codeBlocks.count();
+        if (blockCount == 0) {
+            return;
+        }
+
+        List<String> emptyBlocks = new ArrayList<>();
+        for (int i = 0; i < blockCount; i++) {
+            String content = codeBlocks.nth(i).textContent();
+            if (content == null || content.isBlank()) {
+                String lang = codeBlocks.nth(i).getAttribute("class");
+                emptyBlocks.add("block " + (i + 1) + " (" + lang + ")");
+            }
+        }
+        assertTrue(emptyBlocks.isEmpty(),
+                path + ": Found " + emptyBlocks.size() + " empty code block(s) out of " + blockCount
+                        + ". Source includes (include:: with tags) may not be resolving: "
+                        + String.join(", ", emptyBlocks));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkusio.github.io/issues/2939

The correct fix for this is obviously to do https://github.com/quarkiverse/quarkus-roq/issues/1178, but this is pretty severe, so I think a patch is warranted. I experimented with Quarkus Shim, but it couldn't patch 'deep' enough to get over classloader isolation in this case, so I've done a manual update of the jar. We'll want to remove that as soon as we can. 

I've also added a test to make sure we don't have this kind of thing again (it will also protect against other include problems, like missing files). The test will fail locally unless people run the patch script, but I think that's ok as a very short term thing. 