### PR TITLE
Correct workaround for xrelpaths to fix dead cross references in versioned guides

### DIFF
--- a/content/versions/2.13/guides/_attributes-local.adoc
+++ b/content/versions/2.13/guides/_attributes-local.adoc
@@ -3,11 +3,11 @@
 :doc-guides: .
 :generated-dir: ../../../_generated-doc/2.13
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/2.13/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/2.13/
+:relfileprefix: /version/2.13/guides/
 :relfilesuffix: /
 :create-app-stream: 2.13
 :create-cli-stream: 2.13

--- a/content/versions/2.16/guides/_attributes-local.adoc
+++ b/content/versions/2.16/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/2.16
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/2.16/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/2.16/
+:relfileprefix: /version/2.16/guides/
 :relfilesuffix: /
 :create-app-stream: 2.16
 :create-cli-stream: {create-app-stream}

--- a/content/versions/3.15/guides/_attributes-local.adoc
+++ b/content/versions/3.15/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.15
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/3.15/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/3.15/
+:relfileprefix: /version/3.15/guides/
 :relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.15 https://github.com/quarkusio/quarkus-quickstarts.git

--- a/content/versions/3.2/guides/_attributes-local.adoc
+++ b/content/versions/3.2/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.2
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/3.2/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/3.2/
+:relfileprefix: /version/3.2/guides/
 :relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.2 https://github.com/quarkusio/quarkus-quickstarts.git

--- a/content/versions/3.20/guides/_attributes-local.adoc
+++ b/content/versions/3.20/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.20
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/3.20/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/3.20/
+:relfileprefix: /version/3.20/guides/
 :relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.20 https://github.com/quarkusio/quarkus-quickstarts.git

--- a/content/versions/3.27/guides/_attributes-local.adoc
+++ b/content/versions/3.27/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.27
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/3.27/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/3.27/
+:relfileprefix: /version/3.27/guides/
 :relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.27 https://github.com/quarkusio/quarkus-quickstarts.git

--- a/content/versions/3.33/guides/_attributes-local.adoc
+++ b/content/versions/3.33/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.33
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/3.33/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/3.33/
+:relfileprefix: /version/3.33/guides/
 :relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.33 https://github.com/quarkusio/quarkus-quickstarts.git

--- a/content/versions/3.34/guides/_attributes-local.adoc
+++ b/content/versions/3.34/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.34
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/3.34/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/3.34/
+:relfileprefix: /version/3.34/guides/
 :relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.34 https://github.com/quarkusio/quarkus-quickstarts.git

--- a/content/versions/3.8/guides/_attributes-local.adoc
+++ b/content/versions/3.8/guides/_attributes-local.adoc
@@ -2,11 +2,11 @@
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.8
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/3.8/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/3.8/
+:relfileprefix: /version/3.8/guides/
 :relfilesuffix: /
 //
 :quickstarts-clone-url: -b 3.8 https://github.com/quarkusio/quarkus-quickstarts.git

--- a/content/versions/main/guides/_attributes-local.adoc
+++ b/content/versions/main/guides/_attributes-local.adoc
@@ -3,11 +3,11 @@
 :doc-guides: .
 :generated-dir: ../../../_generated-doc/main
 :code-examples: {generated-dir}/examples
-:imagesdir: ./images
+:imagesdir: /version/main/guides/images
 :includes: ./_includes
 :sectanchors:
 // TODO: Remove these once Roq 2.1.8+ is released with parentPath() fix (https://github.com/quarkiverse/quarkus-roq/pull/1158)
-:relfileprefix: /version/main/
+:relfileprefix: /version/main/guides/
 :relfilesuffix: /
 :quarkus-platform-groupid: io.quarkus
 //


### PR DESCRIPTION
While working on https://github.com/quarkusio/quarkusio.github.io/pull/2928, I discovered that we were missing out checking a whole bunch of pages, because of a race condition. Then, while working on https://github.com/quarkusio/quarkusio.github.io/pull/2931, I changed CI to build all versions in the PR builds. That showed up a whole bunch more failures in the versioned guides. 

Basically, the fix done in https://github.com/quarkusio/quarkusio.github.io/pull/2919 fixed dev mode, but it turned out that it didn't work for the built site, but I didn't know because previews and preview tests didn't cover older versions. This version seems to pass in both dev mode and normal mode. https://github.com/quarkusio/quarkusio.github.io/pull/2928 is still red, but for other reasons.