### PR TITLE
Add redirect for retired /worldtour/ page

### DIFF
--- a/content/posts/2021-06-22-calling-all-roadies.adoc
+++ b/content/posts/2021-06-22-calling-all-roadies.adoc
@@ -12,9 +12,9 @@ author: jbeck
 
 image::callingallroadies.png[]
 
-The https://quarkus.io/worldtour/[Quarkus World Tour] kicked off in March to provide a unique, hands-on Quarkus experience for Java developers across the globe. The goal of the tour is to introduce Quarkus to Java developers and set them down the path of creating applications and participating in the community.
+The Quarkus World Tour kicked off in March to provide a unique, hands-on Quarkus experience for Java developers across the globe. The goal of the tour is to introduce Quarkus to Java developers and set them down the path of creating applications and participating in the community.
 
-Since the tour began, we have performed for crowds of developers from *15+* JUGs across the world with many more https://quarkus.io/worldtour/[tour stops] being added every day.
+Since the tour began, we have performed for crowds of developers from *15+* JUGs across the world with many more tour stops being added every day.
 
 == Bands Make It “Rock”, Roadies Make It “Roll”
 A global world tour takes an entire community to ensure its success. We have a great group of roadies that have made the world tour a success so far but we need your help.

--- a/content/redirects/worldtour.md
+++ b/content/redirects/worldtour.md
@@ -1,0 +1,4 @@
+---
+link: /worldtour/
+newUrl: /blog/calling-all-roadies/
+---


### PR DESCRIPTION
More https://github.com/quarkusio/quarkusio.github.io/pull/2928 discoveries. This is unrelated to Roq.

The Quarkus World Tour (2021-2022) page no longer exists. Lots of newsletters reference it, so I added a redirect to the "Calling All Roadies" blog post and de-linked the two /worldtour/ references in that post to avoid self-redirects.