### PR TITLE
Be more helpful with error message in BlogTest

### DIFF
--- a/src/test/java/io/quarkusio/BlogPageTest.java
+++ b/src/test/java/io/quarkusio/BlogPageTest.java
@@ -166,8 +166,10 @@ public class BlogPageTest extends BrowserTest {
 
             String bodyText = page.locator(".doc-content").first().textContent();
             List<String> findings = findUnrenderedMarkup(bodyText);
+            String fullUrl = href.startsWith("http") ? href : baseUrl + href;
             assertTrue(findings.isEmpty(),
-                    () -> "\"" + title + "\" (" + href + ") contains unrendered markup: " + String.join("; ", findings));
+                    () -> "\"" + title + "\" (" + href + ") contains unrendered markup: "
+                            + String.join("; ", findings) + " -- view in browser: " + fullUrl);
 
             page.navigate(baseUrl + BLOG_PATH);
         }


### PR DESCRIPTION
This is a test where users might break it with content changes, or infra changes might break it. So finding the right message is a bit tricky, but we can do better than we do now. 

@cescoffier says this message was not helpful:

> BlogPageTest.blogPostsDoNotContainUnrenderedMarkup:169 "Java 21: the foundation for Quarkus 4" (/blog/java21/) contains unrendered markup: AsciiDoc heading: "== T" ==> expected: <true> but was: <false> 
