### PR TITLE
Contributing instructions: Do not ask for duplicate dates in blog frontmatter

### DIFF
--- a/.agents/skills/building-blog/SKILL.md
+++ b/.agents/skills/building-blog/SKILL.md
@@ -74,7 +74,7 @@ For blog-only work, `serve-noguides.sh` is the fastest option.
 ## Blog Post File Conventions
 
 - Location: `content/posts/YYYY-MM-DD-slug.adoc` (or `.asciidoc`, `.md`)
-- Front matter fields: `layout: post`, `title`, `date`, `tags`, `synopsis`, `author`
+- Front matter fields: `layout: post`, `title`, `tags`, `synopsis`, `author`
 - `author` must match a key in `_data/authors.yaml`
 - Tags: lowercase, space-separated — e.g. `tags: extension kafka`
 - Images: store in `public/assets/images/posts/<slug>/`, reference with `:imagesdir: /assets/images/posts/<slug>`

--- a/.agents/skills/release-announcement/SKILL.md
+++ b/.agents/skills/release-announcement/SKILL.md
@@ -117,7 +117,6 @@ content/posts/YYYY-MM-DD-quarkus-<major>-<minor>-released.adoc
 
 For example: `content/posts/2026-09-30-quarkus-3-39-released.adoc`
 
-The date in the filename **must match** the `date` in the front matter.
 
 ### Front matter
 
@@ -125,7 +124,6 @@ The date in the filename **must match** the `date` in the front matter.
 ---
 layout: post
 title: 'Quarkus <version> - <headline features summary>'
-date: YYYY-MM-DD
 tags: release
 synopsis: 'We released Quarkus <version>, which comes with <brief feature list>.'
 author: gsmet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ Requires Java 21+. Site is served at http://localhost:8080.
 
 ## Blog Post Conventions
 
-- Location: `content/posts/YYYY-MM-DD-slug.adoc` (date must match front matter `date`)
-- Front matter: `layout: post`, `title`, `date`, `tags`, `synopsis`, `author`
+- Location: `content/posts/YYYY-MM-DD-slug.adoc`
+- Front matter: `layout: post`, `title`, `tags`, `synopsis`, `author`
 - Author must be defined in `_data/authors.yaml`
 - Tags: lowercase, space-separated
 - Permalink pattern: `/blog/:Name/` (configured in `config/application.properties`)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To write a blog:
   - `emailhash` you can get by running `echo -n your@email.org | md5sum` on Linux or `echo -n your@email.org | md5` on macOS using an email you have registered from the [Gravatar service](https://gravatar.com),
 
 - create a blog entry under [content/posts](https://github.com/quarkusio/quarkusio.github.io/tree/main/content/posts)
-  - the file name is `yyyy-mm-dd-slug.adoc`. Set the `date` to the same value in the front matter.
+  - the file name is `yyyy-mm-dd-slug.adoc` (the publication date of the blog).
 - `tags` should be used with some care as an archive page is created for each of them. Below are some basic rules to try to follow:
   - `quarkus-release` used for Quarkus release blogs
   - `announcement` used for general announcements with some impact.
@@ -117,7 +117,7 @@ To write a blog:
   - tags is a space-separated list: `tags: extension grpc`
   - tags must be in lowercase
 - it's in asciidoc format, there is an example at [2019-06-05-quarkus-and-web-ui-development-mode.adoc](https://github.com/quarkusio/quarkusio.github.io/blob/main/content/posts/2019-06-05-quarkus-and-web-ui-development-mode.adoc)
-  - Be aware that the `date` attribute in the front matter defines when the article will be published. Posts with a future date will not be visible in production until that date arrives; use `./serve.sh` locally to preview them regardless of date.
+  - Be aware that the `date` attribute in the file name defines when the article will be published. Posts with a future date will not be visible in production until that date arrives; use dev mode or `./serve.sh` locally to preview them regardless of date.
 - send a pull request against the main branch and voilà
 
 


### PR DESCRIPTION
Even on Jekyll, there was no need to put a date in the frontmatter, as long as there was one in the filename. This is also true on Roq. I've updated the instructions to be DRY-er. This is nice since contributors sometimes have to adjust the date a few times.