### PR TITLE
Pick up updated Yupiik to correct titles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,8 @@ jobs:
         if: steps.detect.outputs.roq == 'true'
         run: ./roq-plugin-toc/build.sh
 
-      # TODO: Remove once https://github.com/quarkiverse/quarkus-roq/issues/1178 is fixed and Roq is upgraded
-      - name: Patch Roq AsciiDoc tag handling
+      # TODO: Remove with Roq 2.1.8
+      - name: Patch Roq for pre-2.1.8 workarounds
         if: steps.detect.outputs.roq == 'true'
         run: |
           mvn -B dependency:resolve -q

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
         run: |
           mvn -B dependency:resolve -q
           bash patches/apply-roq-include-fix.sh
+          bash patches/apply-roq-header-fix.sh
 
       - name: Detect infra changes
         id: infra
@@ -116,6 +117,14 @@ jobs:
           else
             echo "include_versions=false" >> $GITHUB_OUTPUT
           fi
+
+      # TODO: Remove with Roq 2.1.8
+      - name: Patch Roq for pre-2.1.8 workarounds
+        if: steps.detect.outputs.roq == 'true'
+        run: |
+          mvn -B dependency:resolve -q
+          bash patches/apply-roq-include-fix.sh
+          bash patches/apply-roq-header-fix.sh
 
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,12 +76,13 @@ jobs:
         if: steps.detect.outputs.roq == 'true'
         run: ./roq-plugin-toc/build.sh
 
-      # TODO: Remove once https://github.com/quarkiverse/quarkus-roq/issues/1178 is fixed and Roq is upgraded
-      - name: Patch Roq AsciiDoc tag handling
+      # TODO: Remove with Roq 2.1.8
+      - name: Patch Roq for pre-2.1.8 workarounds
         if: steps.detect.outputs.roq == 'true'
         run: |
           mvn -B dependency:resolve -q
           bash patches/apply-roq-include-fix.sh
+          bash patches/apply-roq-header-fix.sh
 
       - name: Build with Maven
         if: steps.detect.outputs.roq == 'true'

