### PR TITLE
Remove Jekyll from CI and remaining readme references

### DIFF
--- a/.agents/skills/release-announcement/SKILL.md
+++ b/.agents/skills/release-announcement/SKILL.md
@@ -250,8 +250,7 @@ the user specifically asks.
 
 After creating the post and updating versions, suggest the user preview
 locally. The blog preview skill (`.agents/skills/building-blog/SKILL.md`)
-has full instructions — but note that the preview infrastructure may
-still be Jekyll-based. If `just blog-preview` or `blog-preview.sh` are
+has full instructions. If `just blog-preview` or `blog-preview.sh` are
 available, use them. Otherwise, the Roq dev mode can be started with:
 
 ```bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
 
           RSYNC_OUT=$(rsync -rcn --out-format='%n' \
             --include='*/' --include='*.html' --exclude='*' \
-            ${{ steps.detect.outputs.site_dir }}/ /tmp/gh-pages/ 2>/dev/null) || {
+            target/roq/ /tmp/gh-pages/ 2>/dev/null) || {
             echo "mode=full" >> $GITHUB_OUTPUT
             echo "Site comparison failed, running full link check"
             git worktree remove /tmp/gh-pages 2>/dev/null || true
@@ -273,11 +273,11 @@ jobs:
           fi
 
       - name: Store PR id
-        run: echo ${{ github.event.number }} > ./${{ steps.detect.outputs.site_dir }}/pr-id.txt
+        run: echo ${{ github.event.number }} > ./target/roq/pr-id.txt
 
       - name: Reduce the size of the website to be compatible with surge
         run: |
-          SITE_DIR="${{ steps.detect.outputs.site_dir }}"
+          SITE_DIR="target/roq"
           # Keep only the 10 most recent newsletter editions (by number)
           if [ -d "$SITE_DIR/newsletter" ]; then
             ls -1 "$SITE_DIR/newsletter" | sort -n | head -n -10 | while read -r dir; do
@@ -323,7 +323,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: site
-          path: ./${{ steps.detect.outputs.site_dir }}
+          path: ./target/roq
           retention-days: 3
 
   build-report:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,42 +21,12 @@ jobs:
           fetch-depth: 5000
           fetch-tags: false
 
-      - name: Detect site generator
-        id: detect
-        run: |
-          if [ -f "Gemfile" ]; then
-            echo "jekyll=true" >> $GITHUB_OUTPUT
-            echo "site_dir=_site" >> $GITHUB_OUTPUT
-          else
-            echo "jekyll=false" >> $GITHUB_OUTPUT
-          fi
-          if [ -f "config/application.properties" ]; then
-            echo "roq=true" >> $GITHUB_OUTPUT
-            echo "site_dir=target/roq" >> $GITHUB_OUTPUT
-          else
-            echo "roq=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set up ruby
-        if: steps.detect.outputs.jekyll == 'true'
-        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
-        with:
-          ruby-version: 3.2.3
-
       - name: Set up JDK
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
-
-      - name: Cache Ruby gems
-        if: steps.detect.outputs.jekyll == 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: ${{ runner.os }}-gems-
 
       - name: Cache npm packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -77,18 +47,7 @@ jobs:
       - name: Restore mtime
         run: ./tools/git-restore-mtime
 
-      - name: Install Ruby dependencies
-        if: steps.detect.outputs.jekyll == 'true'
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      - name: Build Jekyll site
-        if: steps.detect.outputs.jekyll == 'true'
-        run: bundle exec jekyll build --future --config _config.yml,_only_latest_guides_config.yml
-
       - name: Build TOC plugin
-        if: steps.detect.outputs.roq == 'true'
         run: ./roq-plugin-toc/build.sh
 
       - name: Detect infra changes
@@ -111,7 +70,6 @@ jobs:
           fi
 
       - name: Build with Maven
-        if: steps.detect.outputs.roq == 'true'
         run: |
           export QUARKUS_ROQ_GENERATOR_BATCH=true
           if [ "${{ steps.infra.outputs.include_versions }}" != "true" ]; then
@@ -126,19 +84,9 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps --only-shell chromium"
 
-      # Jekyll serve handles extensionless URLs (e.g. /guides/getting-started)
-      # the same way GitHub Pages does; a plain HTTP server would 404 on them.
-      - name: Start Jekyll test server
-        if: steps.detect.outputs.jekyll == 'true'
-        run: |
-          bundle exec jekyll serve --port 8090 --no-watch --skip-initial-build &
-          timeout 30 bash -c 'until curl -s http://localhost:8090 > /dev/null 2>&1; do sleep 0.5; done'
-
       - uses: jbangdev/setup-jbang@main
-        if: steps.detect.outputs.roq == 'true'
 
       - name: Start Java test server
-        if: steps.detect.outputs.roq == 'true'
         run: |
           jbang trust add https://repo1.maven.org/maven2/io/quarkiverse/roq/quarkus-roq-cli/
           jbang roq@quarkiverse/quarkus-roq serve target/roq/ -p 8090 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,46 +26,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Detect site generator
-        id: detect
-        run: |
-          if [ -f "Gemfile" ]; then
-            echo "jekyll=true" >> $GITHUB_OUTPUT
-            echo "site_dir=_site" >> $GITHUB_OUTPUT
-          else
-            echo "jekyll=false" >> $GITHUB_OUTPUT
-          fi
-          if [ -f "config/application.properties" ]; then
-            echo "roq=true" >> $GITHUB_OUTPUT
-            echo "site_dir=target/roq" >> $GITHUB_OUTPUT
-          else
-            echo "roq=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set up ruby
-        if: steps.detect.outputs.jekyll == 'true'
-        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
-        with:
-          ruby-version: 3.2.3
-
-      - name: Cache Ruby gems
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: ${{ runner.os }}-gems-
-      - name: Install dependencies
-        if: steps.detect.outputs.jekyll == 'true'
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      - name: Build Jekyll site
-        if: steps.detect.outputs.jekyll == 'true'
-        run: bundle exec jekyll build
 
       - name: Set up JDK
-        if: steps.detect.outputs.roq == 'true'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '25'
@@ -73,17 +35,15 @@ jobs:
           cache: 'maven'
 
       - name: Build TOC plugin
-        if: steps.detect.outputs.roq == 'true'
         run: ./roq-plugin-toc/build.sh
 
       - name: Build with Maven
-        if: steps.detect.outputs.roq == 'true'
         run: QUARKUS_ROQ_GENERATOR_BATCH=true mvn -B package quarkus:run -DskipTests
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v4.0.1
         with:
-          path: ./${{ steps.detect.outputs.site_dir }}
+          path: ./target/roq
           include-hidden-files: true
       - name: Deploy to GitHub Pages
         id: deploy
@@ -93,7 +53,7 @@ jobs:
       - name: Sync gh-pages branch
         run: |
           SITE_DIR=$(mktemp -d)
-          rsync -a ./${{ steps.detect.outputs.site_dir }}/ "$SITE_DIR"
+          rsync -a ./target/roq/ "$SITE_DIR"
           
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -104,7 +64,7 @@ jobs:
 
           rsync -a --delete --exclude='.git' --exclude='.nojekyll' "$SITE_DIR"/ .
           git add -A
-          git rm -rf --cached --ignore-unmatch ${{ steps.detect.outputs.site_dir }}
+          git rm -rf --cached --ignore-unmatch target/roq
 
           git commit --allow-empty -m "deploy: ${{ github.sha }}"
           git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These instructions will get you a copy of the Quarkus.io website up and running 
 > Listening on: http://0.0.0.0:8042
 > ```
 
