### PR TITLE
Do not use latest yupiik in non-CI builds to avoid incompatible binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Patch Roq for pre-2.1.8 workarounds
         if: steps.detect.outputs.roq == 'true'
         run: |
+          rm pom.xml
+          cp patches/pom.xml .
           mvn -B dependency:resolve -q
           bash patches/apply-roq-include-fix.sh
           bash patches/apply-roq-header-fix.sh

--- a/patches/pom.xml
+++ b/patches/pom.xml
@@ -28,6 +28,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO drop this override once Roq 2.1.8 is available -->
+            <dependency>
+                <groupId>io.yupiik.maven</groupId>
+                <artifactId>asciidoc-java</artifactId>
+                <version>1.2.16</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This should all go away soon, but in the interim, normal local builds should work.

I've checked the prevew, and guide titles are still correct, I *think*. Only some guides had the issue so I checked a few and see 

<img width="1484" height="446" alt="image" src="https://github.com/user-attachments/assets/57ba7ab3-8f6d-4720-a3f7-744a7b98eb1b" />