--- a/patches/AsciidocHeaderParser.java
+++ b/patches/AsciidocHeaderParser.java
@@ -1,0 +1,267 @@
+// Patched version of io.quarkiverse.roq.plugin.asciidoc.common.deployment.AsciidocHeaderParser
+// Fixes binary incompatibility with asciidoc-java 1.2.16:
+//   Header.author() changed from Author to List<Author>
+// See: https://github.com/yupiik/tools-maven-plugin/issues/92
+// TODO: Remove with Roq 2.1.8
+package io.quarkiverse.roq.plugin.asciidoc.common.deployment;
+
+import static io.quarkiverse.roq.frontmatter.deployment.util.RoqFrontMatterTemplateUtils.stripFrontMatter;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.DESCRIPTION;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.ESCAPE;
+import static io.quarkiverse.roq.frontmatter.runtime.RoqFrontMatterKeys.TITLE;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.roq.frontmatter.deployment.items.scan.RoqFrontMatterHeaderParserBuildItem;
+import io.quarkiverse.roq.frontmatter.deployment.items.scan.TemplateContext;
+import io.vertx.core.json.JsonObject;
+import io.yupiik.asciidoc.model.Author;
+import io.yupiik.asciidoc.model.Header;
+import io.yupiik.asciidoc.parser.Parser;
+import io.yupiik.asciidoc.parser.internal.Reader;
+import io.yupiik.asciidoc.parser.resolver.ContentResolver;
+import io.yupiik.asciidoc.parser.resolver.RelativeContentResolver;
+
+public class AsciidocHeaderParser {
+    private static final Logger LOGGER = org.jboss.logging.Logger.getLogger(AsciidocHeaderParser.class);
+
+    private static final String QUTE_KEY = "qute";
+
+    // Pattern used to short-circuit more complex evaluation
+    private static final Pattern SIMPLE_CONDITIONAL = Pattern
+            .compile("ifn?(?:def|eval)");
+
+    // Mirrors Asciidoctor's ConditionalDirectiveRx — one pattern for all conditional directives.
+    // group 1: leading backslash (escaped directive, treat as literal text)
+    // group 2: directive name (ifdef, ifndef, ifeval, endif)
+    // group 3: target attributes (may be empty for endif/ifeval)
+    // group 4: bracket content (null for empty brackets = block form, non-null = inline form)
+    private static final Pattern CONDITIONAL_DIRECTIVE = Pattern
+            .compile("^(\\\\)?(ifdef|ifndef|ifeval|endif)::(\\S*?)\\[(.+)?\\]\\s*$");
+
+    // Matches attribute entries: :name: value, :!name: (unset), :name!: (unset)
+    private static final Pattern ATTRIBUTE_ENTRY = Pattern.compile("^:(!?\\w[^:]*):(?:[ \\t]+(.*))?$");
+
+    public static RoqFrontMatterHeaderParserBuildItem createBuildItem(boolean qute, Predicate<TemplateContext> isApplicable) {
+        return new RoqFrontMatterHeaderParserBuildItem(isApplicable, templateContext -> {
+            Parser parser = new Parser();
+            String content = stripFrontMatter(templateContext.content());
+            if (SIMPLE_CONDITIONAL.matcher(content).find()) {
+                content = stripConditionalDirectives(content);
+            }
+
+            ContentResolver contentResolver = new PathContentResolver(templateContext.sourceFile().getParent());
+            Header header = parser.parseHeader(new Reader(content.lines().toList()),
+                    new Parser.ParserContext(contentResolver));
+            final JsonObject pageData = toPageData(header);
+            boolean escape = !qute;
+
+            if (header.attributes().containsKey(QUTE_KEY)) {
+                final String quteAttribute = header.attributes().get(QUTE_KEY);
+                escape = !(quteAttribute.isEmpty() || Boolean.parseBoolean(quteAttribute));
+            }
+
+            if (!pageData.containsKey(ESCAPE)) {
+                pageData.put(ESCAPE, escape);
+            }
+            return pageData;
+        }, Function.identity(), 20);
+    }
+
+    public static JsonObject toPageData(Header header) {
+        JsonObject pageData = new JsonObject();
+        final Map<String, String> attributes = processAttributes(header.attributes());
+        pageData.put("attributes", JsonObject.mapFrom(attributes));
+        for (String key : attributes.keySet()) {
+            if (key.startsWith("page-")) {
+                final String value = attributes.get(key);
+                pageData.put(key.substring(5), value.isEmpty() ? true : value);
+            }
+        }
+        if (!header.title().isBlank()) {
+            pageData.put(TITLE, header.title());
+        }
+        if (header.attributes().containsKey(DESCRIPTION) && !header.attributes().get(DESCRIPTION).isBlank()) {
+            pageData.put(DESCRIPTION, header.attributes().get("description"));
+        }
+        if (header.author() != null && !header.author().isEmpty()
+                && !header.author().get(0).name().isBlank()) {
+            Author firstAuthor = header.author().get(0);
+            pageData.put("author", firstAuthor.name());
+            pageData.put("author-email", firstAuthor.mail());
+        }
+        if (!header.revision().number().isBlank()) {
+            pageData.put("revision", new JsonObject()
+                    .put("number", header.revision().number())
+                    .put("date", header.revision().date())
+                    .put("remark", header.revision().revmark()));
+        }
+        if (attributes.containsKey("description")) {
+            pageData.put(DESCRIPTION, attributes.get("description"));
+        }
+        if (attributes.containsKey("image")) {
+            pageData.put("image", attributes.get("image"));
+        }
+        return pageData;
+    }
+
+    public static Map<String, String> processAttributes(Map<String, String> input) {
+        Map<String, String> result = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> entry : input.entrySet()) {
+            String key = entry.getKey();
+
+            if (key.startsWith("!")) {
+                result.remove(key.substring(1));
+            } else {
+                result.put(key, entry.getValue());
+            }
+        }
+
+        return result;
+    }
+
+    static String stripConditionalDirectives(String content) {
+        List<String> result = new ArrayList<>();
+        Deque<Boolean> includeStack = new ArrayDeque<>();
+        Set<String> definedAttributes = new HashSet<>();
+
+        for (String line : (Iterable<String>) content.lines()::iterator) {
+            Matcher m = CONDITIONAL_DIRECTIVE.matcher(line);
+            if (m.matches()) {
+                if (m.group(1) != null) {
+                    if (isIncluding(includeStack)) {
+                        result.add(line.substring(1));
+                    }
+                    continue;
+                }
+
+                LOGGER.debugf("Stripping conditional directive from AsciiDoc header: '%s'", line);
+                String directive = m.group(2);
+                String target = m.group(3);
+                String bracketContent = m.group(4);
+
+                switch (directive) {
+                    case "ifdef", "ifndef" -> {
+                        if (bracketContent == null) {
+                            boolean include = isIncluding(includeStack)
+                                    && evaluateCondition(directive, target, definedAttributes);
+                            includeStack.push(include);
+                        } else {
+                            if (isIncluding(includeStack)
+                                    && evaluateCondition(directive, target, definedAttributes)) {
+                                result.add(bracketContent);
+                                trackAttribute(bracketContent, definedAttributes);
+                            }
+                        }
+                    }
+                    case "endif" -> {
+                        if (!includeStack.isEmpty()) {
+                            includeStack.pop();
+                        }
+                    }
+                    case "ifeval" -> includeStack.push(isIncluding(includeStack));
+                }
+                continue;
+            }
+
+            if (isIncluding(includeStack)) {
+                result.add(line);
+                trackAttribute(line, definedAttributes);
+            }
+        }
+
+        return String.join("\n", result);
+    }
+
+    private static boolean isIncluding(Deque<Boolean> includeStack) {
+        return !includeStack.contains(false);
+    }
+
+    private static final Pattern COMMA = Pattern.compile(",");
+    private static final Pattern PLUS = Pattern.compile("\\+");
+
+    static boolean evaluateCondition(String directive, String attributes, Set<String> definedAttributes) {
+        boolean defined;
+        if (attributes.contains(",")) {
+            defined = COMMA.splitAsStream(attributes)
+                    .map(String::trim)
+                    .anyMatch(definedAttributes::contains);
+        } else if (attributes.contains("+")) {
+            defined = PLUS.splitAsStream(attributes)
+                    .map(String::trim)
+                    .allMatch(definedAttributes::contains);
+        } else {
+            defined = definedAttributes.contains(attributes.trim());
+        }
+
+        return "ifdef".equals(directive) ? defined : !defined;
+    }
+
+    private static void trackAttribute(String line, Set<String> definedAttributes) {
+        Matcher attr = ATTRIBUTE_ENTRY.matcher(line);
+        if (attr.matches()) {
+            String raw = attr.group(1);
+            boolean unset = raw.startsWith("!") || raw.endsWith("!");
+            String name = unset ? raw.replace("!", "") : raw;
+            if (unset) {
+                definedAttributes.remove(name);
+            } else {
+                definedAttributes.add(name);
+            }
+        }
+    }
+
+    static class PathContentResolver implements RelativeContentResolver {
+
+        private final Path base;
+
+        PathContentResolver(Path base) {
+            this.base = base;
+        }
+
+        @Override
+        public Optional<Resolved> resolve(Path parent, String ref, Charset encoding) {
+            final var rel = Path.of(ref);
+            if (rel.isAbsolute()) {
+                return doRead(rel, encoding);
+            }
+            if (parent != null && parent.getParent() != null) {
+                return doRead(parent.getParent().resolve(ref), encoding);
+            }
+            final var resolved = base.resolve(ref);
+            return doRead(resolved, encoding);
+        }
+
+        private static Optional<Resolved> doRead(Path resolved, Charset encoding) {
+            if (Files.isRegularFile(resolved)) {
+                try {
+                    return Optional.of(new Resolved(resolved, Files.readAllLines(resolved, encoding)));
+                } catch (IOException e) {
+                    throw new RuntimeException("Can't read '" + resolved + "'");
+                }
+            }
+            LOGGER.warnf("Include file '%s' not found", resolved);
+            return Optional.of(new Resolved(null, List.of()));
+        }
+    }
+
+}

