### PR TITLE
Make blogging process clearer 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,5 @@ Contributions are welcome, please submit pull requests for the `main` branch.
 
 **Important:** the guides are maintained in the main Quarkus repository and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc.
+
+Please see the README for instructions on [running the site locally](https://github.com/quarkusio/quarkusio.github.io/#running-locally) and [contributing a blog](https://github.com/quarkusio/quarkusio.github.io/#writing-a-blog).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If for some reason you need to deploy from your local machine, follow these inst
 
 > [!WARNING]
 > Using generative AI in *assisting* writing is fine, but please don't use it to write entire posts.
-> Used badly, generative AI has a tendency to use complex words and phrasing. This makes the content hard to read and understand. Always review your blog with a human reader in mind, make sure it's factually correct and especially keep the human touch and opinions in the content.
+> Used badly, generative AI has a tendency to use complex words and phrasing. This makes the content hard to read and understand. Always review your blog with a human reader in mind, make sure it's factually correct and especially keep the human touch and opinions in the content. We want _your_ voice!
 
 To write a blog:
 

--- a/content/blog.md
+++ b/content/blog.md
@@ -6,3 +6,4 @@ paginate:
   size: 10
   link: blog/page/:page
 ---
+

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -5,3 +5,4 @@ layout: base
 {#include partials/title-band.html _unisolated /}
 
 {#include partials/blog-band.html _unisolated /}
+

--- a/templates/partials/blog-band.html
+++ b/templates/partials/blog-band.html
@@ -1,4 +1,10 @@
+
+
 {#let _m=mut:map()}<div class="blog-page grid-wrapper">
+    <div class="grid__item width-9-12 width-12-12-m encouragement">
+        The Quarkus blog is part of our community. We want your Quarkus stories, expertise, and ecosystem news! See <a href="https://github.com/quarkusio/quarkusio.github.io/#writing-a-blog">the site source</a> for instructions on contributing a blog.
+    </div>
+
   <div class="grid__item width-9-12 width-12-12-m">
     <div>
       {#for post in site.collections.get('posts').paginated(page.paginator).orEmpty}

--- a/web/layouts/_blog.scss
+++ b/web/layouts/_blog.scss
@@ -170,6 +170,11 @@ body.post {
   }
 }
 
+.encouragement {
+  font-style: italic;
+  padding-top: 1em;
+}
+
 .post-page {
 
   .byline-wrapper {


### PR DESCRIPTION
People sometimes ask on zulip if they're allowed to write blogs, which makes me think we don't do a good enough job of making it obvious they are. We also don't have any google-find-able instructions for writing a blog. I've added something on the main blog page to solicit contributions and done a bit of cross-linking in the source markdown docs. 

<img width="1131" height="456" alt="image" src="https://github.com/user-attachments/assets/cea10b28-e7b8-46d5-b21c-a43a2623d1ad" />
