### PR TITLE
Firefox SVG homepage fix for supporters band

### DIFF
--- a/web/includes/_homepage-benefactors-band.scss
+++ b/web/includes/_homepage-benefactors-band.scss
@@ -15,9 +15,9 @@
     justify-content: center;
     
     img {
-      max-height: 150px;
-      width: 100%;
-      max-width: 300px;
+      height: 100px;
+      width: auto;
+      max-width: 100%;
       object-fit: contain;
       padding: 1rem;
 


### PR DESCRIPTION
Resolves #2918 
This is the fox for the too small supporters logos (svg) on the home page on firefox. 

Tested on firefox, chrome and safari.