--- a/patches/apply-roq-header-fix.sh
+++ b/patches/apply-roq-header-fix.sh
@@ -19,14 +19,28 @@ M2="$HOME/.m2/repository"
 TARGET_JAR="$M2/io/quarkiverse/roq/quarkus-roq-plugin-asciidoc-common-deployment/$ROQ_VERSION/quarkus-roq-plugin-asciidoc-common-deployment-$ROQ_VERSION.jar"
 MARKER="$TARGET_JAR.patched-header-author"
 
-if [ ! -f "$TARGET_JAR" ]; then
-  echo "Target JAR not found at $TARGET_JAR — run 'mvn dependency:resolve' first"
-  exit 1
-fi
-
 if [ -f "$MARKER" ]; then
   echo "AsciidocHeaderParser already patched, skipping"
   exit 0
+fi
+
+# The target jar and some compile deps are Quarkus deployment artifacts
+# (not regular transitive deps), so download them explicitly if missing.
+for gav in \
+  "io.quarkiverse.roq:quarkus-roq-plugin-asciidoc-common-deployment:$ROQ_VERSION" \
+  "io.quarkiverse.roq:quarkus-roq-frontmatter-deployment:$ROQ_VERSION" \
+  "io.yupiik.maven:asciidoc-java:1.2.16"; do
+  IFS=: read -r g a v <<< "$gav"
+  jar_path="$M2/$(echo "$g" | tr '.' '/')/$a/$v/$a-$v.jar"
+  if [ ! -f "$jar_path" ]; then
+    echo "Downloading $gav..."
+    mvn -B dependency:get -Dartifact="$gav" -q
+  fi
+done
+
+if [ ! -f "$TARGET_JAR" ]; then
+  echo "Target JAR not found at $TARGET_JAR"
+  exit 1
 fi
 
 WORK_DIR=$(mktemp -d)
