### PR TITLE
Fix serve scripts and blog-preview.sh (follow-up to #2862)

### DIFF
--- a/blog-preview.sh
+++ b/blog-preview.sh
@@ -2,12 +2,21 @@
 SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit 1
 cd "$SCRIPTDIR" || exit 1
 
-for cmd in find curl grep sed sort comm head basename date wc tr; do
+for cmd in find curl grep sed sort comm head basename date wc tr java; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "ERROR: required command not found: $cmd"
     exit 1
   fi
 done
+
+MVN="${SCRIPTDIR}/mvnw"
+if [ ! -x "$MVN" ]; then
+  MVN="mvn"
+  if ! command -v mvn >/dev/null 2>&1; then
+    echo "ERROR: neither ${SCRIPTDIR}/mvnw nor mvn found on PATH"
+    exit 1
+  fi
+fi
 
 PREVIEW_REF="$SCRIPTDIR/.blog-preview-last-run"
 PORT="${QUARKUS_HTTP_PORT:-8080}"
@@ -48,34 +57,53 @@ post_slug() {
   echo "$filename" | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//; s/\.\(asciidoc\|adoc\|md\)$//'
 }
 
+# --- Port conflict check ---
+
+port_in_use() {
+  curl --connect-timeout 1 --max-time 2 -s -o /dev/null "http://127.0.0.1:${1}" 2>/dev/null
+}
+
+if port_in_use "$PORT"; then
+  echo "ERROR: Port ${PORT} is already in use. Set QUARKUS_HTTP_PORT to a free port and retry."
+  exit 1
+fi
+
 # --- Start dev server in background ---
 
 echo "=== Starting preview server (noguides profile) ==="
-QUARKUS_HTTP_PORT="$PORT" QUARKUS_PROFILE=noguides mvn quarkus:dev "$@" &
+QUARKUS_HTTP_PORT="$PORT" QUARKUS_PROFILE=noguides "$MVN" quarkus:dev "$@" &
 SERVER_PID=$!
 
 cleanup() {
-  kill "$SERVER_PID" 2>/dev/null
-  wait "$SERVER_PID" 2>/dev/null
+  local pid="$SERVER_PID"
+  SERVER_PID=""
+  [ -n "$pid" ] && kill "$pid" 2>/dev/null && wait "$pid" 2>/dev/null
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # --- Wait for server to be ready ---
 
+TIMEOUT=300
 echo "  Waiting for server on port ${PORT}..."
 START=$(date +%s)
 while true; do
+  ELAPSED=$(( $(date +%s) - START ))
+  if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    echo "  Timeout after ${TIMEOUT}s waiting for server."
+    exit 1
+  fi
   if ! kill -0 "$SERVER_PID" 2>/dev/null; then
     echo "  Server process exited unexpectedly."
     exit 1
   fi
-  if [ "$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}" 2>/dev/null)" = "200" ]; then
-    ELAPSED=$(( $(date +%s) - START ))
+  if [ "$(curl --connect-timeout 1 --max-time 2 -s -o /dev/null -w '%{http_code}' "${BASE_URL}" 2>/dev/null)" = "200" ]; then
     printf '  Ready in %ds\n' "$ELAPSED"
     break
   fi
   if [ -t 1 ]; then
-    printf '\r  Waiting... %ds ' "$(( $(date +%s) - START ))"
+    printf '\r  Waiting... %ds ' "$ELAPSED"
   fi
   sleep 2
 done
@@ -134,7 +162,8 @@ else
   echo "No recent changes detected."
 fi
 
-touch "$PREVIEW_REF" || true
+touch "$PREVIEW_REF" \
+  || echo "WARNING: Could not update .blog-preview-last-run — next-run change detection may be inaccurate."
 
 echo ""
 if [ -n "$BROWSER_CMD" ]; then
@@ -155,5 +184,5 @@ echo "Preview is running. Edit a post and save — Roq will rebuild automaticall
 echo "Press Ctrl-C to stop."
 echo ""
 
-# Bring server to foreground so Ctrl-C reaches it naturally
+# Wait for the server process to finish (keeps the script alive for Ctrl-C).
 wait "$SERVER_PID"

--- a/serve-noguides.sh
+++ b/serve-noguides.sh
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit 1
+cd "$SCRIPTDIR" || exit 1
 echo "WARNING: Serving site with no guides. It is fast though!"
-QUARKUS_PROFILE=noguides ${SCRIPTDIR}/mvnw quarkus:dev "$@"
+QUARKUS_PROFILE=noguides "${SCRIPTDIR}/mvnw" quarkus:dev "$@"

--- a/serve-only-latest-guides.sh
+++ b/serve-only-latest-guides.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-pushd "${SCRIPTDIR}"
+SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit 1
+cd "$SCRIPTDIR" || exit 1
 echo "WARNING: Serving site with only the latest guides (latest and main)"
-QUARKUS_PROFILE=only-latest-guides ${SCRIPTDIR}/mvnw quarkus:dev "$@"
-popd
+QUARKUS_PROFILE=only-latest-guides "${SCRIPTDIR}/mvnw" quarkus:dev "$@"

--- a/serve.sh
+++ b/serve.sh
@@ -1,3 +1,4 @@
-#!/bin/sh
-SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-${SCRIPTDIR}/mvnw quarkus:dev "$@"
+#!/bin/bash
+SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit 1
+cd "$SCRIPTDIR" || exit 1
+"${SCRIPTDIR}/mvnw" quarkus:dev "$@"


### PR DESCRIPTION
Follow-up to Holly's PR #2862 (merged Aug 28). Supersedes the now-closed #2960 — same content, rebased cleanly onto `upstream/main` after the merge.

## What's fixed

### `blog-preview.sh` (improvements over what #2862 merged)
- **Use `./mvnw`** instead of bare `mvn`; validate the fallback is on PATH with a clear error
- **Add `java` to early dependency check** — fails fast before Maven starts
- **Port-in-use pre-check** before starting Maven — fail fast instead of accepting an unrelated HTTP 200 as Roq readiness
- **Bounded `curl`** — `--connect-timeout 1 --max-time 2` on every request so a stale listener cannot block the loop
- **300s timeout** on the readiness loop
- **Idempotent cleanup + separated traps**: `EXIT` fires cleanup, `INT` exits 130, `TERM` exits 143 — no double-kill on Ctrl-C
- **Warn on `touch` failure** instead of silently discarding
- **Fix comment**: `wait` keeps the shell alive; it does not bring the process to the foreground

### `serve.sh` / `serve-noguides.sh` / `serve-only-latest-guides.sh`
- **Fix `#!/bin/sh` → `#!/bin/bash`** — `${BASH_SOURCE[0]}` is bash-specific; fails on dash (default `/bin/sh` on Ubuntu)
- **Define `SCRIPTDIR` in `serve-noguides.sh`** — was used but never set, expanding to `/mvnw` (exit 127 on every run)
- **Add `cd "$SCRIPTDIR"`** — Maven must run from the project root to find `pom.xml` when invoked from outside the repo
- **Quoted `"${SCRIPTDIR}/mvnw"`** consistently
- **Remove `pushd`/`popd`** from `serve-only-latest-guides.sh` (superseded by `cd "$SCRIPTDIR"`)

## Validation
- `bash -n`: ✅ all four scripts
- `shellcheck`: ✅ no diagnostics