### PR TITLE
Extend idprefix/idseparator fix to blog posts and versioned guides

### DIFF
--- a/content/posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
+++ b/content/posts/2019-09-23-quarkus-developer-joy-for-vs-code.adoc
@@ -6,6 +6,8 @@ date: 2019-09-23
 synopsis: Showcasing the new Quarkus VS Code extension.
 author: dakwon
 ---
+:idprefix:
+:idseparator: -
 
 :imagesdir: /assets/images/posts/quarkus-vs-code
 

--- a/content/posts/2019-10-31-vscode-quarkus-1.1.0.adoc
+++ b/content/posts/2019-10-31-vscode-quarkus-1.1.0.adoc
@@ -6,6 +6,8 @@ synopsis: New features for Quarkus Tools for Visual Studio Code.
 author: dakwon
 tags:  ide
 ---
+:idprefix:
+:idseparator: -
 :blank: pass:[ +] 
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.1.0
 

--- a/content/posts/2019-11-21-vscode-quarkus-1.2.0.adoc
+++ b/content/posts/2019-11-21-vscode-quarkus-1.2.0.adoc
@@ -5,6 +5,8 @@ date: 2019-11-21
 tags: ide 
 author: dakwon
 ---
+:idprefix:
+:idseparator: -
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.2.0
 
 We are proud to present the new release of Quarkus Tools for Visual Studio Code,

--- a/content/posts/2020-01-28-vscode-quarkus-1.3.0.adoc
+++ b/content/posts/2020-01-28-vscode-quarkus-1.3.0.adoc
@@ -5,6 +5,8 @@ date: 2020-02-07
 author: dakwon
 tags: ide 
 ---
+:idprefix:
+:idseparator: -
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.3.0
 :star: *
 

--- a/content/posts/2021-09-01-using-lra.adoc
+++ b/content/posts/2021-09-01-using-lra.adoc
@@ -6,6 +6,8 @@ tags: extension
 synopsis: How to use the narayana LRA extension to create reliable long running activities.
 author: mmusgrov
 ---
+:idprefix:
+:idseparator: -
 
 == Introduction
 

--- a/content/posts/2021-09-01-using-lra.adoc
+++ b/content/posts/2021-09-01-using-lra.adoc
@@ -330,7 +330,7 @@ First build a native executable:
 $ ./mvnw package -DskipTests -Pnative
 ----
 
-Check that the external coordinator started in <<_lra-coordinators,the section on coordinators>> is still running on
+Check that the external coordinator started in <<lra-coordinators,the section on coordinators>> is still running on
 port 50000 and then start the service as a native executable in the background. Note that if the coordinator is not
 running on the default port you would need to either pass in the location of a running coordinator as a Java system property
 (`-Dquarkus.lra.coordinator-url=http://localhost:50000/lra-coordinator`) or you can update the application config and
