### PR TITLE
Update building-blog skill for Roq migration

### DIFF
--- a/.agents/skills/building-blog/SKILL.md
+++ b/.agents/skills/building-blog/SKILL.md
@@ -2,7 +2,9 @@
 name: building-blog
 description: >
   How to preview blog posts locally using the Roq-based dev server:
-  start the site with serve-noguides.sh for fast iteration.
+  blog-preview.sh detects your changed posts and opens them automatically
+  in your default browser; serve-noguides.sh starts the server only,
+  for when you prefer to navigate to the URL yourself.
 ---
 
 # Building Blog Posts
@@ -10,12 +12,14 @@ description: >
 ## Supported Platforms
 
 This workflow is supported on Linux, macOS, and Windows through WSL2.
-Java 21+ and Maven (or the included `./mvnw` wrapper) are required.
+Java 21+ is required. The repository includes a `./mvnw` wrapper — no
+separate Maven install is needed.
 
 ## Quick Start
 
-Run the full preview pipeline in one command — starts the dev server, detects which
-posts you changed, and opens the right URLs in your browser:
+Run the full preview pipeline in one command — starts the Roq dev
+server, waits for it to be ready, detects which posts you changed, and
+opens the right URLs in your browser:
 
 ```bash
 just blog-preview
@@ -27,7 +31,7 @@ Or directly:
 bash blog-preview.sh
 ```
 
-To just start the dev server without the auto-open behaviour:
+To start the dev server without the auto-open behaviour:
 
 ```bash
 ./serve-noguides.sh
@@ -38,12 +42,13 @@ Then browse to [http://localhost:8042/blog/](http://localhost:8042/blog/).
 ## How It Works
 
 The site is built with [Quarkus Roq](https://docs.quarkiverse.io/quarkus-roq/dev/index.html),
-a Quarkus-based static site generator. Running `mvn quarkus:dev` starts a live-reload
-dev server — edits to content files are picked up automatically without a server restart.
+a Quarkus-based static site generator. `./mvnw quarkus:dev` starts a
+live-reload dev server — edits to content files are picked up
+automatically without a server restart.
 
-`blog-preview.sh` starts the dev server in the background, waits for it to be ready,
-then detects recently changed posts and opens the right URLs in your browser before
-bringing the server to the foreground. Press Ctrl-C to stop.
+`blog-preview.sh` starts the dev server in the background, waits for
+it to be ready (up to 300 seconds), then detects recently changed posts
+and opens the right URLs in your browser. Press Ctrl-C to stop.
 
 ### Detect and Open
 
@@ -56,10 +61,12 @@ The script auto-detects what you were working on and opens the right page:
 | 5+ posts | `/blog/` (listing only), unless git narrows it |
 | No changes | `/blog/` (listing only) |
 
-The slug is derived from the filename: strip the `YYYY-MM-DD-` prefix and the file extension.
+The slug is derived from the filename: strip the `YYYY-MM-DD-` prefix
+and the file extension (`.adoc`, `.asciidoc`, or `.md`).
 
-Change detection uses a `.blog-preview-last-run` timestamp file on repeat runs, and
-falls back to `git diff`/`git log` on first run. Delete `.blog-preview-last-run` to reset.
+Change detection uses a `.blog-preview-last-run` timestamp file on
+repeat runs, and falls back to `git diff`/`git log` on first run.
+Delete `.blog-preview-last-run` to reset.
 
 ### Profiles
 
@@ -77,32 +84,62 @@ For blog-only work, `serve-noguides.sh` is the fastest option.
 - Front matter fields: `layout: post`, `title`, `tags`, `synopsis`, `author`
 - `author` must match a key in `_data/authors.yaml`
 - Tags: lowercase, space-separated — e.g. `tags: extension kafka`
-- Images: store in `public/assets/images/posts/<slug>/`, reference with `:imagesdir: /assets/images/posts/<slug>`
+- Images: store in `public/assets/images/posts/<slug>/`, reference with
+  `:imagesdir: /assets/images/posts/<slug>`
 
 ## Future-Dated Posts
 
-Posts with a `date` value in the future are served normally by the local dev server.
-No special flag or workaround is needed — just run `./serve-noguides.sh` and the post will appear.
+Posts with a `date` value in the future are served normally by the
+local dev server. No special flag or workaround is needed.
 
 ## Iteration Loop
 
 ```
