### PR TITLE
Fix missing authors page content

### DIFF
--- a/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
+++ b/src/main/java/io/quarkus/tools/migration/JekyllFiltersExtension.java
@@ -178,6 +178,38 @@ public class JekyllFiltersExtension {
         return sorted;
     }
 
+    /**
+     * A simple key/value pair whose properties are named exactly as the templates
+     * expect: {@code data.first} for the key and {@code data.last} for the value.
+     * Mirrors the shape of the entries produced by Roq's built-in JsonObject iteration.
+     */
+    public record JsonEntry(String first, Object last) {
+    }
+
+    /**
+     * Jekyll's "sort" filter for JsonObject (map-of-maps, e.g. data/authors.yaml).
+     * Returns a list of {@link JsonEntry} sorted by the named property on each value,
+     * so templates can use {data.first} (key) and {data.last} (value).
+     * Usage in Qute: {cdi:authors.sort('name')}
+     */
+    static List<JsonEntry> sort(JsonObject obj, String property) {
+        if (obj == null || obj.isEmpty()) {
+            return List.of();
+        }
+        List<JsonEntry> entries = new ArrayList<>();
+        for (String key : obj.fieldNames()) {
+            entries.add(new JsonEntry(key, obj.getValue(key)));
+        }
+        entries.sort((a, b) -> {
+            String va = extractProperty(a.last(), property);
+            String vb = extractProperty(b.last(), property);
+            if (va == null) return vb == null ? 0 : 1;
+            if (vb == null) return -1;
+            return va.compareToIgnoreCase(vb);
+        });
+        return entries;
+    }
+
     /** Jekyll's "sort" filter for JsonArray. */
     static JsonArray sort(JsonArray array, String property) {
         if (array == null || array.isEmpty()) {

--- a/src/test/java/io/quarkusio/AuthorPageTest.java
+++ b/src/test/java/io/quarkusio/AuthorPageTest.java
@@ -11,9 +11,9 @@ public class AuthorPageTest extends BrowserTest {
     @Test
     void authorIndexPageListsAuthors() {
         page.navigate(baseUrl + "/author/");
-        int authorCount = page.locator(".authors a[href*='/author/']").count();
-        assertTrue(authorCount >= 5,
-                "Expected at least 5 authors but found " + authorCount);
+        int authorCount = page.locator(".authors a[href^='/author/']").count();
+        assertTrue(authorCount >= 6,
+                "Expected at least 6 authors but found " + authorCount);
     }
 
     @Test
@@ -32,7 +32,7 @@ public class AuthorPageTest extends BrowserTest {
     @Test
     void authorPageListsPosts() {
         page.navigate(baseUrl + "/blog/");
-        var authorLink = page.locator(".byline a[href*='/author/']").first();
+        var authorLink = page.locator(".byline a[href^='/author/']").first();
         authorLink.click();
 
         page.waitForURL("**/author/**");

--- a/src/test/java/io/quarkusio/NewsletterPageTest.java
+++ b/src/test/java/io/quarkusio/NewsletterPageTest.java
@@ -18,7 +18,7 @@ public class NewsletterPageTest extends BrowserTest {
     @Test
     void newsletterEditionsLinkToValidPaths() {
         page.navigate(baseUrl + "/newsletter/");
-        int linkCount = page.locator(".card a[href*='/newsletter/']").count();
+        int linkCount = page.locator(".card a[href^='/newsletter/']").count();
         assertTrue(linkCount >= 10,
                 "Expected at least 10 newsletter links but found " + linkCount);
     }

--- a/templates/layouts/authors.html
+++ b/templates/layouts/authors.html
@@ -6,7 +6,7 @@ layout: base
 
 <div class="grid-wrapper authors">
     <div class="grid__item width-12-12">
-{#let authors=cdi:authors.sort(name)}
+{#let authors=cdi:authors.sort('name')}
 {#for data in authors.orEmpty}
 {#let authorid=data.first}
 {#let author=data.last}


### PR DESCRIPTION
Resolves #2999 

The authors page did not list authors, despite tests asserting it did. 

This happened because of a combination of bugs:
- The test checked for a decent number of `/author/*` entries, but it so happens that the internationalisation links at the top matched this pattern. It also happened that 'decent' was 5, which is exactly how many internationalised sites we have. 
- The key for the sort needed quotes 
- The sort virtual method was missing