### PR TITLE
Update dev mode port so tests pass

### DIFF
--- a/src/test/java/io/quarkusio/BrowserTest.java
+++ b/src/test/java/io/quarkusio/BrowserTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class BrowserTest {
 
-    static final String DEFAULT_BASE_URL = "http://localhost:8080";
+    static final String DEFAULT_BASE_URL = "http://localhost:8042";
 
     static Playwright playwright;
     static Browser browser;


### PR DESCRIPTION
When I changed the port, I forgot to update the tests. The tests were designed to work with both Roq and Jekyll, so don't use `QuarkusTest`. That can now change, but tactically, I'll just fix the port.