### PR TITLE
Bump Roq

### DIFF
--- a/patches/apply-roq-include-fix.sh
+++ b/patches/apply-roq-include-fix.sh
@@ -14,7 +14,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Extract the Roq version from pom.xml
 ROQ_VERSION=$(grep -m1 -oP '(?<=quarkus-roq-plugin-asciidoc-jruby</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
   || grep -oP '(?<=quarkus-roq</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
-  || echo "2.1.8")
+  || echo "2.1.9")
 
 ROQ_JAR="$HOME/.m2/repository/io/quarkiverse/roq/quarkus-roq-plugin-asciidoc-jruby/$ROQ_VERSION/quarkus-roq-plugin-asciidoc-jruby-$ROQ_VERSION.jar"
 MARKER="$ROQ_JAR.patched-issue-2939"

--- a/patches/apply-roq-include-fix.sh
+++ b/patches/apply-roq-include-fix.sh
@@ -14,7 +14,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Extract the Roq version from pom.xml
 ROQ_VERSION=$(grep -m1 -oP '(?<=quarkus-roq-plugin-asciidoc-jruby</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
   || grep -oP '(?<=quarkus-roq</artifactId>\s{0,99}<version>)[^<]+' "$PROJECT_DIR/pom.xml" \
-  || echo "2.1.7")
+  || echo "2.1.8")
 
 ROQ_JAR="$HOME/.m2/repository/io/quarkiverse/roq/quarkus-roq-plugin-asciidoc-jruby/$ROQ_VERSION/quarkus-roq-plugin-asciidoc-jruby-$ROQ_VERSION.jar"
 MARKER="$ROQ_JAR.patched-issue-2939"

--- a/patches/pom.xml
+++ b/patches/pom.xml
@@ -16,7 +16,7 @@
         <quarkus.platform.version>3.38.3</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <roq.version>2.1.7</roq.version>
+        <roq.version>2.1.8</roq.version>
     </properties>
 
     <dependencyManagement>

--- a/patches/pom.xml
+++ b/patches/pom.xml
@@ -16,7 +16,7 @@
         <quarkus.platform.version>3.38.3</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <roq.version>2.1.8</roq.version>
+        <roq.version>2.1.9</roq.version>
     </properties>
 
     <dependencyManagement>
@@ -28,7 +28,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- TODO drop this override once Roq 2.1.8 is available -->
+            <!-- TODO drop this override once Roq 2.1.9 is available -->
             <dependency>
                 <groupId>io.yupiik.maven</groupId>
                 <artifactId>asciidoc-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <quarkus.platform.version>3.38.3</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <roq.version>2.1.7</roq.version>
+        <roq.version>2.1.8</roq.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <quarkus.platform.version>3.38.3</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <roq.version>2.1.8</roq.version>
+        <roq.version>2.1.9</roq.version>
     </properties>
 
     <dependencyManagement>

--- a/roq-plugin-toc/pom.xml
+++ b/roq-plugin-toc/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.version>3.38.3</quarkus.version>
-        <roq.version>2.1.7</roq.version>
+        <roq.version>2.1.8</roq.version>
         <jsoup.version>1.22.2</jsoup.version>
         <assertj.version>3.27.7</assertj.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/roq-plugin-toc/pom.xml
+++ b/roq-plugin-toc/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.version>3.38.3</quarkus.version>
-        <roq.version>2.1.8</roq.version>
+        <roq.version>2.1.9</roq.version>
         <jsoup.version>1.22.2</jsoup.version>
         <assertj.version>3.27.7</assertj.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>


### PR DESCRIPTION
See  https://github.com/quarkusio/quarkusio.github.io/pull/2955

I'm expecting this to fail with some dead links, but will do a CI run to be sure.

Confirmed failing, but not in the way I was expecting: 27 failures of the form 

```
404 http://localhost:8090/https:/quarkus.io/guides/deploying-to-kubernetes/ ← http://localhost:8090/guides/init-tasks/
```

(single slash instead of double after https)

https://github.com/quarkusio/quarkusio.github.io/pull/2947/changes didn't seem to cause problems.

Edit: I've raised a Roq PR with a fix, waiting for a new Roq release.