### PR TITLE
Repin the Roq TOC plugin to 07015acc

### DIFF
--- a/roq-plugin-toc/build.sh
+++ b/roq-plugin-toc/build.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 UPSTREAM_REPO="${UPSTREAM_REPO:-https://github.com/rolfedh/quarkus-roq.git}"
-UPSTREAM_COMMIT="${UPSTREAM_COMMIT:-94dc2ccb3825a8e9a716d46298a10811e9d17653}"
+UPSTREAM_COMMIT="${UPSTREAM_COMMIT:-07015acc83022f964563e1b2cb2a8b5704c7cd94}"
 
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT


### PR DESCRIPTION
## TLDR

Repins the Roq TOC plugin build to the new head of `rolfedh/quarkus-roq` branch `fix-toc`, commit `07015acc`. The plugin branch was rewritten to drop `Co-Authored-By` trailers, so the previously pinned commit `94dc2ccb` no longer exists on that branch and `build.sh` would fail to check it out.

## What changed on the plugin branch

- The extension now guards `{page.toc}` against re-entry when a page uses it inside its own content, which was the change requested in the review of quarkiverse/quarkus-roq#776.
- The plugin docs moved from the Antora docs to the Roq marketplace.
- The sources that `build.sh` copies still build unmodified, and the standalone build still installs `io.quarkiverse.roq:quarkus-roq-plugin-toc:1.0.0-SNAPSHOT`.

## Verification

- `UPSTREAM_REPO=file:///path/to/quarkus-roq UPSTREAM_COMMIT=07015acc83022f964563e1b2cb2a8b5704c7cd94 ./roq-plugin-toc/build.sh` against a local checkout: BUILD SUCCESS, 44 unit tests pass against Roq 2.1.7.
- `templates/layouts/guides.html` calls `{page.toc}` from the layout, not from page content, so the re-entrancy guard does not change the guides' output.

Developed with assistance from Claude Code; the change was reviewed and verified by the author.