-Edit content/posts/YYYY-MM-DD-slug.adoc → save → Roq rebuilds → browser refreshes
+Edit content/posts/YYYY-MM-DD-slug.adoc (or .asciidoc / .md) → save → Roq rebuilds → browser refreshes
 ```
 
-Quarkus dev mode watches for file changes and triggers an incremental rebuild automatically.
+Quarkus dev mode watches for file changes and triggers an incremental
+rebuild automatically.
 
 ## Troubleshooting
 
-**Port 8042 already in use** — Another process is occupying the default port.
-Pass a different port: `./serve-noguides.sh -Dquarkus.http.port=8081`.
+**Port already in use** — Both `blog-preview.sh` and `./serve-noguides.sh`
+default to port 8042.
+First, check whether it is a leftover preview from a previous run
+(e.g. a `java` process launched by `mvnw`). If so, kill it and retry.
+**Always tell the user before using a different port** — do not
+silently switch ports without informing them. If the conflict cannot
+be resolved, ask the user which port to use, then set the environment
+variable:
 
-**Changes not appearing** — Quarkus dev mode watches source files. If a change is not picked
-up, press `s` in the terminal running the dev server to force a restart, or stop and re-run
-`./serve-noguides.sh`.
+```bash
+QUARKUS_HTTP_PORT=8081 bash blog-preview.sh
+```
 
-**Post not appearing** — Check that the file is in `content/posts/` with the correct
-`YYYY-MM-DD-slug.adoc` naming and that the front matter `layout: post` and `author` fields
+or for the bare server:
+
+```bash
+QUARKUS_HTTP_PORT=8081 ./serve-noguides.sh
+```
+
+**Changes not appearing** — Quarkus dev mode watches source files. If a
+change is not picked up, press `s` in the terminal running the dev
+server to force a restart, or stop and re-run `./serve-noguides.sh`.
+
+**Post not appearing** — Check that the file is in `content/posts/`
+with the correct `YYYY-MM-DD-slug.adoc` (or `.asciidoc`, `.md`)
+naming and that the front matter `layout: post` and `author` fields
 are present and valid.
 
-**Slow first start** — The first run downloads Maven dependencies. Subsequent starts are fast.
+**Slow first start** — The first run downloads Maven dependencies.
+Subsequent starts are fast.
+
+**`blog-preview.sh` exits with "Server process exited unexpectedly"**
+— Maven started but then died. Scroll up in the terminal to find the
+build error. Common causes: corrupted local Maven repository, a
+missing or broken dependency, or a compile error in the project.
+
+**`blog-preview.sh` exits with "neither mvnw nor mvn found"** — The
+`./mvnw` wrapper is missing or not executable. Run `chmod +x mvnw`
+to restore it. Do not attempt to install Maven system-wide — the
+wrapper is the correct entry point for this project.

--- a/blog-preview.sh
+++ b/blog-preview.sh
@@ -19,7 +19,7 @@ if [ ! -x "$MVN" ]; then
 fi
 
 PREVIEW_REF="$SCRIPTDIR/.blog-preview-last-run"
-PORT="${QUARKUS_HTTP_PORT:-8080}"
+PORT="${QUARKUS_HTTP_PORT:-8042}"
 BASE_URL="http://127.0.0.1:${PORT}"
 
 # --- Environment detection ---


### PR DESCRIPTION
The `building-blog` skill was originally written for the old Jekyll/container-based preview pipeline. Now that the site has migrated to Quarkus Roq (PR #2862), the skill needs to accurately reflect the new stack.

## What's changed

### `.agents/skills/building-blog/SKILL.md`

- **Description** — updated to mention `blog-preview.sh` auto-open behaviour (the key feature), not just `serve-noguides.sh`
- **Prerequisites** — clarified: Java 21+ required, `./mvnw` wrapper included so no separate Maven install is needed
- **How It Works** — references `./mvnw quarkus:dev` instead of bare `mvn`; removes the inaccurate claim that the script "brings the server to the foreground" (`wait` keeps the shell alive, not the same thing); mentions the 300s readiness timeout
- **Port override troubleshooting** — fixed: the correct way to change the port is `QUARKUS_HTTP_PORT=8081 bash blog-preview.sh`, not `-Dquarkus.http.port=8081` (the `-D` form goes to Maven but the readiness probe continues polling the original port)
- **New troubleshooting entries** — "Server process exited unexpectedly" and "neither mvnw nor mvn found" — both possible now that `blog-preview.sh` validates Maven availability