-5. Now browse to [http://localhost:4000](http://localhost:4000).
+5. Now browse to [http://localhost:8042](http://localhost:8042).
 
 
 ### Deploying to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -42,49 +42,8 @@ These instructions will get you a copy of the Quarkus.io website up and running 
 > Listening on: http://0.0.0.0:8042
 > ```
 
- If an error occurs mentioning a name conflict, try:
-```sh
-docker compose up --force-recreate
-```
-
 5. Now browse to [http://localhost:4000](http://localhost:4000).
-#### Using a local Ruby environment
-[Jekyll static site generator docs](https://jekyllrb.com/docs/).
 
-1. Install a full [Ruby development environment](https://jekyllrb.com/docs/installation/). If you use `rvm`, run: `rvm use 3.2.3`.
-2. Install [bundler](https://jekyllrb.com/docs/ruby-101/#bundler)  [gems](https://jekyllrb.com/docs/ruby-101/#gems)
-   ```sh
-   gem install bundler
-   ```
-3. Fork the [project repository](https://github.com/quarkusio/quarkusio.github.io), then clone your fork.
-   ```sh
-   git clone git@github.com:YOUR_USER_NAME/quarkusio.github.io.git
-   ```
-4. Change into the project directory:
-   ```sh
-   cd quarkusio.github.io
-   ```
-5. Use bundler to fetch all required gems in their respective versions
-   ```sh
-   bundle install
-   ```
-6. Build the site and make it available on a local server
-   ```sh
-   ./serve.sh
-   ```
-   Or if you want it faster and okay to not have guides included use the following:
-
-   ```sh
-   ./serve-noguides.sh
-   ```
-
-
-7. Now browse to http://localhost:4000
-
->[!NOTE]
->If you encounter any unexpected errors during the above, please refer to the [troubleshooting](https://jekyllrb.com/docs/troubleshooting/#configuration-problems) page or the [requirements](https://jekyllrb.com/docs/installation/#requirements) page, as you might be missing development headers or other prerequisites.
-
-**For more regarding the use of Jekyll, please refer to the [Jekyll Step by Step Tutorial](https://jekyllrb.com/docs/step-by-step/01-setup/).**
 
 ### Deploying to GitHub Pages
 


### PR DESCRIPTION
I think we're ready to get rid of Jekyll from the actions workflows. Note that the deploy change is risky because it doesn't get tested until we actually do a deploy. 

I've also tidied up some lingering references in the readme and skills.