@@ -41,7 +55,7 @@ JBOSS_LOGGING=$(find "$M2/org/jboss/logging/jboss-logging" -name '*.jar' -not -n
 
 for dep in ASCIIDOC_JAVA FRONTMATTER_DEPLOYMENT FRONTMATTER_RUNTIME VERTX_CORE JBOSS_LOGGING; do
   if [ -z "${!dep}" ]; then
-    echo "Missing dependency: $dep — run 'mvn dependency:resolve' first"
+    echo "Missing dependency: $dep"
     exit 1
   fi
 done

--- a/patches/apply-roq-header-fix.sh
+++ b/patches/apply-roq-header-fix.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Patches AsciidocHeaderParser to fix binary incompatibility with asciidoc-java 1.2.16:
+#   Header.author() changed from Author to List<Author>
+#
+# Fixes: https://github.com/yupiik/tools-maven-plugin/issues/92
+# Upstream: https://github.com/quarkiverse/quarkus-roq/pull/1184
+# TODO: Remove with Roq 2.1.8
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Extract the Roq version from pom.xml
+ROQ_VERSION=$(grep -m1 -oP '(?<=quarkus-roq-plugin-asciidoc-jruby</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
+  || grep -oP '(?<=quarkus-roq</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
+  || echo "2.1.7")
+
+M2="$HOME/.m2/repository"
+TARGET_JAR="$M2/io/quarkiverse/roq/quarkus-roq-plugin-asciidoc-common-deployment/$ROQ_VERSION/quarkus-roq-plugin-asciidoc-common-deployment-$ROQ_VERSION.jar"
+MARKER="$TARGET_JAR.patched-header-author"
+
+if [ ! -f "$TARGET_JAR" ]; then
+  echo "Target JAR not found at $TARGET_JAR — run 'mvn dependency:resolve' first"
+  exit 1
+fi
+
+if [ -f "$MARKER" ]; then
+  echo "AsciidocHeaderParser already patched, skipping"
+  exit 0
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Build the compilation classpath from resolved dependencies
+ASCIIDOC_JAVA=$(find "$M2/io/yupiik/maven/asciidoc-java" -name 'asciidoc-java-1.2.16.jar' | head -1)
+FRONTMATTER_DEPLOYMENT=$(find "$M2/io/quarkiverse/roq/quarkus-roq-frontmatter-deployment" -name "*.jar" -not -name '*sources*' | sort -V | tail -1)
+FRONTMATTER_RUNTIME=$(find "$M2/io/quarkiverse/roq/quarkus-roq-frontmatter" -name "quarkus-roq-frontmatter-$ROQ_VERSION.jar" | head -1)
+VERTX_CORE=$(find "$M2/io/vertx/vertx-core" -name '*.jar' -not -name '*sources*' | sort -V | tail -1)
+JBOSS_LOGGING=$(find "$M2/org/jboss/logging/jboss-logging" -name '*.jar' -not -name '*sources*' | sort -V | tail -1)
+
+for dep in ASCIIDOC_JAVA FRONTMATTER_DEPLOYMENT FRONTMATTER_RUNTIME VERTX_CORE JBOSS_LOGGING; do
+  if [ -z "${!dep}" ]; then
+    echo "Missing dependency: $dep — run 'mvn dependency:resolve' first"
+    exit 1
+  fi
+done
+
+CP="$TARGET_JAR:$ASCIIDOC_JAVA:$FRONTMATTER_DEPLOYMENT:$FRONTMATTER_RUNTIME:$VERTX_CORE:$JBOSS_LOGGING"
+
+echo "Compiling patched AsciidocHeaderParser..."
+javac --release 21 -cp "$CP" -d "$WORK_DIR" "$SCRIPT_DIR/AsciidocHeaderParser.java"
+
+echo "Patching $TARGET_JAR..."
+# Update all generated class files (main class + inner classes)
+cd "$WORK_DIR"
+for classfile in $(find . -name 'AsciidocHeaderParser*.class'); do
+  jar uf "$TARGET_JAR" "$classfile"
+done
+
+touch "$MARKER"
+echo "AsciidocHeaderParser patched successfully"

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO drop this override once Roq 2.1.8 is available -->
+            <dependency>
+                <groupId>io.yupiik.maven</groupId>
+                <artifactId>asciidoc-java</artifactId>
+                <version>1.2.16</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
We don't expect a Roq release for at least a few days, but yupiik has released, so override the version. See https://github.com/quarkiverse/quarkus-roq/issues/1136

This ended up being a bit ugly, because yupiik changed an API, so I needed to do a Roq patch.

Before: 

<img width="1293" height="474" alt="image" src="https://github.com/user-attachments/assets/114d7d47-edc0-414e-8130-e9d74a546df4" />

After: 

<img width="2194" height="931" alt="image" src="https://github.com/user-attachments/assets/516416a4-17d7-414c-b251-e2e657b92447" />
