### PR TITLE
Add tests for files users might not see, but crawlers use

### DIFF
--- a/src/test/java/io/quarkusio/DnsVerificationTest.java
+++ b/src/test/java/io/quarkusio/DnsVerificationTest.java
@@ -1,0 +1,53 @@
+package io.quarkusio;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DnsVerificationTest extends BrowserTest {
+
+    @Override
+    @BeforeEach
+    void createContext() {
+    }
+
+    @Override
+    @AfterEach
+    void closeContext() {
+    }
+
+    @Test
+    void atprotoDidReturns200() throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/.well-known/atproto-did"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, response.statusCode(),
+                    "Expected 200 for /.well-known/atproto-did but got " + response.statusCode());
+        }
+    }
+
+    @Test
+    void atprotoDidContainsValidDid() throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/.well-known/atproto-did"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            String body = response.body().trim();
+            assertFalse(body.isEmpty(), "atproto-did should not be empty");
+            assertTrue(body.startsWith("did:"), "atproto-did should start with 'did:'");
+        }
+    }
+}

--- a/src/test/java/io/quarkusio/SitemapTest.java
+++ b/src/test/java/io/quarkusio/SitemapTest.java
@@ -119,4 +119,73 @@ public class SitemapTest extends BrowserTest {
         }
         assertTrue(foundHome, "Sitemap should include the home page URL (ending with /)");
     }
+
+    @Test
+    void sitemapHtmlReturns200() throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/sitemap.html"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, response.statusCode(),
+                    "Expected 200 for /sitemap.html but got " + response.statusCode());
+        }
+    }
+
+    @Test
+    void sitemapHtmlContainsLinks() throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/sitemap.html"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            String body = response.body();
+            assertFalse(body.isEmpty(), "sitemap.html should not be empty");
+            assertTrue(body.contains("<a href="), "sitemap.html should contain anchor links");
+            assertTrue(body.contains("quarkus.io"), "sitemap.html should contain quarkus.io URLs");
+        }
+    }
+
+    @Test
+    void llmsTxtReturns200() throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/llms.txt"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, response.statusCode(),
+                    "Expected 200 for /llms.txt but got " + response.statusCode());
+        }
+    }
+
+    @Test
+    void llmsTxtIsPlainText() throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/llms.txt"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            String contentType = response.headers().firstValue("Content-Type").orElse("");
+            assertTrue(contentType.contains("text/plain"),
+                    "llms.txt should have text/plain content type, but got: " + contentType);
+        }
+    }
+
+    @Test
+    void llmsTxtContainsContent() throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/llms.txt"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            String body = response.body();
+            assertFalse(body.isEmpty(), "llms.txt should not be empty");
+            assertTrue(body.contains("Quarkus"), "llms.txt should contain Quarkus information");
+        }
+    }
 }


### PR DESCRIPTION
Slightly closing the barn door after the https://github.com/quarkusio/quarkusio.github.io/pull/2958 horse, but regressions here would be hard for users to spot.

This test did find another problem, though - sitemap.html is missing, and I don't think that's intended. I've raised https://github.com/quarkusio/quarkusio.github.io/issues/3023 and disabled the test.