### PR TITLE
Be DRY with Roq version in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <quarkus.platform.version>3.38.3</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
+        <roq.version>2.1.7</roq.version>
     </properties>
 
     <dependencyManagement>
@@ -34,7 +35,7 @@
         <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq</artifactId>
-            <version>2.1.7</version>
+            <version>${roq.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -43,22 +44,22 @@
         <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-testing</artifactId>
-            <version>2.1.7</version>
+            <version>${roq.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-plugin-aliases</artifactId>
-            <version>2.1.7</version>
+            <version>${roq.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-plugin-tagging</artifactId>
-            <version>2.1.7</version>
+            <version>${roq.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-plugin-asciidoc-jruby</artifactId>
-            <version>2.1.7</version>
+            <version>${roq.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.playwright</groupId>


### PR DESCRIPTION
For various boring reasons relating to the incremental conversion, we couldn't really be DRY with the Roq version in the pom.xml. Now we can, so we should. 