### PR TITLE
Add missing EOL date for 3.36

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -66,7 +66,7 @@ releases:
 
   - version: "3.36"
     release_date: 2026-05-27
-    eol_date:
+    eol_date: 2026-06-24
     lts: false
     latest_patch: "3.36.3"
     latest_patch_date: 2026-06-18


### PR DESCRIPTION
As pointed out by @yrodiere (thanks!). I'll do an investigation to see why the automation didn't add the EOL date when 3.37 came out, but in the interim, I'll manually fix the data.