### PR TITLE
Adjust port to 8042, show future posts in dev mode

### DIFF
--- a/.agents/skills/building-blog/SKILL.md
+++ b/.agents/skills/building-blog/SKILL.md
@@ -33,7 +33,7 @@ To just start the dev server without the auto-open behaviour:
 ./serve-noguides.sh
 ```
 
-Then browse to [http://localhost:8080/blog/](http://localhost:8080/blog/).
+Then browse to [http://localhost:8042/blog/](http://localhost:8042/blog/).
 
 ## How It Works
 
@@ -94,7 +94,7 @@ Quarkus dev mode watches for file changes and triggers an incremental rebuild au
 
 ## Troubleshooting
 
-**Port 8080 already in use** — Another process is occupying the default port.
+**Port 8042 already in use** — Another process is occupying the default port.
 Pass a different port: `./serve-noguides.sh -Dquarkus.http.port=8081`.
 
 **Changes not appearing** — Quarkus dev mode watches source files. If a change is not picked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ guidance before starting work:
 ./serve-only-latest-guides.sh  # only latest + main guides
 ```
 
-Requires Java 21+. Site is served at http://localhost:8080.
+Requires Java 21+. Site is served at http://localhost:8042.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These instructions will get you a copy of the Quarkus.io website up and running 
     ```sh
     ./serve.sh
     ```
-    This runs `mvn quarkus:dev` and serves the full site (including guides) at [http://localhost:8080](http://localhost:8080).
+    This runs `mvn quarkus:dev` and serves the full site (including guides) at [http://localhost:8042](http://localhost:8042).
 
     For a faster startup without guides:
     ```sh
@@ -39,7 +39,7 @@ These instructions will get you a copy of the Quarkus.io website up and running 
 > The startup process may take a minute or two on the first run while Maven downloads dependencies and Roq generates the site. Subsequent starts are faster. Once ready, you will see output like:
 >
 > ```
-> Listening on: http://0.0.0.0:8080
+> Listening on: http://0.0.0.0:8042
 > ```
 
  If an error occurs mentioning a name conflict, try:

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,3 +1,5 @@
+quarkus.http.port=8042
+quarkus.http.test-port=8043
 quarkus.asciidoc.attributes."!showtitle"=true
 quarkus.asciidoc.attributes.add-copy-button-to-config-props=true
 quarkus.asciidoc.attributes.add-copy-button-to-env-var=true
@@ -23,6 +25,10 @@ site.collections.versions.layout=guides
 # Trailing slash works around https://github.com/quarkiverse/quarkus-web-bundler/issues/473
 site.collections.versions.link=/version/:dir[1]/:name/
 site.date-format=yyyy-MM-dd['T'HH:mm:ss][X]
+%dev.site.draft=true
+%dev.site.future=true
+%test.site.draft=true
+%test.site.future=true
 site.escaped-pages=guides/**,versions/**
 site.url=https://quarkus.io
 site.ignored-files=**/_**,_**,**/!(.well\\\\-known)**.**


### PR DESCRIPTION
@cescoffier pointed out we lost the ability to see future posts in dev mode. I've added that back for dev mode, and also test mode.

I've also adjusted the port to 8042 to avoid conflicts with other Quarkus apps.