### PR TITLE
Insights: Fix incorrect links to previous episodes

### DIFF
--- a/_data/insights-videos.yaml
+++ b/_data/insights-videos.yaml
@@ -41,11 +41,11 @@ pastvideos:
 - title: 'Episode #257: Taming the JVM: Optimizing Java Workloads on OpenShift & Kubernetes'
   date: August 31st, 2026
   authors: Rob Sedor
-  link: https://www.youtube.com/watch?v=SvjxzODWPzA
+  link: https://youtube.com/live/UQWcXTB6Cfg
 - title: 'Episode #256: What is Floci?'
   date: August 10th, 2026
   authors: Hector Ventura
-  link: https://www.youtube.com/watch?v=Nudqk1DM7fM
+  link: https://youtube.com/live/VFYZUZbjzd4
 - title: "Episode #255 - Faster, Leaner, Predictable: Quarkus in the real world"
   link: https://youtube.com/live/BWr3NXgMQds
   date: "August 3rd, 2026"


### PR DESCRIPTION
The new workflow to automatically update the Quarkus Insights page uses the wrong links for the episodes.

The two posted using the workflow links to the last short instead of the proper episode URL. 

Episode #257: Taming the JVM: Optimizing Java Workloads on OpenShift & Kubernetes
Currently links to this short: https://www.youtube.com/watch?v=SvjxzODWPzA

Episode #256: What is Floci?
Currently links to this short: https://www.youtube.com/watch?v=Nudqk1DM7fM

This PR is a temp fix for the incorrect links but doesn't address the underlaying workflow issue.