@@ -466,7 +466,7 @@ property to the application config file (`src/main/resources/application.propert
 quarkus.resteasy.ignore-application-classes=true 
 ----
 
-The same caveats as described in the <<_lra-coordinators,the section on coordinators>> still apply:
+The same caveats as described in the <<lra-coordinators,the section on coordinators>> still apply:
 
 - no support for native executables.
 - each instance requires dedicated storage for the coordinators' transaction logs (since sharing transaction stores is not currently supported).

--- a/content/posts/2022-02-22-quarkus-superheroes-to-the-rescue.adoc
+++ b/content/posts/2022-02-22-quarkus-superheroes-to-the-rescue.adoc
@@ -6,6 +6,8 @@ tags: apicurio avro fault-tolerance kafka messaging metrics openapi reactive res
 synopsis: Introduction to the Quarkus Superheroes sample application, discusses some of the requirements for building it, and illustrates how to run it locally or deploy it to Kubernetes.
 author: edeandrea
 ---
+:idprefix:
+:idseparator: -
 :imagesdir: /assets/images/posts/quarkus-superheroes-to-the-rescue
 
 = Quarkus Superheroes to the Rescue!

--- a/content/posts/2023-04-19-vscode-quarkus-1.13.0-released.adoc
+++ b/content/posts/2023-04-19-vscode-quarkus-1.13.0-released.adoc
@@ -6,6 +6,8 @@ date: 2023-04-19
 tags: ide
 author: jhe
 ---
+:idprefix:
+:idseparator: -
 :imagesdir: /assets/images/posts/quarkus-vs-code-1.13.0
 :star: *
 

--- a/content/posts/2023-04-19-vscode-quarkus-1.13.0-released.adoc
+++ b/content/posts/2023-04-19-vscode-quarkus-1.13.0-released.adoc
@@ -19,9 +19,9 @@ This release focuses on Qute Templating Engine Support by introducing support fo
 == New Features
 Notable Qute features included in Quarkus Tools for Visual Studio Code 1.13.0 include:
 
-* link:#include-and-insert-section-support[`#include` and `#insert` Section Support]
+* link:#include-and-insert-section-support-improvement[`#include` and `#insert` Section Support]
 * link:#fragment-section-support[`#fragment` Section support]
-* link:#user-tag-support-improvements[User Tag Support Improvement]
+* link:#user-tag-support-improvement[User Tag Support Improvement]
 * link:#validation-for-all-opened-and-unopened-qute-templates[Validation for All Opened and Unopened Qute Templates]
 * link:#new-qute-syntax-validator[New Qute Syntax Validator]
 * link:#surround-with-command[Surround with Command]

--- a/content/posts/2023-11-16-quarkus-meets-langchain4j.adoc
+++ b/content/posts/2023-11-16-quarkus-meets-langchain4j.adoc
@@ -6,6 +6,8 @@ tags: ai langchain4j llm
 synopsis: 'Learn about the new quarkus-langchain4j extension to integrate LLMs in Quarkus applications.'
 author: cescoffier
 ---
+:idprefix:
+:idseparator: -
 :imagesdir: /assets/images/posts/llms
 
 Large language models (LLMs) are reshaping the world of software, altering the way we interact with users and develop business logic.

--- a/content/posts/2024-08-28-quarkus-3-14-1-released.adoc
+++ b/content/posts/2024-08-28-quarkus-3-14-1-released.adoc
@@ -6,6 +6,8 @@ tags: release
 synopsis: 'We released Quarkus 3.14, in which we upgraded the ORM stack, added Let''s encrypt support, provided a way to speed up your Jackson serialization, and a lot more!'
 author: gsmet
 ---
+:idprefix:
+:idseparator: -
 
 It is our pleasure to announce the release of Quarkus 3.14.1
 (we skipped the release of 3.14.0 so 3.14.1 is actually the first 3.14 release).

--- a/content/versions/2.13/guides/_attributes-local.adoc
+++ b/content/versions/2.13/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :doc-guides: .

--- a/content/versions/2.16/guides/_attributes-local.adoc
+++ b/content/versions/2.16/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/2.16

--- a/content/versions/3.15/guides/_attributes-local.adoc
+++ b/content/versions/3.15/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.15

--- a/content/versions/3.2/guides/_attributes-local.adoc
+++ b/content/versions/3.2/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.2

--- a/content/versions/3.20/guides/_attributes-local.adoc
+++ b/content/versions/3.20/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.20

--- a/content/versions/3.27/guides/_attributes-local.adoc
+++ b/content/versions/3.27/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.27

--- a/content/versions/3.33/guides/_attributes-local.adoc
+++ b/content/versions/3.33/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.33

--- a/content/versions/3.34/guides/_attributes-local.adoc
+++ b/content/versions/3.34/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.34

--- a/content/versions/3.8/guides/_attributes-local.adoc
+++ b/content/versions/3.8/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :generated-dir: ../../../_generated-doc/3.8

--- a/content/versions/main/guides/_attributes-local.adoc
+++ b/content/versions/main/guides/_attributes-local.adoc
@@ -1,3 +1,5 @@
+:idprefix:
+:idseparator: -
 // tag::xref-attributes[]
 :doc-examples: ./_examples
 :doc-guides: .


### PR DESCRIPTION
PR #2934 set :idprefix:/:idseparator: - at the document level to restore the jekyll-asciidoc defaults lost in the Roq migration, but only for the FAQ and the live guides' _attributes-local.adoc. While trying to get #2713 in, I spotted the gap. This extends the approach to the versioned guides and also some blog posts.

As before, https://github.com/quarkiverse/quarkus-roq/pull/1175 is the more compact fix, but not yet available.

Even with this, #2713 isn't green, but it gets it closer.