### PR TITLE
Fix blog posts linking to retired/renamed guides

### DIFF
--- a/content/posts/2020-03-19-quarkus-1-3-0-final-released.adoc
+++ b/content/posts/2020-03-19-quarkus-1-3-0-final-released.adoc
@@ -98,7 +98,7 @@ It optimizes planning and scheduling problems.
 
 The OptaPlanner Quarkus extension brings all the features of OptaPlanner to Quarkus,
 even in native executables.
-If you want to discover how OptaPlanner can help, please visit https://docs.timefold.ai/timefold-solver/latest/quickstart/quarkus-quickstart[the Timefold Solver quickstart] (OptaPlanner's successor).
+If you want to discover how OptaPlanner can help, please have a look at https://docs.timefold.ai/timefold-platform/latest/introduction[Timefold] (OptaPlanner's successor).
 
 ==== Security JPA
 

--- a/content/posts/2020-03-19-quarkus-1-3-0-final-released.adoc
+++ b/content/posts/2020-03-19-quarkus-1-3-0-final-released.adoc
@@ -98,7 +98,7 @@ It optimizes planning and scheduling problems.
 
 The OptaPlanner Quarkus extension brings all the features of OptaPlanner to Quarkus,
 even in native executables.
-If you want to discover how OptaPlanner can help, please read https://quarkus.io/guides/optaplanner[the OptaPlanner guide].
+If you want to discover how OptaPlanner can help, please visit https://docs.timefold.ai/timefold-solver/latest/quickstart/quarkus-quickstart[the Timefold Solver quickstart] (OptaPlanner's successor).
 
 ==== Security JPA
 

--- a/content/posts/2021-12-02-logicdrop-automating-quarkus-with-gitlab.adoc
+++ b/content/posts/2021-12-02-logicdrop-automating-quarkus-with-gitlab.adoc
@@ -67,7 +67,7 @@ Other extensions we integrated into GitLab are:
 - https://quarkus.io/guides/logging-sentry[Quarkus Logging Sentry^] hooks into https://docs.gitlab.com/ee/operations/error_tracking.html[GitLab Error Tracking^]
 - https://quarkus.io/guides/smallrye-health[Quarkus SmallRye Health^] hooks into https://docs.gitlab.com/ee/operations/metrics/[GitLab Metrics^]
 - https://quarkus.io/guides/openapi-swaggerui[Quarkus SmallRye OpenAPI^] exposes the https://docs.gitlab.com/ee/api/openapi/openapi_interactive.html[Swagger API^]
-- https://quarkus.io/guides/opentracing[Quarkus SmallRye OpenTracing^] hooks into https://docs.gitlab.com/ee/operations/tracing.html[GitLab Tracing^]
+- https://quarkus.io/guides/opentelemetry-tracing[Quarkus OpenTelemetry Tracing^] hooks into https://docs.gitlab.com/ee/operations/tracing.html[GitLab Tracing^]
 
 Using the Quarkus extensions in combination with GitLab we get a complete picture of our environments, from development to deployment and monitoring, making building microservices easier. 
 

--- a/content/posts/2022-12-14-quarkus-2-15-0-final-released.adoc
+++ b/content/posts/2022-12-14-quarkus-2-15-0-final-released.adoc
@@ -39,7 +39,7 @@ Quarkus 2.15 brings support for https://aws.amazon.com/blogs/aws/new-accelerate-
 
 This has already been announced in details in https://quarkus.io/blog/quarkus-support-for-aws-lambda-snapstart/[a previous blog post].
 
-See https://quarkus.io/guides/amazon-snapstart[the dedicated guide] for more information about how to use AWS Lambda SnapStart with Quarkus.
+See https://quarkus.io/guides/aws-lambda-snapstart[the dedicated guide] for more information about how to use AWS Lambda SnapStart with Quarkus.
 
 === New gRPC implementation
 

--- a/content/posts/2024-08-06-quarkus-and-leyden.adoc
+++ b/content/posts/2024-08-06-quarkus-and-leyden.adoc
@@ -94,7 +94,7 @@ A default CDS archive for JDK runtime classes has been shipped with every JVM re
 .When doing training runs, we create an archive that contains information on how the application runs. This archive includes not only classes from the core libraries, but also classes from our application.
 image::AoT_vs_JiT_dynamic.svg[Dynamic CDS benefits,float="right",align="center"]
 
-Quarkus makes it really easy to generate CDS archives specific to your application code; this feature has been around since some years already: see the https://quarkus.io/guides/appcds[AppCDS guide in Quarkus].
+Quarkus makes it really easy to generate CDS archives specific to your application code; this feature has been around since some years already: see the https://quarkus.io/guides/aot#appcds-legacy[AppCDS section in the Quarkus AOT guide].
 As Leyden is coming, we aim to evolve this further and fully automate it for Leyden as well, so to get you even more benefits at no additional hassle.
 
 The goal of Project Leyden is extending the AOT vs JIT trade-off from class loading (as done by CDS) to other JIT operations in the JVM; there's a number of operations which could be "moved in time" to AOT, such as creation of heap objects to represent constants, gathering execution profile information, and many more.


### PR DESCRIPTION
- amazon-snapstart → aws-lambda-snapstart (guide was renamed)
- appcds → aot#appcds-legacy (guide was merged into AOT guide)
- opentracing → opentelemetry-tracing (OpenTracing was replaced)
- optaplanner → Timefold Solver docs (OptaPlanner was renamed)

More problems found by the improved link checker. 
